### PR TITLE
chore: release v0.1.0

### DIFF
--- a/.ito/changes/002-10_validate-completion-before-exit/proposal.md
+++ b/.ito/changes/002-10_validate-completion-before-exit/proposal.md
@@ -2,30 +2,49 @@
 
 ## Why
 
-The Ralph loop currently trusts the agent's completion promise without verification. This allows agents to claim "COMPLETE" while leaving build errors, test failures, or other validation issues unresolved. Users have observed loops exiting successfully despite 236+ compilation errors remaining, which violates the principle of verified completion.
+The Ralph loop currently trusts the agent's completion promise without verification. This allows agents to claim "COMPLETE" while leaving build errors, test failures, or incomplete tasks. Users have observed loops exiting successfully despite 236+ compilation errors remaining, which violates the principle of verified completion.
+
+The loop already has access to the change ID and can use Ito's own tooling to verify task completion status. It should also run the project's standard validation (tests, checks, lints) before accepting completion.
 
 ## What Changes
 
 - **BREAKING**: Ralph loop will no longer exit immediately upon detecting a completion promise
-- Add a post-completion validation step that runs Ito validation commands (`make check`, `make test`, or configurable validation command)
-- If validation fails, the loop continues with an injected context message about what failed
-- Add `--validation-command` flag to customize the validation step (defaults to `make check`)
-- Add `--skip-validation` flag to opt out of validation (preserve current behavior for edge cases)
-- Update the preamble to inform agents that completion promises are subject to validation
+- Add Ito-native validation: check task completion status via `ito tasks status <change-id>`
+  - All tasks must be `complete` or `shelved` (with reason)
+  - If tasks remain pending/in-progress, reject completion and continue
+- Add project validation: run the project's standard checks (`make check`, `make test`, or configured command)
+  - Ralph should *always* run project validation when a completion promise is detected
+  - This catches build errors, test failures, lint issues, etc.
+- Add `--validation-command` flag for additional explicit validation beyond project defaults
+- Add `--skip-validation` flag to opt out of all validation (escape hatch for edge cases)
+- If any validation fails, inject failure output as context and continue to next iteration
+- Update the preamble to inform agents that completion promises are validated
+
+## Validation Order
+
+When a completion promise is detected:
+
+1. **Ito task status** (if change-id provided): Verify all tasks complete/shelved
+2. **Project validation**: Run validation commands from project configuration (ito.json, .ito/config.json, AGENTS.md, CLAUDE.md)
+3. **Extra validation** (if `--validation-command` specified): Run additional explicit check
+
+All must pass for completion to be accepted.
 
 ## Capabilities
 
 ### New Capabilities
 
-- `ralph-completion-validation`: Validation logic that runs after a completion promise is detected to verify the work is actually complete before exiting the loop
+- `ralph-completion-validation`: Validation logic that verifies task completion status and runs project validation before accepting a completion promise
 
 ### Modified Capabilities
 
-- `cli-ralph`: Add `--validation-command` and `--skip-validation` flags; change completion detection to include a validation gate
+- `cli-ralph`: Add `--validation-command` and `--skip-validation` flags; change completion detection to include validation gate
 
 ## Impact
 
-- **Affected specs**: `cli-ralph`, `preamble-generation` (to update preamble text)
-- **Affected code**: `ito-rs/crates/ito-core/src/ralph/runner.rs` (main loop logic)
-- **User behavior change**: Loops will take longer but produce verified results; agents claiming false completion will be caught and the loop will continue
+- **Affected specs**: `cli-ralph`
+- **Affected code**: 
+  - `ito-rs/crates/ito-core/src/ralph/runner.rs` (main loop logic)
+  - `ito-rs/crates/ito-core/src/ralph/prompt.rs` (context injection)
+- **User behavior change**: Loops will take longer but produce verified results; agents claiming false completion will be caught and the loop will continue with feedback
 - **Backward compatibility**: Add `--skip-validation` for users who want the old trust-based behavior

