### PR TITLE
docs(002-16): Ralph worktree awareness change proposal

### DIFF
--- a/.ito/changes/002-16_ralph-worktree-awareness/.ito.yaml
+++ b/.ito/changes/002-16_ralph-worktree-awareness/.ito.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-14

--- a/.ito/changes/002-16_ralph-worktree-awareness/proposal.md
+++ b/.ito/changes/002-16_ralph-worktree-awareness/proposal.md
@@ -1,0 +1,34 @@
+<!-- ITO:START -->
+## Why
+
+Ralph's outer loop runs the harness, commits, and validates entirely within the process's inherited working directory (`std::env::current_dir()`). When a project uses git worktrees — e.g. the `bare_control_siblings` strategy where each change gets its own worktree — Ralph has no knowledge of the worktree layout. It spawns the harness, runs `git add -A && git commit`, and executes validation commands all in the directory where `ito ralph` was invoked. If that directory is the bare repo root (or a different worktree), the pre-commit hook checks the wrong code, `git add` stages the wrong files, and the harness edits the wrong tree. This makes Ralph unusable in worktree-based workflows unless the user manually `cd`s into the correct worktree first — defeating the purpose of `--change`-driven automation.
+
+## What Changes
+
+- **Resolve the effective working directory for a change**: When `--change` targets a change that has an existing worktree (branch name matches the change ID), Ralph resolves the worktree path and uses it as the working directory for the harness, git commands, and validation.
+- **Pass resolved cwd through the pipeline**: `HarnessRunConfig.cwd`, `commit_iteration`, and `run_project_validation` all use the resolved worktree path instead of the inherited process cwd.
+- **Detect worktrees via git**: Use `git worktree list --porcelain` (leveraging the existing `discover_worktrees` function in `audit/worktree.rs`) to find a worktree whose branch matches the change ID.
+- **Graceful fallback**: When no matching worktree exists, Ralph falls back to the current behaviour (process cwd). This preserves compatibility for non-worktree workflows.
+- **No automatic worktree creation**: Ralph detects existing worktrees but does not create them. Creation remains the user's or instruction template's responsibility.
+
+## Capabilities
+
+### New Capabilities
+
+- `ralph-worktree-awareness`: Ralph's ability to detect and use an existing git worktree for a targeted change, ensuring the harness, git operations, and validation run in the correct working directory.
+
+### Modified Capabilities
+
+- `rust-ralph`: The core Ralph runner gains worktree resolution logic that changes where the harness and git commands execute when a matching worktree exists.
+- `cli-ralph`: The CLI layer passes worktree configuration context to the core runner to enable worktree resolution.
+
+## Impact
+
+- **`ito-core/src/ralph/runner.rs`**: `run_ralph` gains a worktree resolution step early in execution. `commit_iteration` and the harness `cwd` use the resolved path. `count_git_changes` also uses the resolved path.
+- **`ito-core/src/audit/worktree.rs`**: The existing `discover_worktrees` function may be reused or a lighter-weight variant extracted for Ralph's needs.
+- **`ito-core/src/ralph/mod.rs`**: `RalphOptions` or a new internal struct carries the resolved worktree path.
+- **`ito-cli/src/commands/ralph.rs`**: May need to pass worktree config context from the runtime.
+- **`ito-config`**: Worktree configuration (`WorktreesConfig`) is already modelled; Ralph needs read access to `layout.dir_name` and `strategy` to compute expected worktree paths.
+- **Existing tests**: New tests for worktree detection and cwd override. Existing tests unaffected (no worktree present = fallback to current behaviour).
+- **No user-facing breaking changes**: Default behaviour is unchanged. Worktree-aware behaviour activates only when a matching worktree is detected.
+<!-- ITO:END -->

