### PR TITLE
fix(ci): restore shell invocation and doctest examples

### DIFF
--- a/ito-rs/crates/ito-config/src/ito_dir/mod.rs
+++ b/ito-rs/crates/ito-config/src/ito_dir/mod.rs
@@ -57,8 +57,13 @@ pub fn get_ito_path(project_root: &Path, ctx: &ConfigContext) -> PathBuf {
 /// # Examples
 ///
 /// ```no_run
+/// use ito_common::fs::StdFs;
+/// use ito_config::ConfigContext;
+/// use ito_config::ito_dir::get_ito_path_fs;
 /// use std::path::Path;
-/// // `fs` and `ctx` are implementations of `FileSystem` and `ConfigContext` from this crate.
+///
+/// let fs = StdFs;
+/// let ctx = ConfigContext::default();
 /// let ito_path = get_ito_path_fs(&fs, Path::new("some/project"), &ctx);
 /// assert!(ito_path.ends_with(".ito"));
 /// ```
@@ -82,8 +87,10 @@ pub fn get_ito_path_fs<F: FileSystem>(fs: &F, project_root: &Path, ctx: &ConfigC
 /// # Examples
 ///
 /// ```
+/// use ito_config::ito_dir::absolutize_and_normalize;
 /// use std::path::Path;
-/// let abs = crate::absolutize_and_normalize(Path::new(".")).unwrap();
+///
+/// let abs = absolutize_and_normalize(Path::new(".")).unwrap();
 /// assert!(abs.is_absolute());
 /// ```
 pub fn absolutize_and_normalize(input: &Path) -> std::io::Result<PathBuf> {
@@ -106,11 +113,9 @@ pub fn absolutize_and_normalize(input: &Path) -> std::io::Result<PathBuf> {
 ///
 /// # Examples
 ///
-/// ```
-/// use std::path::Path;
-///
-/// let p = crate::absolutize_and_normalize_lossy(Path::new("foo/./bar"));
-/// assert!(p.ends_with(Path::new("foo/bar")));
+/// ```ignore
+/// // Private helper function example:
+/// // absolutize_and_normalize_lossy(Path::new("foo/./bar")) -> .../foo/bar
 /// ```
 fn absolutize_and_normalize_lossy(input: &Path) -> PathBuf {
     absolutize_and_normalize(input).unwrap_or_else(|_| lexical_normalize(input))
@@ -124,15 +129,17 @@ fn absolutize_and_normalize_lossy(input: &Path) -> PathBuf {
 /// # Examples
 ///
 /// ```
+/// use ito_config::ito_dir::lexical_normalize;
 /// use std::path::{Path, PathBuf};
+///
 /// let p = Path::new("a/./b/../c");
-/// assert_eq!(super::lexical_normalize(p), PathBuf::from("a/c"));
+/// assert_eq!(lexical_normalize(p), PathBuf::from("a/c"));
 ///
 /// let abs = Path::new("/a/b/../c");
-/// assert_eq!(super::lexical_normalize(abs), PathBuf::from("/a/c"));
+/// assert_eq!(lexical_normalize(abs), PathBuf::from("/a/c"));
 ///
 /// let up = Path::new("../a/../b");
-/// assert_eq!(super::lexical_normalize(up), PathBuf::from("../b"));
+/// assert_eq!(lexical_normalize(up), PathBuf::from("../b"));
 /// ```
 pub fn lexical_normalize(path: &Path) -> PathBuf {
     use std::path::Component;

--- a/ito-rs/crates/ito-core/src/process.rs
+++ b/ito-rs/crates/ito-core/src/process.rs
@@ -449,7 +449,7 @@ mod tests {
     #[test]
     fn captures_stdout_and_stderr() {
         let runner = SystemProcessRunner;
-        let request = ProcessRequest::new("sh").args(["-lc", "echo out; echo err >&2"]);
+        let request = ProcessRequest::new("sh").args(["-c", "echo out; echo err >&2"]);
         let output = runner.run(&request).unwrap();
         assert!(output.success);
         assert_eq!(output.exit_code, 0);
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn captures_non_zero_exit() {
         let runner = SystemProcessRunner;
-        let request = ProcessRequest::new("sh").args(["-lc", "echo boom >&2; exit 7"]);
+        let request = ProcessRequest::new("sh").args(["-c", "echo boom >&2; exit 7"]);
         let output = runner.run(&request).unwrap();
         assert!(!output.success);
         assert_eq!(output.exit_code, 7);

--- a/ito-rs/crates/ito-core/src/ralph/validation.rs
+++ b/ito-rs/crates/ito-core/src/ralph/validation.rs
@@ -317,7 +317,7 @@ impl ShellRunOutput {
 fn run_shell_with_timeout(cwd: &Path, cmd: &str, timeout: Duration) -> CoreResult<ShellRunOutput> {
     let runner = SystemProcessRunner;
     let request = ProcessRequest::new("sh")
-        .args(["-lc", cmd])
+        .args(["-c", cmd])
         .current_dir(cwd.to_path_buf());
     let output = runner.run_with_timeout(&request, timeout).map_err(|e| {
         CoreError::Process(format!("Failed to run validation command '{cmd}': {e}"))


### PR DESCRIPTION
### Motivation
- Restore CI/test stability by fixing failing process and validation tests that relied on an invalid shell invocation and broken doctest examples.

### Description
- Replace `sh -lc` with `sh -c` for `ProcessRequest` invocations used in `ito-core` tests and in Ralph validation to match the process runner validation rules (files changed: `ito-rs/crates/ito-core/src/process.rs`, `ito-rs/crates/ito-core/src/ralph/validation.rs`).
- Repair doctest examples in `ito-rs/crates/ito-config/src/ito_dir/mod.rs` by adding proper imports, referencing the public helpers, and marking a private-helper example as ignored so docs-tests compile in the doctest context.
- Kept changes minimal and focused to unblock CI while preserving existing behavior and test intentions.

### Testing
- Ran targeted `cargo test` cases: `cargo test -p ito-core process::tests::captures_stdout_and_stderr`, `cargo test -p ito-core process::tests::captures_non_zero_exit`, and `cargo test -p ito-core ralph::validation::tests::run_extra_validation_success`, all of which passed.
- Ran documentation tests `cargo test -p ito-config --doc`, which passed after doctest fixes (one example intentionally `ignore`).
- Ran full test suite via `make test`, which completed successfully in this environment.
- `make check` could not complete here because `prek` is not installed, so equivalent checks `cargo fmt --all --check` and `RUSTFLAGS='-D warnings' cargo clippy --workspace --exclude ito-web -- -D warnings -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented` were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931e30ac248325bc914d785f47017d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public API for resolving Ito paths with custom filesystem implementations.

* **Documentation**
  * Enhanced documentation examples and improved references to public utility functions.

* **Improvements**
  * Refined shell command execution behavior in validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->