### PR TITLE
chore: refresh README and Windows install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,11 +367,28 @@ jobs:
         run: |
           make docs-site-check
 
+  powershell:
+    name: PowerShell Scripts (parse)
+    needs: [autofix]
+    if: |
+      always()
+      && (needs.autofix.result == 'success' || needs.autofix.result == 'skipped')
+      && needs.autofix.outputs.pushed != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Parse scripts/install.ps1
+        run: |
+          pwsh -NoProfile -Command '$t=@();$e=@();[System.Management.Automation.Language.Parser]::ParseFile("scripts/install.ps1",[ref]$t,[ref]$e) | Out-Null; if ($e.Count -gt 0) { $e | Format-List -Property Message,Extent | Out-String; exit 1 } else { "OK: scripts/install.ps1 parsed cleanly" }'
+
   required-checks-pr:
     name: All checks passed
     # runs-on: ubuntu-latest
     runs-on: namespace-profile-linux-amd64-4c8gb
-    needs: [autofix, test, lint, arch_guardrails, docs]
+    needs: [autofix, test, lint, arch_guardrails, docs, powershell]
     if: always() && github.event_name == 'pull_request'
     steps:
       - name: Verify all checks passed
@@ -399,13 +416,17 @@ jobs:
             echo "Docs job failed"
             exit 1
           fi
+          if [[ "${{ needs.powershell.result }}" != "success" ]]; then
+            echo "PowerShell job failed"
+            exit 1
+          fi
           echo "All required checks passed!"
 
   required-checks-main:
     name: All checks passed
     # runs-on: withakay-selfhosted
     runs-on: namespace-profile-linux-amd64-4c8gb
-    needs: [test, lint, arch_guardrails, docs]
+    needs: [test, lint, arch_guardrails, docs, powershell]
     if: always() && github.event_name != 'pull_request'
     steps:
       - name: Verify all checks passed
@@ -424,6 +445,10 @@ jobs:
           fi
           if [[ "${{ needs.docs.result }}" != "success" ]]; then
             echo "Docs job failed"
+            exit 1
+          fi
+          if [[ "${{ needs.powershell.result }}" != "success" ]]; then
+            echo "PowerShell job failed"
             exit 1
           fi
           echo "All required checks passed!"

--- a/.github/workflows/polish-release-notes.yml
+++ b/.github/workflows/polish-release-notes.yml
@@ -25,9 +25,23 @@ jobs:
           gh release view "${{ github.event.release.tag_name }}" --json body -q '.body' > current-notes.md
           echo "Fetched release notes for ${{ github.event.release.tag_name }}"
 
+      - name: Prepare install block
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          {
+            printf '%s\n' '## Install'
+            printf '\n'
+            printf '%s\n' '- **macOS (Homebrew)**: `brew tap withakay/ito && brew install ito-cli`'
+            printf '%s\n' "- **macOS/Linux (script)**: \`ITO_VERSION=${TAG} curl -fsSL https://raw.githubusercontent.com/withakay/ito/${TAG}/scripts/install.sh | sh\`"
+            printf '%s\n' "- **Windows (PowerShell script)**: download \`https://raw.githubusercontent.com/withakay/ito/${TAG}/scripts/install.ps1\` and run \`./install.ps1 -Version ${TAG} -AddToPath\`"
+            printf '\n'
+            printf '%s\n' 'Docs: https://withakay.github.io/ito'
+          } > install-block.md
+
       - name: Transform release notes with Claude
         uses: anthropics/claude-code-action@v1
         id: claude
+        if: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,6 +95,12 @@ jobs:
             ### Fixed
 
             - What was broken, now works
