### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🚀 Features
+
+- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
+- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))
+
+### 🐛 Bug Fixes
+
+- *(coordination)* Address PR review security and safety feedback
+
+### 🚜 Refactor
+
+- *(coordination)* Address remaining PR nitpicks
 ## [0.1.2] - 2026-02-11
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.65"
+version = "4.5.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
 dependencies = [
  "clap",
 ]
@@ -360,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "colorchoice"
@@ -1030,7 +1030,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "ito-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -1059,14 +1059,14 @@ dependencies = [
 
 [[package]]
 name = "ito-common"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "miette",
 ]
 
 [[package]]
 name = "ito-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ito-common",
  "schemars",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "ito-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "filetime",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "ito-domain"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "ito-common",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "ito-logging"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "hex",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "ito-templates"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "include_dir",
  "minijinja",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "ito-test-support"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "ito-domain",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "ito-web"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "axum",
  "axum-extra",
@@ -1478,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
@@ -1492,15 +1492,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -1571,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags 2.10.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/withakay/ito"
@@ -21,13 +21,13 @@ homepage = "https://github.com/withakay/ito"
 
 [workspace.dependencies]
 # Internal crates
-ito-common = { path = "ito-rs/crates/ito-common", version = "0.1.2" }
-ito-config = { path = "ito-rs/crates/ito-config", version = "0.1.2" }
-ito-core = { path = "ito-rs/crates/ito-core", version = "0.1.2" }
-ito-domain = { path = "ito-rs/crates/ito-domain", version = "0.1.2" }
-ito-logging = { path = "ito-rs/crates/ito-logging", version = "0.1.2" }
-ito-templates = { path = "ito-rs/crates/ito-templates", version = "0.1.2" }
-ito-web = { path = "ito-rs/crates/ito-web", version = "0.1.2" }
+ito-common = { path = "ito-rs/crates/ito-common", version = "0.1.3" }
+ito-config = { path = "ito-rs/crates/ito-config", version = "0.1.3" }
+ito-core = { path = "ito-rs/crates/ito-core", version = "0.1.3" }
+ito-domain = { path = "ito-rs/crates/ito-domain", version = "0.1.3" }
+ito-logging = { path = "ito-rs/crates/ito-logging", version = "0.1.3" }
+ito-templates = { path = "ito-rs/crates/ito-templates", version = "0.1.3" }
+ito-web = { path = "ito-rs/crates/ito-web", version = "0.1.3" }
 
 # External dependencies
 clap = { version = "4.5.23", features = ["derive"] }

--- a/ito-rs/crates/ito-common/CHANGELOG.md
+++ b/ito-rs/crates/ito-common/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🚜 Refactor
+
+- *(ito-common)* Tighten id parsing and improve docs
 ## [0.1.2] - 2026-02-11
 
 ### 🚜 Refactor

--- a/ito-rs/crates/ito-config/CHANGELOG.md
+++ b/ito-rs/crates/ito-config/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🚀 Features
+
+- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))
+
+### 🐛 Bug Fixes
+
+- *(coordination)* Address PR review security and safety feedback
+
+### 🚜 Refactor
+
+- *(coordination)* Address remaining PR nitpicks
 ## [0.1.2] - 2026-02-11
 
 ### 🚜 Refactor

