### PR TITLE
fix: audit hook should warn, not block, on validation failure

### DIFF
--- a/.claude/hooks/ito-audit.sh
+++ b/.claude/hooks/ito-audit.sh
@@ -8,16 +8,19 @@ if [ -z "${HOOK_PAYLOAD}" ]; then
   HOOK_PAYLOAD='{}'
 fi
 
+# Attempt audit validation — warn on failure but never block.
+# Blocking here creates a catch-22: the fix command (ito audit reconcile --fix)
+# also requires Bash, which this hook would block.
 if ! ito audit validate >/dev/null 2>&1; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "additionalContext": "Ito audit validation failed before tool execution. Run `ito audit validate` to inspect issues and `ito audit reconcile --fix` if drift must be repaired."
+    "additionalContext": "Ito audit validation failed. Run `ito audit validate` to inspect issues and `ito audit reconcile --fix` if drift must be repaired."
   }
 }
 EOF
-  exit 2
+  exit 0
 fi
 
 RECONCILE_OUTPUT="$(ito audit reconcile 2>&1 || true)"

--- a/ito-rs/crates/ito-templates/assets/adapters/claude/hooks/ito-audit.sh
+++ b/ito-rs/crates/ito-templates/assets/adapters/claude/hooks/ito-audit.sh
@@ -8,16 +8,19 @@ if [ -z "${HOOK_PAYLOAD}" ]; then
   HOOK_PAYLOAD='{}'
 fi
 
+# Attempt audit validation — warn on failure but never block.
+# Blocking here creates a catch-22: the fix command (ito audit reconcile --fix)
+# also requires Bash, which this hook would block.
 if ! ito audit validate >/dev/null 2>&1; then
   cat <<'EOF'
 {
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "additionalContext": "Ito audit validation failed before tool execution. Run `ito audit validate` to inspect issues and `ito audit reconcile --fix` if drift must be repaired."
+    "additionalContext": "Ito audit validation failed. Run `ito audit validate` to inspect issues and `ito audit reconcile --fix` if drift must be repaired."
   }
 }
 EOF
-  exit 2
+  exit 0
 fi
 
 RECONCILE_OUTPUT="$(ito audit reconcile 2>&1 || true)"


### PR DESCRIPTION
## Summary

- Changes `exit 2` (hard block) to `exit 0` (warn) in the audit PreToolUse hook when `ito audit validate` fails
- Fixes catch-22 where the fix command (`ito audit reconcile --fix`) was itself blocked by the hook
- Updates both the template source and the installed copy

## Details

The `PreToolUse` hook matched on `Bash|Edit|Write`. When audit validation failed (e.g., empty `.ito/audit/` on fresh clone), `exit 2` blocked all tool operations — including the command needed to repair the audit state. This made the session completely unrecoverable without manual intervention.

The fix makes validation failure a **warning** (context injected back to the model) instead of a **blocker**, matching the pattern already used by the drift detection section of the same script.

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit validation failures are now non-blocking; the audit reconciliation process continues and completes successfully regardless of validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->