### PR TITLE
ci: autofix config schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,15 @@ jobs:
         if: steps.loop_check.outputs.skip != 'true'
         run: cargo fmt --all
 
+      # --- Generated artifacts ---
+
+      - name: Update config schema artifact
+        if: steps.loop_check.outputs.skip != 'true'
+        run: |
+          # Keep schemas/ito-config.schema.json in sync with the code.
+          # If this changes the working tree, the commit step below will push it.
+          make config-schema
+
       # --- Commit and push if anything changed ---
 
       - name: Commit and push fixes
@@ -160,14 +169,15 @@ jobs:
           fi
 
           git add -A
-          git commit -m "ci: autofix lint and formatting issues
+          git commit -m "ci: autofix lint, formatting, and generated artifacts
 
           Automated fixes applied by CI:
           - Line endings (CRLF -> LF)
           - Trailing whitespace
           - Final newlines
           - JSON formatting
-          - Rust formatting (cargo fmt)"
+          - Rust formatting (cargo fmt)
+          - Regenerated config schema (schemas/ito-config.schema.json)"
 
           git push
           echo "pushed=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
CI currently fails PRs when schemas/ito-config.schema.json is stale (make config-schema-check).

This updates the existing **Autofix (lint & format)** job to also run cargo run -p ito-cli --bin ito -- config schema --output schemas/ito-config.schema.json and include any schema changes in the autofix commit push, so contributors don’t have to regenerate/commit the schema manually.

Notes:
- Only runs on non-fork PRs (same guard as existing autofix job).
- Uses the existing autofix push mechanism; downstream jobs are skipped and a new CI run validates the pushed changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow to automatically synchronize the configuration schema during builds, ensuring schema definitions stay current with codebase updates.
  * Improved commit messages to better document generated artifacts and schema regeneration activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->