--- a/.ito/changes/002-10_validate-completion-before-exit/specs/ralph-completion-validation/spec.md
+++ b/.ito/changes/002-10_validate-completion-before-exit/specs/ralph-completion-validation/spec.md
@@ -1,79 +1,126 @@
 ## ADDED Requirements
 
-### Requirement: Completion validation runs after promise detection
+### Requirement: Ito task status validation
 
-The system SHALL run a configurable validation command after detecting a completion promise, before accepting the completion as valid.
+The system SHALL verify that all tasks for the change are complete or shelved before accepting a completion promise.
 
-#### Scenario: Validation command succeeds
+#### Scenario: All tasks complete
 
+- **GIVEN** a Ralph loop running with `--change <change-id>`
 - **WHEN** the agent outputs the completion promise
-- **AND** the validation command exits with code 0
-- **THEN** the system SHALL accept the completion and exit the loop successfully
+- **AND** all tasks in the change are marked `complete`
+- **THEN** the system SHALL proceed to project validation
 
-#### Scenario: Validation command fails
+#### Scenario: All tasks complete or shelved
 
+- **GIVEN** a Ralph loop running with `--change <change-id>`
 - **WHEN** the agent outputs the completion promise
-- **AND** the validation command exits with a non-zero code
+- **AND** all tasks are either `complete` or `shelved`
+- **THEN** the system SHALL proceed to project validation
+
+#### Scenario: Tasks remain pending
+
+- **GIVEN** a Ralph loop running with `--change <change-id>`
+- **WHEN** the agent outputs the completion promise
+- **AND** one or more tasks are `pending` or `in-progress`
 - **THEN** the system SHALL reject the completion
-- **AND** the system SHALL continue to the next iteration
+- **AND** the system SHALL inject the task status summary as context for the next iteration
+
+#### Scenario: No change-id provided
+
+- **GIVEN** a Ralph loop running without `--change`
+- **WHEN** the agent outputs the completion promise
+- **THEN** the system SHALL skip Ito task validation
+- **AND** the system SHALL proceed to project validation
+
+### Requirement: Project validation always runs
+
+The system SHALL always run the project's configured validation commands when a completion promise is detected.
+
+#### Scenario: Project validation succeeds
+
+- **WHEN** the agent outputs the completion promise
+- **AND** Ito task validation passes (or is skipped)
+- **AND** the project validation commands exit with code 0
+- **THEN** the system SHALL proceed to extra validation (if specified) or accept completion
+
+#### Scenario: Project validation fails
+
+- **WHEN** the agent outputs the completion promise
+- **AND** the project validation commands exit with a non-zero code
+- **THEN** the system SHALL reject the completion
 - **AND** the system SHALL inject the validation failure output as context for the next iteration
 
-#### Scenario: Validation command not found
+#### Scenario: Project validation commands from configuration
 
-- **WHEN** the agent outputs the completion promise
-- **AND** the configured validation command does not exist
-- **THEN** the system SHALL warn the user
-- **AND** the system SHALL accept the completion (graceful degradation)
+- **WHEN** the system needs to run project validation
+- **THEN** the system SHALL read validation commands from project configuration
+- **AND** the system SHALL check the following sources in order: `ito.json`, `.ito/config.json`, `AGENTS.md`, `CLAUDE.md`
+- **AND** the system SHALL use the first configured validation command found
+
+#### Scenario: No project validation configured
+
+- **WHEN** no project validation commands are configured
+- **THEN** the system SHALL warn the user that no validation is configured
+- **AND** the system SHALL proceed without project validation (graceful degradation)
+
+### Requirement: Extra validation command
+
+The system SHALL support an additional explicit validation command via CLI flag.
+
+#### Scenario: Extra validation specified and succeeds
+
+- **GIVEN** `--validation-command "custom-check"`
+- **WHEN** all prior validation steps pass
+- **AND** the extra validation command exits with code 0
+- **THEN** the system SHALL accept the completion
+
+#### Scenario: Extra validation specified and fails
+
+- **GIVEN** `--validation-command "custom-check"`
+- **WHEN** all prior validation steps pass
+- **AND** the extra validation command exits with a non-zero code
+- **THEN** the system SHALL reject the completion
+- **AND** the system SHALL inject the failure output as context
 
 ### Requirement: Validation failure context injection
 
 The system SHALL inject validation failure details into the next iteration's context so the agent can address the issues.
 