--- a/ito-rs/crates/ito-core/CHANGELOG.md
+++ b/ito-rs/crates/ito-core/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🚀 Features
+
+- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
+- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))
+
+### 🐛 Bug Fixes
+
+- Resolve merge fallout in workflow/template refactor
+- *(coordination)* Address PR review security and safety feedback
+
+### 💼 Other
+
+- Embed and export workflow schemas ([#15](https://github.com/withakay/ito/pull/15))
+- *(ito-core)* Validate change-id path segments in task flows
+- *(ito-core)* Validate process requests and harden temp output
+
+### 🚜 Refactor
+
+- Make ito workflow a no-op surface ([#17](https://github.com/withakay/ito/pull/17))
+- Remove workflow command and migrate core workflow module to templates
+- Remove workflow compatibility surface across rust crates
+- *(ito-core)* Apply explicit matching style in core helpers
+- *(coordination)* Address remaining PR nitpicks
+
+### 📚 Documentation
+
+- *(ito-core)* Clarify validation issue and report semantics
+
+### 🧪 Testing
+
+- *(ito-core)* Add ValidationIssue helper tests
+- *(ito-core)* Add ReportBuilder behavior coverage
 ## [0.1.2] - 2026-02-11
 
 ### 🐛 Bug Fixes

--- a/ito-rs/crates/ito-domain/CHANGELOG.md
+++ b/ito-rs/crates/ito-domain/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🐛 Bug Fixes
+
+- Resolve merge fallout in workflow/template refactor
+
+### 💼 Other
+
+- Embed and export workflow schemas ([#15](https://github.com/withakay/ito/pull/15))
+- *(ito-domain)* Harden tasks path construction
+
+### 🚜 Refactor
+
+- Remove workflow command and migrate core workflow module to templates
+- Remove workflow compatibility surface across rust crates
+
+### 📚 Documentation
+
+- *(ito-domain)* Expand task module rustdoc coverage
+
+### 🧪 Testing
+
+- *(ito-domain)* Add DomainError constructor tests
 ## [0.1.2] - 2026-02-11
 
 ### 🐛 Bug Fixes

--- a/ito-rs/crates/ito-logging/CHANGELOG.md
+++ b/ito-rs/crates/ito-logging/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
 ## [0.1.2] - 2026-02-11
 
 ### 💼 Other

--- a/ito-rs/crates/ito-templates/CHANGELOG.md
+++ b/ito-rs/crates/ito-templates/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 🚀 Features
+
+- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
 ## [0.1.2] - 2026-02-11
 
 ### 💼 Other

--- a/ito-rs/crates/ito-web/CHANGELOG.md
+++ b/ito-rs/crates/ito-web/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.3] - 2026-02-11
+
+### 💼 Other
+
+- *(ito-web)* Harden auth cookie and template path checks
+- *(ito-web)* Bound API request, path, and listing sizes
+
+### 📚 Documentation
+
+- *(ito-web)* Clarify adapter, auth, and terminal behavior
 ## [0.1.2] - 2026-02-11
 
 ### 🧪 Testing


### PR DESCRIPTION



## 🤖 New release

* `ito-common`: 0.1.2 -> 0.1.3
* `ito-config`: 0.1.2 -> 0.1.3
* `ito-domain`: 0.1.2 -> 0.1.3
* `ito-templates`: 0.1.2 -> 0.1.3
* `ito-core`: 0.1.2 -> 0.1.3
* `ito-logging`: 0.1.2 -> 0.1.3
* `ito-web`: 0.1.2 -> 0.1.3
* `ito-cli`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `ito-common`

<blockquote>

## [0.1.3] - 2026-02-11

### 🚜 Refactor

- *(ito-common)* Tighten id parsing and improve docs
</blockquote>

## `ito-config`

<blockquote>

## [0.1.3] - 2026-02-11

### 🚀 Features

- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))

### 🐛 Bug Fixes

- *(coordination)* Address PR review security and safety feedback

### 🚜 Refactor

- *(coordination)* Address remaining PR nitpicks
</blockquote>

## `ito-domain`

<blockquote>

## [0.1.3] - 2026-02-11

### 🐛 Bug Fixes

- Resolve merge fallout in workflow/template refactor

### 💼 Other

- Embed and export workflow schemas ([#15](https://github.com/withakay/ito/pull/15))
- *(ito-domain)* Harden tasks path construction

### 🚜 Refactor

- Remove workflow command and migrate core workflow module to templates
- Remove workflow compatibility surface across rust crates

### 📚 Documentation

- *(ito-domain)* Expand task module rustdoc coverage

### 🧪 Testing

- *(ito-domain)* Add DomainError constructor tests
</blockquote>

## `ito-templates`

<blockquote>

## [0.1.3] - 2026-02-11

### 🚀 Features

- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
</blockquote>

## `ito-core`

<blockquote>

## [0.1.3] - 2026-02-11

### 🚀 Features

- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))

### 🐛 Bug Fixes

- Resolve merge fallout in workflow/template refactor
- *(coordination)* Address PR review security and safety feedback

### 💼 Other

- Embed and export workflow schemas ([#15](https://github.com/withakay/ito/pull/15))
- *(ito-core)* Validate change-id path segments in task flows
- *(ito-core)* Validate process requests and harden temp output

### 🚜 Refactor

- Make ito workflow a no-op surface ([#17](https://github.com/withakay/ito/pull/17))
- Remove workflow command and migrate core workflow module to templates
- Remove workflow compatibility surface across rust crates
- *(ito-core)* Apply explicit matching style in core helpers
- *(coordination)* Address remaining PR nitpicks

### 📚 Documentation

- *(ito-core)* Clarify validation issue and report semantics

### 🧪 Testing

- *(ito-core)* Add ValidationIssue helper tests
- *(ito-core)* Add ReportBuilder behavior coverage
</blockquote>


## `ito-web`

<blockquote>

## [0.1.3] - 2026-02-11

### 💼 Other

- *(ito-web)* Harden auth cookie and template path checks
- *(ito-web)* Bound API request, path, and listing sizes

### 📚 Documentation

- *(ito-web)* Clarify adapter, auth, and terminal behavior
</blockquote>

## `ito-cli`

<blockquote>

## [0.1.3] - 2026-02-11

### 🚀 Features

- *(config)* Generate and version Ito config schema artifact ([#26](https://github.com/withakay/ito/pull/26))
- *(coordination)* Sync change workflows with coordination branch ([#29](https://github.com/withakay/ito/pull/29))

### 🐛 Bug Fixes

- *(coordination)* Address PR review security and safety feedback

### 🚜 Refactor

- *(coordination)* Address remaining PR nitpicks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).