--- a/.ito/changes/002-16_ralph-worktree-awareness/specs/cli-ralph/spec.md
+++ b/.ito/changes/002-16_ralph-worktree-awareness/specs/cli-ralph/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Robust completion promise detection
+
+The system SHALL detect the completion promise in harness output even when the promise contains surrounding whitespace and newlines. When detected, the system SHALL validate the completion before accepting it. All validation and harness execution SHALL occur in the resolved effective working directory (worktree path when available, otherwise the process cwd).
+
+#### Scenario: Completion promise detection ignores whitespace
+
+- **GIVEN** `--completion-promise COMPLETE`
+- **WHEN** harness output contains `<promise>\nCOMPLETE\n</promise>`
+- **THEN** the system SHALL treat the completion promise as detected
+- **AND** the system SHALL proceed to validation
+
+#### Scenario: Completion accepted after all validation passes
+
+- **GIVEN** `--completion-promise COMPLETE`
+- **AND** `--change <change-id>`
+- **WHEN** harness output contains `<promise>COMPLETE</promise>`
+- **AND** all tasks for the change are complete or shelved
+- **AND** project validation (as configured) passes
+- **AND** extra validation (if specified) passes
+- **THEN** the system SHALL exit the loop with a success message
+
+#### Scenario: Completion rejected when tasks incomplete
+
+- **GIVEN** `--completion-promise COMPLETE`
+- **AND** `--change <change-id>`
+- **WHEN** harness output contains `<promise>COMPLETE</promise>`
+- **AND** one or more tasks are pending or in-progress
+- **THEN** the system SHALL NOT exit the loop
+- **AND** the system SHALL proceed to the next iteration
+- **AND** the system SHALL inject the incomplete task list as context
+
+#### Scenario: Completion rejected when project validation fails
+
+- **GIVEN** `--completion-promise COMPLETE`
+- **WHEN** harness output contains `<promise>COMPLETE</promise>`
+- **AND** project validation exits with a non-zero code
+- **THEN** the system SHALL NOT exit the loop
+- **AND** the system SHALL proceed to the next iteration
+- **AND** the system SHALL inject the validation failure as context

--- a/.ito/changes/002-16_ralph-worktree-awareness/specs/ralph-worktree-awareness/spec.md
+++ b/.ito/changes/002-16_ralph-worktree-awareness/specs/ralph-worktree-awareness/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Resolve worktree for targeted change
+
+When Ralph targets a specific change (via `--change`), the runner SHALL attempt to resolve an existing git worktree whose branch name matches the change ID. If a matching worktree is found, Ralph SHALL use that worktree's root as the effective working directory for the harness, git operations, and validation commands.
+
+#### Scenario: Matching worktree exists
+
+- **WHEN** `ito ralph --change 002-16_ralph-worktree-awareness` is invoked
+- **AND** `git worktree list --porcelain` shows a worktree on branch `002-16_ralph-worktree-awareness`
+- **THEN** Ralph SHALL resolve the effective working directory to that worktree's path
+- **AND** the harness SHALL execute in the worktree directory
+- **AND** `git add -A` and `git commit` SHALL execute in the worktree directory
+- **AND** validation commands SHALL execute in the worktree directory
+
+#### Scenario: No matching worktree exists
+
+- **WHEN** `ito ralph --change 005-01_some-change` is invoked
+- **AND** no worktree exists on branch `005-01_some-change`
+- **THEN** Ralph SHALL fall back to the process's current working directory
+- **AND** behaviour SHALL be identical to the pre-change baseline
+
+#### Scenario: Worktrees not enabled in config
+
+- **WHEN** worktree support is not enabled in the project configuration
+- **THEN** Ralph SHALL skip worktree resolution entirely
+- **AND** behaviour SHALL be identical to the pre-change baseline
+
+#### Scenario: No change targeted (unscoped run)
+
+- **WHEN** `ito ralph --file prompt.md` is invoked without `--change`
+- **THEN** Ralph SHALL skip worktree resolution
+- **AND** the effective working directory SHALL be the process's current working directory
+
+### Requirement: Worktree detection uses git porcelain output
+
+Ralph SHALL detect worktrees by parsing the output of `git worktree list --porcelain`. The branch field from the porcelain output SHALL be compared against the change ID to find a match.
+
+#### Scenario: Branch name matches change ID
+
+- **WHEN** the porcelain output contains a worktree with `branch refs/heads/002-16_ralph-worktree-awareness`
+- **THEN** Ralph SHALL treat this as a matching worktree for change `002-16_ralph-worktree-awareness`
+
+#### Scenario: Bare repo worktree is excluded
+
+- **WHEN** the porcelain output contains a bare worktree entry
+- **THEN** Ralph SHALL NOT consider it as a candidate match
+
+### Requirement: Verbose logging of resolved working directory
+
+When `--verbose` is enabled, Ralph SHALL log the resolved effective working directory so users can confirm Ralph is operating in the correct location.
+
+#### Scenario: Worktree resolved with verbose
+
+- **WHEN** `--verbose` is enabled
+- **AND** a matching worktree is found
+- **THEN** Ralph SHALL print a message indicating the resolved worktree path
+
+#### Scenario: Fallback with verbose
+
+- **WHEN** `--verbose` is enabled
+- **AND** no matching worktree is found
+- **THEN** Ralph SHALL print a message indicating it is using the current working directory
+
+### Requirement: Ralph does not create worktrees
+
+Ralph SHALL NOT create git worktrees. Worktree creation remains the responsibility of the user, instruction templates, or other Ito commands. Ralph only detects and uses existing worktrees.
+
+#### Scenario: Missing worktree is not created
+
+- **WHEN** a change has no existing worktree
+- **THEN** Ralph SHALL NOT run `git worktree add`
+- **AND** Ralph SHALL fall back to the current working directory