-#### Scenario: Build errors injected as context
+#### Scenario: Task status failure injected as context
 
-- **GIVEN** the validation command output contains error messages
-- **WHEN** validation fails after a completion promise
-- **THEN** the next iteration prompt SHALL include a section labeled `## Validation Failure (completion rejected)`
+- **GIVEN** task validation fails due to incomplete tasks
+- **WHEN** the next iteration starts
+- **THEN** the prompt SHALL include a section labeled `## Validation Failure (completion rejected)`
+- **AND** the section SHALL list the incomplete tasks with their status
+- **AND** the section SHALL explain that all tasks must be complete or shelved
+
+#### Scenario: Build/test errors injected as context
+
+- **GIVEN** project validation fails with error output
+- **WHEN** the next iteration starts
+- **THEN** the prompt SHALL include a section labeled `## Validation Failure (completion rejected)`
 - **AND** the section SHALL contain the validation command's stderr/stdout
 - **AND** the section SHALL explain that the loop continues until validation passes
 
-### Requirement: Configurable validation command
-
-The system SHALL support customizing the validation command via CLI flag.
-
-#### Scenario: Default validation command
-
-- **WHEN** no `--validation-command` is specified
-- **THEN** the system SHALL use `make check` as the default validation command
-
-#### Scenario: Custom validation command
-
-- **WHEN** `--validation-command "npm test"` is specified
-- **THEN** the system SHALL run `npm test` for validation instead of the default
-
-#### Scenario: Multi-command validation
-
-- **WHEN** `--validation-command "make check && make test"` is specified
-- **THEN** the system SHALL execute the full command string via shell
-
 ### Requirement: Validation can be skipped
 
-The system SHALL support skipping validation for backward compatibility or edge cases.
+The system SHALL support skipping all validation for backward compatibility or edge cases.
 
 #### Scenario: Skip validation flag
 
 - **WHEN** `--skip-validation` is specified
 - **AND** the agent outputs the completion promise
-- **THEN** the system SHALL accept the completion immediately without running validation
+- **THEN** the system SHALL accept the completion immediately without running any validation
 - **AND** the system SHALL print a warning that validation was skipped
 
 ### Requirement: Validation timeout
 
-The system SHALL enforce a timeout on the validation command to prevent infinite hangs.
+The system SHALL enforce a timeout on validation commands to prevent infinite hangs.
 
-#### Scenario: Validation times out
+#### Scenario: Validation command times out
 
-- **WHEN** the validation command runs longer than 5 minutes
+- **WHEN** a validation command runs longer than 5 minutes
 - **THEN** the system SHALL kill the validation process
 - **AND** the system SHALL treat it as a validation failure
 - **AND** the system SHALL inject a timeout error message as context

--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ dev: ## Build and install debug version with git info (fast iteration)
 release-plz-update: ## Run release-plz update (bump versions based on commits)
 	@set -e; \
 	if release-plz --version >/dev/null 2>&1; then \
-		release-plz update --manifest-path ito-rs/Cargo.toml --config ito-rs/release-plz.toml; \
+		release-plz update --manifest-path ito-rs/Cargo.toml --config release-plz.toml; \
 	else \
 		echo "release-plz is not installed."; \
 		echo "Install: cargo install release-plz"; \
@@ -248,7 +248,7 @@ release-plz-update: ## Run release-plz update (bump versions based on commits)
 release-plz-release-pr: ## Run release-plz release-pr (create/update release PR)
 	@set -e; \
 	if release-plz --version >/dev/null 2>&1; then \