+
+            ## Install
+
+            - **macOS (Homebrew)**: `brew tap withakay/ito && brew install ito-cli`
+            - **macOS/Linux (script)**: `ITO_VERSION=${{ github.event.release.tag_name }} curl -fsSL https://raw.githubusercontent.com/withakay/ito/${{ github.event.release.tag_name }}/scripts/install.sh | sh`
+            - **Windows (PowerShell script)**: download `https://raw.githubusercontent.com/withakay/ito/${{ github.event.release.tag_name }}/scripts/install.ps1` and run `./install.ps1 -Version ${{ github.event.release.tag_name }} -AddToPath`
             ```
 
             Omit empty sections.
@@ -94,6 +114,7 @@ jobs:
             5. Use **bold** for feature/area names
             6. Skip internal changes (CI, refactors, tests) unless they affect users
             7. If the input is already well-formatted, just clean up structure and remove noise
+            8. Keep the Install section short and correct; don't invent installers that don't exist
 
             ## Example
 
@@ -118,6 +139,17 @@ jobs:
             ```
 
             Write both files. No other output.
+
+      - name: Ensure release notes include install section
+        run: |
+          if [ ! -f polished-notes.md ]; then
+            cp current-notes.md polished-notes.md
+          fi
+
+          if ! grep -qF "## Install" polished-notes.md; then
+            printf '\n\n' >> polished-notes.md
+            cat install-block.md >> polished-notes.md
+          fi
 
       - name: Update release
         env:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center">
   <a href="https://github.com/withakay/Ito/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/withakay/Ito/actions/workflows/ci.yml/badge.svg" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" /></a>
+  <a href="https://withakay.github.io/ito"><img alt="Docs" src="https://img.shields.io/badge/Docs-withakay.github.io%2Fito-2d7ff9.svg?style=flat-square" /></a>
 </p>
 
 # Ito
@@ -18,34 +19,30 @@ Ito is not a project management tool, but rather a lightweight, flexible framewo
 
 ## What You Get
 
-- Project planning foundation: `PROJECT.md`, `ROADMAP.md`, `STATE.md` templates
-- Research phase: parallel domain investigation + synthesis (`research/*`)
-- Enhanced tasks format: waves, verification criteria, completion tracking (`tasks.md`)
-- Agent configuration: per-tool models + context budgets (`config.json`)
-- Workflow orchestration: YAML workflows with waves + checkpoints, plus execution status tracking
-- Unified "research" and "adversarial review" workflows available as slash commands in supported tools
-- Ito agent skills installed automatically during repositiroy inititialisaton
-- Built in Ralph loop - create a change proposal and then use `ito ralph` to execute it in a loop with the agent, tracking progress and updating the proposal as you go.
-- Docs server \*:
-    - `ito serve` to browse `.ito/` artifacts and project docs over HTTP.
-    - Integrates with Tailscale for secure remote access, allows for a remote terminal based workflow in a cheap VM with easy access to documents in the browser.
-    - Embedded terminal in the docs UI for quick commands.
+Ito centers work around a small set of versioned artifacts under `.ito/`.
 
-\*It is pretty easy to accidentally expose sensitive info with the docs server, so it is opt-in and requires explicit configuration. Use with caution and consider running in a separate VM if you want remote access.
+- Change lifecycle: proposal artifacts you iterate on, then implement, then archive into the long-term spec.
+- Specs and deltas: stable capability specs under `.ito/specs/`, with per-change deltas under `.ito/changes/<change-id>/specs/`.
+- Tasks: a structured `tasks.md` per change, with CLI support for status/next/start/complete.
+- Modules: optional grouping of related changes with validation of scope and naming.
+- Validation: checks that changes/modules/specs follow conventions and are internally consistent.
+- Agent-facing instructions: generated instruction artifacts (`ito agent instruction ...`) and tool adapters installed by `ito init` / `ito update`.
+- Optional project planning: templates and commands for `.ito/planning/{PROJECT,ROADMAP,STATE}.md` (`ito plan ...`, `ito state ...`).
+- Optional local docs server: browse `.ito/` artifacts over HTTP (`ito serve ...`, requires `caddy`).
+
+## Core Workflow
+
+The intended workflow is:
+
+1. Create a change.
+2. Write/iterate on the proposal: the “why”, design notes (if needed), spec deltas, and tasks.
+3. Validate the change while you iterate.
+4. Implement the tasks.
+5. Archive the change to merge approved deltas into the main specs.
+
+At each step, the existing specs are the baseline. Changes are expressed as deltas, reviewed, then merged into `.ito/specs/` when archived.
 
 ## Quick Start