--- a/.ito/changes/002-16_ralph-worktree-awareness/specs/rust-ralph/spec.md
+++ b/.ito/changes/002-16_ralph-worktree-awareness/specs/rust-ralph/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: State is written under `.ito/.state/ralph/<change>`
+
+Rust MUST write loop state and history in the same location and structure as TypeScript. When Ralph resolves a worktree for the targeted change, state files SHALL be written relative to the worktree's `.ito` directory, not the invoking process's `.ito` directory.
+
+#### Scenario: State files exist
+
+- **GIVEN** a completed loop run
+- **WHEN** the user inspects `.ito/.state/ralph/<change-id>/`
+- **THEN** the expected state and history files exist
+
+#### Scenario: State written in worktree when resolved
+
+- **GIVEN** Ralph resolves a worktree at `/project/ito-worktrees/002-16_foo/`
+- **WHEN** a loop iteration completes
+- **THEN** state files SHALL be written under `/project/ito-worktrees/002-16_foo/.ito/.state/ralph/002-16_foo/`

--- a/.ito/changes/002-16_ralph-worktree-awareness/tasks.md
+++ b/.ito/changes/002-16_ralph-worktree-awareness/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: 002-16_ralph-worktree-awareness
+
+## Wave 1: Worktree resolution in ito-core
+
+- [ ] 1.1: Extract or expose a `find_worktree_for_branch(branch: &str) -> Option<PathBuf>` function in `ito-core` that parses `git worktree list --porcelain` and returns the worktree path whose branch matches the given name. Reuse or adapt logic from `audit/worktree.rs::discover_worktrees`.
+- [ ] 1.2: Add unit tests for `find_worktree_for_branch` covering: matching branch found, no match, bare worktree excluded, multiple worktrees.
+- [ ] 1.3: Add a `resolve_effective_cwd` function in `ralph/runner.rs` that takes `ito_path`, the resolved `change_id`, and the worktree config, and returns the effective working directory. When worktrees are enabled and a matching worktree exists, return the worktree path; otherwise return `std::env::current_dir()`.
+- [ ] 1.4: Add unit tests for `resolve_effective_cwd` covering: worktree found, no worktree found (fallback), worktrees not enabled (fallback), no change targeted (fallback).
+
+## Wave 2: Thread resolved cwd through Ralph pipeline
+
+- [ ] 2.1: Call `resolve_effective_cwd` early in `run_ralph` and store the result. Log the resolved path when `--verbose`.
+- [ ] 2.2: Pass the resolved cwd to `HarnessRunConfig.cwd` instead of `std::env::current_dir()`.
+- [ ] 2.3: Pass the resolved cwd to `commit_iteration` (add a `cwd: &Path` parameter) and set `current_dir` on the `git add` and `git commit` `ProcessRequest`s.
+- [ ] 2.4: Pass the resolved cwd to `count_git_changes` (add a `cwd: &Path` parameter) and set `current_dir` on the `git status` `ProcessRequest`.
+- [ ] 2.5: Pass the resolved cwd to `run_project_validation` — derive `ito_path` from the worktree's `.ito` directory when a worktree is active.
+- [ ] 2.6: Update `run_ralph` to use the worktree's `ito_path` for state file writes when a worktree is resolved.
+
+## Wave 3: CLI layer and config plumbing
+
+- [ ] 3.1: Load `WorktreesConfig` from the cascading config in the CLI runtime and pass it (or a relevant subset) to `run_ralph` via `RalphOptions` or a new parameter.
+- [ ] 3.2: Update `RalphOptions` (or add a separate struct) to carry the worktree config needed for resolution (enabled flag, strategy, layout dir name).
+
+## Wave 4: Integration tests and verification
+
+- [ ] 4.1: Add an integration test in `ralph_smoke.rs` that sets up a temporary git repo with a worktree for a change, runs `ito ralph --change <id> --harness stub`, and verifies the harness ran in the worktree directory (e.g. by checking state files are written under the worktree's `.ito`).
+- [ ] 4.2: Add an integration test verifying fallback: no worktree exists, Ralph runs normally in the process cwd.
+- [ ] 4.3: Run `make check` — all checks pass.
+- [ ] 4.4: Run `make test` — all tests pass.

--- a/.ito/modules/002_ralph-loop/module.md
+++ b/.ito/modules/002_ralph-loop/module.md
@@ -21,3 +21,5 @@
 - [x] 002-12_add-ralph-error-threshold
 - [x] 002-13_add-ralph-continue-ready
 - [ ] 002-14_ralph-harnesses-claude-codex-copilot
+- [ ] 002-15_retriable-harness-crashes
+- [ ] 002-16_ralph-worktree-awareness


### PR DESCRIPTION
## Summary

- Adds change proposal for `002-16_ralph-worktree-awareness` — Ralph's outer loop currently runs harness, git, and validation commands in the inherited process cwd, which breaks in worktree-based workflows where the change lives in a separate worktree

## Bug

When using `bare_control_siblings` (or any worktree strategy), `ito ralph --change <id>` runs `git add -A`, `git commit`, pre-commit hooks, and the harness all in the wrong directory. The pre-commit hook validates the wrong code, `git add` stages wrong files, and the harness edits the wrong tree.

## Proposed Fix

Ralph detects existing worktrees (via `git worktree list --porcelain`) whose branch matches the targeted change ID and uses that worktree path as the effective working directory. Falls back to current behavior when no worktree exists.

## Artifacts

- `proposal.md` — motivation, what changes, impact analysis
- `specs/ralph-worktree-awareness/spec.md` — 4 new requirements (worktree resolution, porcelain detection, verbose logging, no auto-creation)
- `specs/rust-ralph/spec.md` — modified state file location for worktrees
- `specs/cli-ralph/spec.md` — modified validation cwd requirement
- `tasks.md` — 4 implementation waves (core resolution, pipeline threading, CLI plumbing, integration tests)

No code changes — proposal only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specification and design proposal for Ralph worktree-awareness feature, enabling Ralph to detect and use existing git worktrees when targeting specific changes.
  * Introduced four-phase implementation plan with detailed requirements for worktree resolution, CLI handling, state management, and integration testing.
  * Updated module tracking to reflect new change initiative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->