-		release-plz release-pr --manifest-path ito-rs/Cargo.toml --config ito-rs/release-plz.toml; \
+		release-plz release-pr --manifest-path ito-rs/Cargo.toml --git-token `gh auth token` --config release-plz.toml; \
 	else \
 		echo "release-plz is not installed."; \
 		echo "Install: cargo install release-plz"; \

--- a/ito-rs/crates/ito-cli/CHANGELOG.md
+++ b/ito-rs/crates/ito-cli/CHANGELOG.md
@@ -1,3 +1,29 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-cli-v0.1.0) - 2026-02-05
+
+### Added
+
+- display git sha and dirty status in debug builds
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- *(ito-models,ito-cli)* modernize code patterns and improve test normalization
+- simplify changelog files and prepare for release-plz
+- add vergen for git metadata in debug builds
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-common/CHANGELOG.md
+++ b/ito-rs/crates/ito-common/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-common-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-config/CHANGELOG.md
+++ b/ito-rs/crates/ito-config/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-config-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-core/CHANGELOG.md
+++ b/ito-rs/crates/ito-core/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-core-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-domain/CHANGELOG.md
+++ b/ito-rs/crates/ito-domain/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-domain-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-harness/CHANGELOG.md
+++ b/ito-rs/crates/ito-harness/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-harness-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-logging/CHANGELOG.md
+++ b/ito-rs/crates/ito-logging/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-logging-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-models/CHANGELOG.md
+++ b/ito-rs/crates/ito-models/CHANGELOG.md
@@ -1,3 +1,24 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-models-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- *(ito-models,ito-cli)* modernize code patterns and improve test normalization
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-schemas/CHANGELOG.md
+++ b/ito-rs/crates/ito-schemas/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-schemas-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-templates/CHANGELOG.md
+++ b/ito-rs/crates/ito-templates/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-templates-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-test-support/CHANGELOG.md
+++ b/ito-rs/crates/ito-test-support/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-test-support-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/ito-rs/crates/ito-web/CHANGELOG.md
+++ b/ito-rs/crates/ito-web/CHANGELOG.md
@@ -1,3 +1,23 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-web-v0.1.0) - 2026-02-05
+
+### Fixed
+
+- release-plz
+
+### Other
+
+- moar docs
+- add CHANGELOG.md templates for all crates
+- The big reset
+# Changelog
+
+All notable changes to this project will be documented in this file.


### PR DESCRIPTION



## 🤖 New release

* `ito-common`: 0.1.0
* `ito-config`: 0.1.0
* `ito-schemas`: 0.1.0
* `ito-domain`: 0.1.0
* `ito-harness`: 0.1.0
* `ito-templates`: 0.1.0
* `ito-core`: 0.1.0
* `ito-logging`: 0.1.0
* `ito-web`: 0.1.0
* `ito-cli`: 0.1.0
* `ito-test-support`: 0.1.0
* `ito-models`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `ito-common`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-common-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-config`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-config-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-schemas`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-schemas-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-domain`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-domain-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-harness`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-harness-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-templates`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-templates-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-core`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-core-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-logging`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-logging-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-web`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-web-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-cli`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-cli-v0.1.0) - 2026-02-05

### Added

- display git sha and dirty status in debug builds

### Fixed

- release-plz

### Other

- moar docs
- *(ito-models,ito-cli)* modernize code patterns and improve test normalization
- simplify changelog files and prepare for release-plz
- add vergen for git metadata in debug builds
- The big reset
</blockquote>

## `ito-test-support`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-test-support-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>

## `ito-models`

<blockquote>

## [0.1.0](https://github.com/withakay/ito/releases/tag/ito-models-v0.1.0) - 2026-02-05

### Fixed

- release-plz

### Other

- moar docs
- *(ito-models,ito-cli)* modernize code patterns and improve test normalization
- add CHANGELOG.md templates for all crates
- The big reset
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).