-
-### Prerequisites
-
-- Rust toolchain (rustup + cargo)
-
-### Recommended Developer Tools
-
-- `bacon` for background Rust checking and quick job switching:
-
-```bash
-cargo install --locked bacon
-```
 
 ### Install
 
@@ -58,24 +55,24 @@ brew install ito-cli
 
 Note: the Homebrew formula name is `ito-cli` (it installs the `ito` binary).
 
-**Build from source:**
-
-```bash
-make rust-install
-ito --version
-```
-
-**Prebuilt binary (macOS/Linux):**
+**Prebuilt binaries (macOS/Linux):**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/withakay/ito/main/scripts/install.sh | sh
 ito --version
 ```
 
-**npm (optional):**
+**Prebuilt binaries (Windows):**
+
+Windows builds are published.
+
+- Manual: download the latest Windows release from [GitHub Releases](https://github.com/withakay/ito/releases) and put `ito.exe` on your `PATH`.
+- PowerShell: download and run `scripts/install.ps1` (supports `-AddToPath`).
+
+**Build from source:**
 
 ```bash
-npm install -g @withakay/ito
+make rust-install
 ito --version
 ```
 
@@ -85,253 +82,58 @@ ito --version
 ito init
 ```
 
-This creates Ito's working directory (default: `.ito/`), installs Ito agent skills, and generates slash commands for the selected supported tools.
+This creates Ito's working directory (default: `.ito/`) and installs tool-specific adapters (skills, prompts, and instruction wiring) for the tools you select.
 
-Note: older docs (and some templates) may refer to `ito/` as the working directory. In this fork, the default is `.ito/`, and the directory name can be customized via `ito.json`.
+## Common Commands
 
-Ito agent skills are installed to `.claude/skills/<skill>/SKILL.md` so supported assistants can load the authoritative instructions.
+```bash
+ito create module <name>
+ito create change <slug> --module <module-id>
+
+ito list
+ito list --specs
+ito list --modules
+
+ito show <change-or-spec>
+ito validate <change-or-spec> --strict
+
+ito status --change <change-id>
+
+ito tasks status <change-id>
+ito tasks next <change-id>
+
+ito agent instruction proposal --change <change-id>
+ito agent instruction apply --change <change-id>
+ito agent instruction archive --change <change-id>
+
+ito archive <change-id> -y
+```
 
 ## On-Disk Layout
 
-After `ito init`, you'll typically have (default layout shown):
-
 ```text
 .ito/
-  AGENTS.md
   project.md
-  planning/
+  specs/                  # Current truth (capabilities)
+    <capability>/
+      spec.md
+      design.md           # Optional
+  changes/                # Proposals (deltas + tasks)
+    <change-id>/
+      proposal.md
+      design.md           # Optional
+      tasks.md
+      specs/
+        <capability>/
+          spec.md         # Delta: ADDED/MODIFIED/REMOVED/RENAMED
+  modules/                # Optional grouping of changes
+    <NNN_module-name>/
+      module.md
+  planning/               # Optional project planning artifacts
     PROJECT.md
     ROADMAP.md
     STATE.md
-  research/
-    SUMMARY.md
-    investigations/
-      stack-analysis.md
-      feature-landscape.md
-      architecture.md
-      pitfalls.md
-  changes/
-    <change-id>/
-      proposal.md
-      design.md
-      tasks.md
-      specs/
-      reviews/
-  workflows/
-    research.yaml
-    execute.yaml
-    review.yaml
-    .state/
-      <workflow>.json
-  commands/
-    <prompt-templates>.md
-  config.json
 ```
-
-## Core Workflows
-
-### 1) Project Planning (`ito plan`)
-
-Project planning lives in `.ito/planning/` and is intended to survive across sessions.
-
-```bash
-ito plan init
-ito plan status
-ito state show
-```
-
-- `PROJECT.md`: project vision, constraints, conventions
-- `ROADMAP.md`: phases/milestones
-- `STATE.md`: current focus, decisions, blockers, session notes
-
-### 2) Research Phase (`/ito … research`)
-
-Research is meant to happen _before_ proposing changes, especially when you're entering an unfamiliar domain.
-
-The built-in research workflow runs in parallel:
-
-- stack analysis
-- feature landscape
-- architecture
-- pitfalls
-
-…and then synthesizes results into `.ito/research/SUMMARY.md`.
-
-### 3) Change Execution With Enhanced Tasks (`ito tasks`)
-
-Ito supports an "enhanced tasks.md" format that is optimized for long-running work:
-
-- waves (grouping and parallelizable chunks)
-- explicit `Verify` commands
-- `Done When` acceptance criteria
-- task status tracking (pending / in-progress / complete)
-
-Ito also supports a lightweight checkbox-only `tasks.md` format in a compatibility mode:
-
-- `- [ ]` pending
-- `- [~]` in-progress (current task)
-- `- [x]` complete
-
-```bash
-ito tasks init <change-id>
-ito tasks status <change-id>
-ito tasks start <change-id> <task-id>
-ito tasks complete <change-id> <task-id>
-ito tasks next <change-id>
-```
-
-### 4) Adversarial Review (`/ito … review`)
-
-Adversarial review is multi-perspective by default:
-
-- security review (vulnerabilities, attack vectors)
-- scale review (perf bottlenecks)
-- edge case review (failure modes, boundaries)
-
-Outputs are written into the change folder under `reviews/`.
-
-### 5) Workflow Instructions (`ito agent instruction`)
-
-Ito workflow execution is instruction- and skill-driven.
-
-```bash
-ito agent instruction proposal --change <change-id>
-ito agent instruction specs --change <change-id>
-ito agent instruction tasks --change <change-id>
-ito agent instruction apply --change <change-id>
-ito agent instruction review --change <change-id>
-ito agent instruction archive --change <change-id>
-```
-
-Use `ito tasks` commands to track and execute task progress.
-
-## Agent Configuration (`ito agent-config`)
-
-Ito can generate and manage `<ito-dir>/config.json` for per-tool model selection and context budgets.
-
-```bash
-ito agent-config init
-ito agent-config summary
-ito agent-config get tools.opencode.default_model
-ito agent-config set agents.review.model_preference powerful
-```
-
-Generated `.ito/config.json` includes a `$schema` reference to the versioned schema artifact in this repository:
-
-- `https://raw.githubusercontent.com/withakay/ito/v<version>/schemas/ito-config.schema.json`
-
-Keep the committed schema artifact up-to-date with:
-
-```bash
-make config-schema
-make config-schema-check
-```
-
-## Slash Commands (Where Supported)
-
-Ito installs slash commands for tools that support them.
-
-- Claude Code (namespace style): `/ito:proposal`, `/ito:apply`, `/ito:archive`, `/ito:research`, `/ito:review`
-- OpenCode / Codex (hyphen style): `/ito-proposal`, `/ito-apply`, `/ito-archive`, `/ito-research`, `/ito-review`
-
-Exact availability depends on which tools you selected during `ito init`.
-
-## Command Reference (Common)
-
-```bash
-ito init
-ito update
-ito list
-ito list --specs
-ito show <change-or-spec>
-ito validate [item]
-ito archive <change-id> -y
-
-# Local docs server (requires Caddy)
-ito serve start
-ito serve status
-ito serve stop
-```
-
-## Local Docs Server (`ito serve`)
-
-Ito can serve a local, per-project docs browser over HTTP to make reviewing `.ito/` artifacts and project docs easy.
-
-### Prerequisite: Caddy
-
-`ito serve start` requires the external `caddy` binary.
-
-If `caddy` is missing, Ito prints an install hint and exits with code 1.
-
-### What Gets Served
-
-Only these allowlisted roots are exposed:
-
-- `.ito/changes/`, `.ito/specs/`, `.ito/modules/`
-- `.ito/planning/` and `.ito/research/` (if present)
-- `docs/` and `documents/` (if present)
-
-### Configuration
-
-Configure in `.ito/config.json` under `serve`:
-
-```json
-{
-    "serve": {
-        "bind": "127.0.0.1",
-        "port": 9009,
-        "token": "optional-only-used-for-non-loopback",
-        "caddyBin": "optional-path-to-caddy"
-    }
-}
-```
-
-- Default bind/port: `127.0.0.1:9009`
-- If the port is busy, Ito auto-increments to the next available port.
-- If `serve.bind` is non-loopback, Ito serves under a tokenized path prefix (`/t/<token>/`) and rejects requests without it.
-
-## Test Plan
-
-- [ ] Run `ito init` and verify `.ito/planning/` + `.ito/research/` templates exist
-- [ ] Run `ito agent instruction apply --change <change-id>` and verify task guidance is generated
-- [ ] Verify research and review slash commands are available in at least one supported tool
-- [ ] Run `make build` to verify the Rust CLI builds
-
-## Pre-commit Hooks (prek)
-
-Ito uses [prek](https://prek.j178.dev/) for pre-commit hooks. prek is a drop-in replacement for pre-commit and runs the same `.pre-commit-config.yaml`.
-
-### Quick Start
-
-```bash
-# Run hooks on staged files
-prek run
-
-# Run hooks on all files
-prek run --all-files
-
-# Install git hooks (runs automatically on commit)
-prek install
-
-# Run architecture guardrails directly
-make arch-guardrails
-```
-
-### Already using pre-commit?
-
-prek is fully compatible. Just replace `pre-commit` with `prek` in your workflow and reinstall hooks once:
-
-```bash
-prek install -f
-```
-
-### What the hooks check
-
-- **Whitespace / line endings**: trailing whitespace, EOF newline, mixed line endings
-- **Structured formats**: JSON syntax, YAML syntax + lint
-- **Markdown**: linting via markdownlint-cli2
-- **Rust**: `cargo fmt` + `cargo clippy` with the repo's lint policy
-- **Architecture**: `make arch-guardrails` for crate-edge and domain API guardrails
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,10 @@
 # Ito Documentation
 
-Welcome to the Ito docs site.
+Project-centric spec + workflow system for long-running AI coding work.
+
+Ito is a change-driven development tool that brings together project-centric planning, design notes (when needed), specifications, and tasks.
+
+It is designed for AI-assisted development where work spans multiple sessions and benefits from explicit artifacts, validation, and repeatable workflows.
 
 ## Ito
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,152 @@
+# Ito installer for Windows (PowerShell)
+#
+# Downloads the latest Windows release from GitHub and installs `ito.exe` into a
+# user-writable directory.
+#
+# Usage (recommended: download, inspect, then run):
+#   powershell -ExecutionPolicy Bypass -File .\install.ps1
+#
+# Optional:
+#   -Version <vX.Y.Z|X.Y.Z>   Install a specific release tag
+#   -InstallDir <path>        Override install directory
+#   -AddToPath                Append InstallDir to the user PATH
+
+[CmdletBinding()]
+param(
+  [string]$Version = "",
+  [string]$InstallDir = "",
+  [switch]$AddToPath
+)
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "withakay/ito"
+
+function Fail([string]$Message) {
+  Write-Error $Message
+  exit 1
+}
+
+function Get-LatestTag([string]$RepoName) {
+  $url = "https://api.github.com/repos/$RepoName/releases/latest"
+  $res = Invoke-RestMethod -Uri $url -Headers @{ "User-Agent" = "ito-install" }
+  if (-not $res.tag_name) {
+    Fail "failed to determine latest release tag"
+  }
+  return [string]$res.tag_name
+}
+
+function Normalize-Tag([string]$Tag) {
+  if ([string]::IsNullOrWhiteSpace($Tag)) {
+    return ""
+  }
+  if ($Tag.StartsWith("v")) {
+    return $Tag
+  }
+  return "v$Tag"
+}
+
+function Get-WindowsTarget() {
+  $arch = $env:PROCESSOR_ARCHITECTURE
+  if ($arch -eq "AMD64") {
+    return "x86_64-pc-windows-msvc"
+  }
+  Fail "unsupported Windows arch: $arch (expected AMD64)"
+}
+
+function Download-File([string]$Url, [string]$OutFile) {
+  Invoke-WebRequest -Uri $Url -OutFile $OutFile -Headers @{ "User-Agent" = "ito-install" } | Out-Null
+}
+
+function Read-ExpectedSha256([string]$ChecksumFile) {
+  $line = (Get-Content -Path $ChecksumFile -TotalCount 1)
+  if ([string]::IsNullOrWhiteSpace($line)) {
+    Fail "checksum file was empty"
+  }
+  return ($line -split "\s+")[0]
+}
+
+function Ensure-PathContains([string]$Dir) {
+  $current = [Environment]::GetEnvironmentVariable("PATH", "User")
+  if (-not $current) {
+    $current = ""
+  }
+
+  $parts = $current -split ";" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" }
+  foreach ($p in $parts) {
+    if ($p -ieq $Dir) {
+      return
+    }
+  }
+
+  $newPath = $current
+  if (-not [string]::IsNullOrWhiteSpace($newPath)) {
+    $newPath = "$newPath;"
+  }
+  $newPath = "$newPath$Dir"
+  [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+}
+
+try {
+  $tag = ""
+  if (-not [string]::IsNullOrWhiteSpace($Version)) {
+    $tag = Normalize-Tag $Version
+  } else {
+    $tag = Normalize-Tag (Get-LatestTag $Repo)
+  }
+
+  if ([string]::IsNullOrWhiteSpace($tag)) {
+    Fail "failed to determine release tag"
+  }
+
+  $target = Get-WindowsTarget
+  $archive = "ito-$tag-$target.zip"
+  $checksum = "ito-$tag-$target.sha256"
+  $baseUrl = "https://github.com/$Repo/releases/download/$tag"
+
+  if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:LOCALAPPDATA "ito\bin"
+  }
+
+  $tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString("n"))
+  New-Item -ItemType Directory -Path $tmpRoot | Out-Null
+
+  $archivePath = Join-Path $tmpRoot $archive
+  $checksumPath = Join-Path $tmpRoot $checksum
+
+  Download-File "$baseUrl/$archive" $archivePath
+  Download-File "$baseUrl/$checksum" $checksumPath
+
+  $expected = (Read-ExpectedSha256 $checksumPath).ToLowerInvariant()
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash.ToLowerInvariant()
+  if ($expected -ne $actual) {
+    Fail "checksum mismatch for $archive`nexpected: $expected`nactual:   $actual"
+  }
+
+  $extractDir = Join-Path $tmpRoot "extract"
+  Expand-Archive -Path $archivePath -DestinationPath $extractDir -Force
+
+  $exe = Get-ChildItem -Path $extractDir -Recurse -File -Filter "ito.exe" | Select-Object -First 1
+  if (-not $exe) {
+    Fail "archive did not contain expected binary: ito.exe"
+  }
+
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  $dest = Join-Path $InstallDir "ito.exe"
+  Copy-Item -Path $exe.FullName -Destination $dest -Force
+
+  Write-Host "installed ito to $dest"
+  & $dest --version | Out-Host
+
+  if ($AddToPath) {
+    Ensure-PathContains $InstallDir
+    Write-Host "added '$InstallDir' to user PATH (open a new terminal)"
+  } else {
+    Write-Host "note: '$InstallDir' is not on PATH by default"
+  }
+}
+finally {
+  if ($tmpRoot -and (Test-Path $tmpRoot)) {
+    Remove-Item -Recurse -Force $tmpRoot
+  }
+}


### PR DESCRIPTION
## Summary
- Refresh `README.md` to reflect the current change -> proposal -> validate -> implement -> archive workflow (no npm install, no workflow hype).
- Add a Windows PowerShell installer (`scripts/install.ps1`) and document Windows install paths.
- Wire a CI parse check for `scripts/install.ps1` and ensure release notes include a short install block.
- Expand the docs index page intro to match the README opening.

## Verification
- `make docs-site-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows PowerShell installer script for seamless release installation
  * Automated generation of OS-specific installation instructions in release notes (macOS Homebrew, Linux, Windows)

* **Documentation**
  * Reorganized README with core workflow narrative and streamlined installation guidance
  * Enhanced project documentation with comprehensive system description

* **Chores**
  * Strengthened CI pipeline with script validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->