### PR TITLE
feat(029-01): add ByteRover integration and bootstrap curation

### DIFF
--- a/.agents/skills/byterover/README.md
+++ b/.agents/skills/byterover/README.md
@@ -1,0 +1,76 @@
+# ByteRover skills (local only)
+
+This directory holds the ByteRover hub skills that all non-Claude agent
+harnesses discover via `.agents/skills/`. Claude Code consumes its own
+connector tree (`.claude/skills/`), so the same four skills are also
+installed there — see the Mirror step below.
+
+The `SKILL.md` at the root of this directory is the base ByteRover skill
+(describes the `brv` CLI and when to query / curate). The four sub-directories
+below are the **hub skills** installed by change
+[`029-01_add-byterover-integration`](../../../.ito/changes/029-01_add-byterover-integration/).
+
+## Installed hub skills
+
+| Skill | Purpose |
+| --- | --- |
+| `byterover-review/` | Review staged changes or specific files against stored conventions, patterns, and architecture decisions. Flags missing tests and security concerns and curates newly observed patterns. |
+| `byterover-plan/` | Produce a goal-backward implementation plan informed by what ByteRover already knows about this project. Stores the plan via `brv curate`. |
+| `byterover-explore/` | Systematically map the codebase, docs, architecture, conventions, testing, integrations, and known concerns into the ByteRover context tree via `brv curate`. |
+| `byterover-audit/` | Audit stored knowledge for freshness and coverage: find stale or outdated entries, identify gaps, and emit targeted `brv curate` commands to fix them. |
+
+## How to reproduce
+
+From the project root:
+
+```bash
+# 1. Install the Claude Code agent-skill connector (required for `.claude/skills/`)
+brv connectors install "Claude Code" --type skill
+
+# 2. Install the four hub skills into Claude Code
+brv hub install byterover-review  --agent "Claude Code"
+brv hub install byterover-plan    --agent "Claude Code"
+brv hub install byterover-explore --agent "Claude Code"
+brv hub install byterover-audit   --agent "Claude Code"
+
+# 3. Mirror the installed skills into the shared skills directory
+#    used by every other agent harness (no byterover hub-install target
+#    writes to .agents/skills/ directly today).
+for id in byterover-review byterover-plan byterover-explore byterover-audit; do
+  rm -rf ".agents/skills/byterover/$id"
+  cp -R ".claude/skills/$id" ".agents/skills/byterover/$id"
+done
+```
+
+After step 3, the same four skills exist under both `.claude/skills/` and
+`.agents/skills/byterover/`, and `SKILL.md` contents match byte-for-byte.
+
+## Bootstrap curation
+
+The change also runs a one-off `brv curate` pass so ByteRover has the
+project's canonical knowledge available for `brv query` / `brv search`:
+
+```bash
+# Folder packs
+brv curate --folder .ito/specs/
+brv curate --folder docs/
+brv curate --folder .ito/changes/archive/
+brv curate --folder .ito/modules/
+
+# Top-level agent-facing docs (file mode)
+brv curate --files AGENTS.md --files .ito/AGENTS.md --files .ito/architecture.md
+```
+
+## Cloud sync — intentionally not used
+
+This integration is **local only**. No workflow, skill, or instruction
+template produced by change `029-01_add-byterover-integration` depends on
+any of:
+
+- `brv login`
+- `brv push`
+- `brv pull`
+- `brv vc …` (ByteRover's context-tree version control)
+
+If you want cloud sync, that is a separate, opt-in step — it is not a
+prerequisite for using the skills above or the bootstrap curation.

--- a/.agents/skills/byterover/byterover-audit/SKILL.md
+++ b/.agents/skills/byterover/byterover-audit/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: byterover-audit
+description: "Audit knowledge freshness and coverage. Checks what's documented against the current codebase, identifies stale or outdated knowledge, finds gaps, and provides targeted brv curate commands to fix them."
+---
+
+# ByteRover Knowledge Audit
+
+A structured workflow for auditing the health of your ByteRover knowledge base. Finds stale entries, missing coverage, and provides actionable remediation commands.
+
+## When to Use
+
+- After major refactors or dependency upgrades
+- Periodically (monthly or per sprint) to maintain knowledge quality
+- When suspecting knowledge drift (documented patterns no longer match code)
+- Before starting a new feature in an area with existing documentation
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+## Process
+
+### Phase 1: Inventory Existing Knowledge
+
+Query every major knowledge domain to understand what ByteRover currently knows:
+
+```bash
+brv query "What is documented about the technology stack and dependencies?"
+brv query "What is documented about the architecture and project structure?"
+brv query "What conventions and coding patterns are documented?"
+brv query "What testing approaches and frameworks are documented?"
+brv query "What integrations and external services are documented?"
+brv query "What concerns, tech debt, and known issues are documented?"
+```
+
+For each query, record:
+- Whether ByteRover returned substantive knowledge or nothing
+- The specificity of the response (file paths referenced? concrete patterns?)
+- The approximate age indicators (does it mention current dependencies?)
+
+If ByteRover returns nothing for most domains, stop and recommend running `byterover-explore` first — auditing requires an existing knowledge base.
+
+### Phase 2: Cross-Reference Against Codebase
+
+For each piece of documented knowledge, verify it matches the current codebase:
+
+**Technology Stack:**
+- Read `package.json`, `requirements.txt`, or equivalent — do documented dependencies still exist? Are versions accurate?
+- Check for new major dependencies not yet documented
+
+**Architecture:**
+- Verify documented directory structure matches reality
+- Check if documented entry points still exist
+- Confirm documented layer boundaries are still respected
+
+**Conventions:**
+- Read linting/formatting configs — do documented conventions match current rules?
+- Sample 2-3 source files — do naming patterns match what's documented?
+
+**Testing:**
+- Verify test framework config matches documentation
+- Check if test file patterns match documented conventions
+
+**Integrations:**
+- Read `.env.example` — are documented integrations still present? Any new ones?
+- Check for new SDK imports not yet documented
+
+### Phase 3: Staleness Detection
+
+Flag knowledge entries as stale when:
+- Referenced files no longer exist (deleted or renamed)
+- Referenced functions/classes have been renamed or removed
+- Documented patterns contradict current linting rules
+- Documented dependencies have been replaced (e.g., "uses moment.js" but codebase has date-fns)
+- Documented architecture no longer matches directory structure
+
+For each stale entry, note:
+- What the knowledge says
+- What the codebase actually shows
+- Severity: **critical** (misleading), **moderate** (outdated but not harmful), **minor** (cosmetic)
+
+### Phase 4: Gap Analysis
+
+Identify areas with zero or insufficient coverage:
+
+- Scan top-level directories — are all major modules documented?
+- Check for new files/directories not mentioned in any knowledge entry
+- Look for undocumented environment variables, API endpoints, or configuration
+- Check if error handling patterns are documented
+- Verify deployment/build process is documented
+
+### Phase 5: Coverage Report and Remediation
+
+Present a structured report:
+
+**Coverage Summary:**
+| Domain | Status | Issues |
+|--------|--------|--------|
+| Technology Stack | Current / Stale / Missing | Count of issues |
+| Architecture | Current / Stale / Missing | Count of issues |
+| Conventions | Current / Stale / Missing | Count of issues |
+| Testing | Current / Stale / Missing | Count of issues |
+| Integrations | Current / Stale / Missing | Count of issues |
+| Concerns | Current / Stale / Missing | Count of issues |
+
+**Stale Entries (fix first — wrong knowledge is worse than missing):**
+
+For each stale entry, provide the exact `brv curate` command to fix it:
+
+```bash
+brv curate "OUTDATED: [old knowledge]. NEW: [current state]. Clean up old context." -f [relevant files]
+```
+
+**Gap Entries (fill after fixing stale):**
+
+For each gap, provide the exact `brv curate` command to fill it:
+
+```bash
+brv curate "[domain]: [what needs documenting]" -f [relevant files]
+```
+
+### Completion
+
+After presenting the report:
+- Prioritize: fix stale entries first, then fill gaps
+- Offer to execute the remediation commands
+- Query the knowledge base again to verify fixes took effect
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, `.key`, `credentials.json`, and similar files
+2. **Wrong knowledge > missing knowledge** — Prioritize fixing stale entries over filling gaps
+3. **Provide actionable commands** — Every finding must include a concrete `brv curate` command
+4. **Reference specific file paths** — Every claim must reference the actual file checked
+5. **Be honest about coverage** — Don't inflate coverage ratings; if knowledge is vague, rate it as partial
+6. **Max 5 files per curate** — Break down large updates into multiple `brv curate` commands
+7. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.agents/skills/byterover/byterover-explore/SKILL.md
+++ b/.agents/skills/byterover/byterover-explore/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: byterover-explore
+description: "Systematically explore a codebase, documentation, and knowledge gaps. Maps technology stack, architecture, conventions, testing, integrations, and concerns into the ByteRover context tree via brv curate."
+---
+
+# ByteRover Explore
+
+A structured workflow for systematically exploring a codebase and curating findings into ByteRover's context tree. Covers code structure, documentation, and knowledge gaps.
+
+## When to Use
+
+- Starting work on an unfamiliar codebase
+- Onboarding to a new project
+- Auditing knowledge coverage after major changes
+- Building a comprehensive project knowledge base from scratch
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+## Process
+
+### Phase 1: Check Existing Knowledge
+
+Before exploring, query what ByteRover already knows to avoid duplicate work:
+
+```bash
+brv query "What is documented about the codebase architecture and structure?"
+brv query "What conventions, patterns, and testing approaches are documented?"
+brv query "What concerns, tech debt, or known issues are documented?"
+```
+
+If ByteRover already has comprehensive coverage, report what exists and ask the user which areas to refresh.
+
+### Phase 2: Codebase Mapping
+
+Explore each area systematically. For each area, read actual files, then curate findings.
+
+#### 2.1 Technology Stack
+
+Identify languages, runtime, frameworks, and key dependencies.
+
+**What to examine:**
+- Package manifests: `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Gemfile`
+- Config files: `tsconfig.json`, `.nvmrc`, `.python-version`, `Dockerfile`
+- SDK/API imports in source files
+
+```bash
+brv curate "Technology stack: [languages, runtime, frameworks, key dependencies]" -f package.json
+```
+
+#### 2.2 Architecture & Structure
+
+Map directory layout, module boundaries, entry points, layers, and data flow.
+
+**What to examine:**
+- Top-level directory structure (excluding `node_modules`, `.git`, `dist`)
+- Entry points: `src/index.*`, `src/main.*`, `app/page.*`
+- Import patterns to understand layer dependencies
+
+```bash
+brv curate "Architecture: [directory layout, layers, data flow, entry points, module boundaries]" -f [key structural files]
+```
+
+#### 2.3 Conventions & Patterns
+
+Analyze coding style, naming conventions, import ordering, error handling patterns.
+
+**What to examine:**
+- Linting/formatting config: `.eslintrc*`, `.prettierrc*`, `biome.json`
+- Sample source files for naming patterns (camelCase, snake_case, etc.)
+- Import ordering and module resolution patterns
+
+```bash
+brv curate "Conventions: [naming, code style, import patterns, error handling]" -f [config files]
+```
+
+#### 2.4 Testing Patterns
+
+Identify test framework, file organization, mocking approaches, fixtures.
+
+**What to examine:**
+- Test config: `jest.config.*`, `vitest.config.*`, `pytest.ini`, `.mocharc.*`
+- Test file locations and naming conventions
+- Sample test files for patterns (mocking, fixtures, assertions)
+
+```bash
+brv curate "Testing: [framework, organization, mocking patterns, fixtures]" -f [test config]
+```
+
+#### 2.5 Integrations
+
+Document external APIs, databases, auth providers, webhooks, third-party services.
+
+**What to examine:**
+- Environment variables (`.env.example`, not `.env`)
+- SDK imports (stripe, supabase, aws, firebase, etc.)
+- Database config, ORM setup, migration files
+
+```bash
+brv curate "Integrations: [external APIs, databases, auth, third-party services]" -f [relevant files]
+```
+
+#### 2.6 Concerns & Technical Debt
+
+Find TODOs, FIXMEs, large files, known issues, security risks, fragile areas.
+
+**What to examine:**
+- `TODO`, `FIXME`, `HACK`, `XXX` comments in source
+- Large files (potential complexity hotspots)
+- Empty stubs, incomplete implementations
+
+```bash
+brv curate "Concerns: [tech debt, TODOs, known issues, fragile areas, security risks]" -f [relevant files]
+```
+
+### Phase 3: Documentation & Knowledge Gaps
+
+#### 3.1 Documentation Coverage
+
+Assess existing documentation quality and coverage.
+
+**What to examine:**
+- `README.md` completeness (setup instructions, architecture overview, contribution guide)
+- `docs/` directory existence and contents
+- API documentation (OpenAPI specs, JSDoc, docstrings)
+- Architectural decision records (ADRs)
+- Inline code comments quality
+
+```bash
+brv curate "Documentation coverage: [what exists, quality assessment, what's missing]"
+```
+
+#### 3.2 Knowledge Gap Analysis
+
+Query ByteRover for each major area and identify what's still missing.
+
+```bash
+brv query "What is documented about the technology stack?"
+brv query "What is documented about the architecture?"
+brv query "What is documented about conventions?"
+brv query "What is documented about testing?"
+brv query "What is documented about integrations?"
+brv query "What is documented about concerns and tech debt?"
+```
+
+For any area with insufficient coverage, curate the missing knowledge:
+
+```bash
+brv curate "Knowledge gaps: [areas with missing or incomplete documentation]"
+```
+
+### Completion
+
+After exploration, verify overall coverage:
+
+```bash
+brv query "Summarize all documented knowledge about this project"
+```
+
+Report to the user:
+- What areas were explored and curated
+- Key findings (notable patterns, concerns, interesting architecture decisions)
+- Remaining gaps that need deeper investigation
+- Suggested next steps
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, `.key`, `credentials.json`, and similar files
+2. **File paths required** — Every finding must reference specific file paths
+3. **Be prescriptive** — "Use camelCase for functions" not "some functions use camelCase"
+4. **Break down large contexts** — Run multiple `brv curate` commands rather than one massive one
+5. **Let ByteRover read files** — Use `-f` flags to let ByteRover read files directly (max 5 per command)
+6. **Be specific in queries** — Use precise questions for faster, more relevant results
+7. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.agents/skills/byterover/byterover-plan/SKILL.md
+++ b/.agents/skills/byterover/byterover-plan/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: byterover-plan
+description: "Create structured implementation plans informed by existing knowledge. Queries architecture, conventions, and related implementations, then produces a goal-backward task breakdown with dependencies. Stores the plan via brv curate."
+---
+
+# ByteRover Context-Aware Planning
+
+A structured workflow for creating implementation plans that leverage ByteRover's existing knowledge. Uses goal-backward methodology to derive concrete tasks from desired outcomes.
+
+## When to Use
+
+- Before implementing a new feature
+- When tackling a complex task that needs decomposition
+- When planning a refactor across multiple files
+- When scope is unclear and needs structured analysis
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+The user must describe what they want to build or change.
+
+## Process
+
+### Phase 1: Gather Existing Context
+
+Query the knowledge base for everything relevant to the planned work:
+
+```bash
+brv query "What is the architecture and structure of [affected area]?"
+brv query "What conventions and patterns are used for [type of work: API, UI, data, etc.]?"
+brv query "Are there existing implementations similar to [planned feature]?"
+brv query "What concerns or tech debt exist in [affected area]?"
+brv query "What testing approach is used for [type of work]?"
+```
+
+Adapt queries to the specific task. The goal is to understand:
+- What patterns already exist that should be followed
+- What concerns or constraints exist in the affected area
+- What similar work has been done before
+
+### Phase 2: Goal-Backward Analysis
+
+Start from the desired outcome, not from tasks:
+
+**1. State the goal as an outcome:**
+> "When this is done, [observable result]"
+
+**2. Derive observable truths (3-7):**
+For each truth, ask: "What must be TRUE for this outcome to exist?"
+
+Example:
+> Goal: "Users can reset their password via email"
+> - Truth 1: Password reset endpoint exists and validates tokens
+> - Truth 2: Email service sends reset links with time-limited tokens
+> - Truth 3: Reset form accepts new password and calls the endpoint
+> - Truth 4: Tests verify the full flow (request → email → reset → login)
+
+**3. For each truth, derive required artifacts:**
+- Specific files to create or modify
+- Specific wiring (exports → imports, API → consumer)
+- Specific tests
+
+### Phase 3: Task Breakdown
+
+Decompose into concrete, sequenced tasks (3-7 per plan):
+
+For each task, specify:
+
+```
+Task: [Name]
+Files: [Exact paths to create/modify]
+Action: [What to implement and how — reference existing patterns from Phase 1]
+Verify: [How to prove this task is complete — run test, check behavior]
+Done: [Acceptance criteria — observable outcome]
+Dependencies: [Which tasks must complete first]
+```
+
+**Sizing guidance:**
+- Each task should be completable in 15-60 minutes
+- If a task would take longer, break it down further
+- Keep total plan to 3-7 tasks (if more needed, create multiple plans)
+
+**Ordering rules:**
+- Data models and interfaces first
+- Implementation before tests (but tests in same plan)
+- Backend before frontend for full-stack features
+
+### Phase 4: Risk and Concern Check
+
+Query known issues in the affected area:
+
+```bash
+brv query "What known issues or tech debt exist in [affected files/modules]?"
+brv query "What are the common pitfalls for [type of work]?"
+```
+
+For each concern that overlaps with the plan:
+- Assess whether the plan addresses it or makes it worse
+- Adjust tasks if needed to mitigate risks
+- Note unresolvable risks for the user
+
+### Phase 5: Store the Plan
+
+Curate the complete plan for future reference:
+
+```bash
+brv curate "Implementation plan for [feature name]: [number] tasks covering [brief scope]. Goal: [outcome]. Key files: [main files]. Approach: [architecture decision]" -f [key files referenced in plan]
+```
+
+If the plan is large, break into multiple curate commands:
+
+```bash
+brv curate "Plan [feature] task 1-3: [summary of first tasks]" -f [relevant files]
+brv curate "Plan [feature] task 4-7: [summary of remaining tasks]" -f [relevant files]
+```
+
+### Completion
+
+Present the plan to the user:
+
+1. **Goal** — What this achieves (outcome statement)
+2. **Context used** — What knowledge informed the plan (patterns followed, concerns addressed)
+3. **Tasks** — Ordered list with files, actions, and verification
+4. **Dependencies** — Which tasks depend on others
+5. **Risks** — Known concerns and mitigations
+6. **Estimated scope** — Number of files, rough complexity
+
+Ask the user to review and approve before execution.
+
+## Important Rules
+
+1. **Plans must be executable** — Specific enough that a different agent could implement without clarification
+2. **Every task needs file paths** — No vague "update the service" — specify exactly which files
+3. **Goal-backward, not forward** — Derive tasks from outcomes, don't list tasks and hope they achieve the goal
+4. **Reuse existing patterns** — Reference patterns from the knowledge base instead of inventing new ones
+5. **Right-size tasks** — 3-7 tasks per plan, 15-60 minutes each
+6. **Store the plan** — Always curate the plan via `brv curate` for future reference
+7. **Max 5 files per curate** — Break down large plans into multiple curate operations
+8. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.agents/skills/byterover/byterover-review/SKILL.md
+++ b/.agents/skills/byterover/byterover-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: byterover-review
+description: "Review code changes against stored conventions, patterns, and architecture decisions. Checks staged changes or specific files for convention violations, pattern mismatches, missing tests, and security concerns. Curates newly discovered patterns."
+---
+
+# ByteRover Code Review
+
+A structured workflow for reviewing code changes against the project's documented conventions, patterns, and architecture decisions stored in ByteRover's knowledge base.
+
+## When to Use
+
+- Before committing changes
+- During pull request reviews
+- After receiving code from other agents or developers
+- When unsure if changes follow project conventions
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+The review needs something to review. Ask the user for one of:
+- Staged changes (default: `git diff --cached`)
+- Unstaged changes (`git diff`)
+- Specific file paths to review
+
+## Process
+
+### Phase 1: Load Project Context
+
+Query the knowledge base for all relevant standards:
+
+```bash
+brv query "What coding conventions and naming patterns are used in this project?"
+brv query "What architecture patterns and layer boundaries are documented?"
+brv query "What testing patterns and requirements are documented?"
+brv query "What error handling and security patterns are documented?"
+```
+
+If ByteRover returns little or no knowledge, note this and recommend running `byterover-explore` first. Proceed with best-effort review based on what's available.
+
+### Phase 2: Identify Changes
+
+Determine what to review:
+
+```bash
+# For staged changes (most common)
+git diff --cached --name-only
+git diff --cached
+
+# For unstaged changes
+git diff --name-only
+git diff
+
+# For specific files - read them directly
+```
+
+Categorize changed files by type:
+- **Source code** — primary review focus
+- **Test files** — check test quality and coverage
+- **Config files** — check for unintended changes
+- **Documentation** — check accuracy
+
+### Phase 3: Convention Compliance
+
+Compare each changed file against documented conventions:
+
+**Naming conventions:**
+- Variable/function names follow documented patterns (camelCase, snake_case, etc.)
+- File naming matches project conventions
+- Export naming is consistent
+
+**Import patterns:**
+- Import ordering matches documented rules
+- No circular dependencies introduced
+- Proper use of type imports where applicable
+
+**Code style:**
+- Error handling follows documented patterns
+- Logging follows documented conventions
+- Comments are meaningful (not redundant)
+
+For each violation, note:
+- File and line number
+- The convention being violated
+- The documented standard (from knowledge base)
+- Severity: **blocking** (must fix) or **suggestion** (nice to have)
+
+### Phase 4: Architecture and Pattern Check
+
+Verify changes respect documented architecture:
+
+**Layer boundaries:**
+- Do changes maintain proper layer separation?
+- Are dependencies flowing in the documented direction?
+- No business logic in presentation layer (or vice versa)
+
+**Pattern compliance:**
+- Do new components/modules follow existing patterns?
+- Are established abstractions reused rather than reinvented?
+- Does data flow match documented architecture?
+
+**API contracts:**
+- Do interface changes maintain backward compatibility?
+- Are new APIs consistent with existing ones?
+
+### Phase 5: Test and Security Check
+
+**Test coverage:**
+- Do changed source files have corresponding test files?
+- Are new functions/components tested?
+- Do test patterns match documented testing approach?
+
+**Security concerns:**
+- No hardcoded secrets, API keys, or credentials
+- Input validation for user-facing endpoints
+- No SQL injection, XSS, or command injection vectors
+- Proper authentication/authorization checks
+- No sensitive data logged or exposed
+
+### Phase 6: Curate New Patterns
+
+If the review reveals patterns not yet documented:
+
+```bash
+# New convention discovered
+brv curate "Convention: [new pattern observed across multiple files]" -f [example files]
+
+# New architectural decision
+brv curate "Architecture decision: [what was decided and why]" -f [relevant files]
+
+# New concern identified
+brv curate "Concern: [potential issue found during review]" -f [affected files]
+```
+
+### Completion
+
+Present a structured review:
+
+**Summary:** X blocking issues, Y suggestions, Z new patterns found
+
+**Blocking Issues (must fix):**
+- [File:line] Issue description | Convention: [source]
+
+**Suggestions (nice to have):**
+- [File:line] Suggestion | Rationale
+
+**New Patterns Curated:**
+- [Pattern description] → stored via `brv curate`
+
+**Missing Coverage:**
+- Areas where knowledge base had no guidance (recommend `byterover-explore`)
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, credential files, and similar
+2. **Knowledge-first** — Base reviews on documented standards, not personal preference
+3. **Distinguish severity** — Clearly separate blocking issues from suggestions
+4. **Be specific** — Reference file paths, line numbers, and the exact convention violated
+5. **Curate discoveries** — Store genuinely new patterns, not noise
+6. **Max 5 files per curate** — Break down large curate operations
+7. **No false positives** — Only flag issues where a documented standard exists or a clear security concern is present
+8. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.claude/skills/byterover-audit/SKILL.md
+++ b/.claude/skills/byterover-audit/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: byterover-audit
+description: "Audit knowledge freshness and coverage. Checks what's documented against the current codebase, identifies stale or outdated knowledge, finds gaps, and provides targeted brv curate commands to fix them."
+---
+
+# ByteRover Knowledge Audit
+
+A structured workflow for auditing the health of your ByteRover knowledge base. Finds stale entries, missing coverage, and provides actionable remediation commands.
+
+## When to Use
+
+- After major refactors or dependency upgrades
+- Periodically (monthly or per sprint) to maintain knowledge quality
+- When suspecting knowledge drift (documented patterns no longer match code)
+- Before starting a new feature in an area with existing documentation
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+## Process
+
+### Phase 1: Inventory Existing Knowledge
+
+Query every major knowledge domain to understand what ByteRover currently knows:
+
+```bash
+brv query "What is documented about the technology stack and dependencies?"
+brv query "What is documented about the architecture and project structure?"
+brv query "What conventions and coding patterns are documented?"
+brv query "What testing approaches and frameworks are documented?"
+brv query "What integrations and external services are documented?"
+brv query "What concerns, tech debt, and known issues are documented?"
+```
+
+For each query, record:
+- Whether ByteRover returned substantive knowledge or nothing
+- The specificity of the response (file paths referenced? concrete patterns?)
+- The approximate age indicators (does it mention current dependencies?)
+
+If ByteRover returns nothing for most domains, stop and recommend running `byterover-explore` first — auditing requires an existing knowledge base.
+
+### Phase 2: Cross-Reference Against Codebase
+
+For each piece of documented knowledge, verify it matches the current codebase:
+
+**Technology Stack:**
+- Read `package.json`, `requirements.txt`, or equivalent — do documented dependencies still exist? Are versions accurate?
+- Check for new major dependencies not yet documented
+
+**Architecture:**
+- Verify documented directory structure matches reality
+- Check if documented entry points still exist
+- Confirm documented layer boundaries are still respected
+
+**Conventions:**
+- Read linting/formatting configs — do documented conventions match current rules?
+- Sample 2-3 source files — do naming patterns match what's documented?
+
+**Testing:**
+- Verify test framework config matches documentation
+- Check if test file patterns match documented conventions
+
+**Integrations:**
+- Read `.env.example` — are documented integrations still present? Any new ones?
+- Check for new SDK imports not yet documented
+
+### Phase 3: Staleness Detection
+
+Flag knowledge entries as stale when:
+- Referenced files no longer exist (deleted or renamed)
+- Referenced functions/classes have been renamed or removed
+- Documented patterns contradict current linting rules
+- Documented dependencies have been replaced (e.g., "uses moment.js" but codebase has date-fns)
+- Documented architecture no longer matches directory structure
+
+For each stale entry, note:
+- What the knowledge says
+- What the codebase actually shows
+- Severity: **critical** (misleading), **moderate** (outdated but not harmful), **minor** (cosmetic)
+
+### Phase 4: Gap Analysis
+
+Identify areas with zero or insufficient coverage:
+
+- Scan top-level directories — are all major modules documented?
+- Check for new files/directories not mentioned in any knowledge entry
+- Look for undocumented environment variables, API endpoints, or configuration
+- Check if error handling patterns are documented
+- Verify deployment/build process is documented
+
+### Phase 5: Coverage Report and Remediation
+
+Present a structured report:
+
+**Coverage Summary:**
+| Domain | Status | Issues |
+|--------|--------|--------|
+| Technology Stack | Current / Stale / Missing | Count of issues |
+| Architecture | Current / Stale / Missing | Count of issues |
+| Conventions | Current / Stale / Missing | Count of issues |
+| Testing | Current / Stale / Missing | Count of issues |
+| Integrations | Current / Stale / Missing | Count of issues |
+| Concerns | Current / Stale / Missing | Count of issues |
+
+**Stale Entries (fix first — wrong knowledge is worse than missing):**
+
+For each stale entry, provide the exact `brv curate` command to fix it:
+
+```bash
+brv curate "OUTDATED: [old knowledge]. NEW: [current state]. Clean up old context." -f [relevant files]
+```
+
+**Gap Entries (fill after fixing stale):**
+
+For each gap, provide the exact `brv curate` command to fill it:
+
+```bash
+brv curate "[domain]: [what needs documenting]" -f [relevant files]
+```
+
+### Completion
+
+After presenting the report:
+- Prioritize: fix stale entries first, then fill gaps
+- Offer to execute the remediation commands
+- Query the knowledge base again to verify fixes took effect
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, `.key`, `credentials.json`, and similar files
+2. **Wrong knowledge > missing knowledge** — Prioritize fixing stale entries over filling gaps
+3. **Provide actionable commands** — Every finding must include a concrete `brv curate` command
+4. **Reference specific file paths** — Every claim must reference the actual file checked
+5. **Be honest about coverage** — Don't inflate coverage ratings; if knowledge is vague, rate it as partial
+6. **Max 5 files per curate** — Break down large updates into multiple `brv curate` commands
+7. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.claude/skills/byterover-explore/SKILL.md
+++ b/.claude/skills/byterover-explore/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: byterover-explore
+description: "Systematically explore a codebase, documentation, and knowledge gaps. Maps technology stack, architecture, conventions, testing, integrations, and concerns into the ByteRover context tree via brv curate."
+---
+
+# ByteRover Explore
+
+A structured workflow for systematically exploring a codebase and curating findings into ByteRover's context tree. Covers code structure, documentation, and knowledge gaps.
+
+## When to Use
+
+- Starting work on an unfamiliar codebase
+- Onboarding to a new project
+- Auditing knowledge coverage after major changes
+- Building a comprehensive project knowledge base from scratch
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+## Process
+
+### Phase 1: Check Existing Knowledge
+
+Before exploring, query what ByteRover already knows to avoid duplicate work:
+
+```bash
+brv query "What is documented about the codebase architecture and structure?"
+brv query "What conventions, patterns, and testing approaches are documented?"
+brv query "What concerns, tech debt, or known issues are documented?"
+```
+
+If ByteRover already has comprehensive coverage, report what exists and ask the user which areas to refresh.
+
+### Phase 2: Codebase Mapping
+
+Explore each area systematically. For each area, read actual files, then curate findings.
+
+#### 2.1 Technology Stack
+
+Identify languages, runtime, frameworks, and key dependencies.
+
+**What to examine:**
+- Package manifests: `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Gemfile`
+- Config files: `tsconfig.json`, `.nvmrc`, `.python-version`, `Dockerfile`
+- SDK/API imports in source files
+
+```bash
+brv curate "Technology stack: [languages, runtime, frameworks, key dependencies]" -f package.json
+```
+
+#### 2.2 Architecture & Structure
+
+Map directory layout, module boundaries, entry points, layers, and data flow.
+
+**What to examine:**
+- Top-level directory structure (excluding `node_modules`, `.git`, `dist`)
+- Entry points: `src/index.*`, `src/main.*`, `app/page.*`
+- Import patterns to understand layer dependencies
+
+```bash
+brv curate "Architecture: [directory layout, layers, data flow, entry points, module boundaries]" -f [key structural files]
+```
+
+#### 2.3 Conventions & Patterns
+
+Analyze coding style, naming conventions, import ordering, error handling patterns.
+
+**What to examine:**
+- Linting/formatting config: `.eslintrc*`, `.prettierrc*`, `biome.json`
+- Sample source files for naming patterns (camelCase, snake_case, etc.)
+- Import ordering and module resolution patterns
+
+```bash
+brv curate "Conventions: [naming, code style, import patterns, error handling]" -f [config files]
+```
+
+#### 2.4 Testing Patterns
+
+Identify test framework, file organization, mocking approaches, fixtures.
+
+**What to examine:**
+- Test config: `jest.config.*`, `vitest.config.*`, `pytest.ini`, `.mocharc.*`
+- Test file locations and naming conventions
+- Sample test files for patterns (mocking, fixtures, assertions)
+
+```bash
+brv curate "Testing: [framework, organization, mocking patterns, fixtures]" -f [test config]
+```
+
+#### 2.5 Integrations
+
+Document external APIs, databases, auth providers, webhooks, third-party services.
+
+**What to examine:**
+- Environment variables (`.env.example`, not `.env`)
+- SDK imports (stripe, supabase, aws, firebase, etc.)
+- Database config, ORM setup, migration files
+
+```bash
+brv curate "Integrations: [external APIs, databases, auth, third-party services]" -f [relevant files]
+```
+
+#### 2.6 Concerns & Technical Debt
+
+Find TODOs, FIXMEs, large files, known issues, security risks, fragile areas.
+
+**What to examine:**
+- `TODO`, `FIXME`, `HACK`, `XXX` comments in source
+- Large files (potential complexity hotspots)
+- Empty stubs, incomplete implementations
+
+```bash
+brv curate "Concerns: [tech debt, TODOs, known issues, fragile areas, security risks]" -f [relevant files]
+```
+
+### Phase 3: Documentation & Knowledge Gaps
+
+#### 3.1 Documentation Coverage
+
+Assess existing documentation quality and coverage.
+
+**What to examine:**
+- `README.md` completeness (setup instructions, architecture overview, contribution guide)
+- `docs/` directory existence and contents
+- API documentation (OpenAPI specs, JSDoc, docstrings)
+- Architectural decision records (ADRs)
+- Inline code comments quality
+
+```bash
+brv curate "Documentation coverage: [what exists, quality assessment, what's missing]"
+```
+
+#### 3.2 Knowledge Gap Analysis
+
+Query ByteRover for each major area and identify what's still missing.
+
+```bash
+brv query "What is documented about the technology stack?"
+brv query "What is documented about the architecture?"
+brv query "What is documented about conventions?"
+brv query "What is documented about testing?"
+brv query "What is documented about integrations?"
+brv query "What is documented about concerns and tech debt?"
+```
+
+For any area with insufficient coverage, curate the missing knowledge:
+
+```bash
+brv curate "Knowledge gaps: [areas with missing or incomplete documentation]"
+```
+
+### Completion
+
+After exploration, verify overall coverage:
+
+```bash
+brv query "Summarize all documented knowledge about this project"
+```
+
+Report to the user:
+- What areas were explored and curated
+- Key findings (notable patterns, concerns, interesting architecture decisions)
+- Remaining gaps that need deeper investigation
+- Suggested next steps
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, `.key`, `credentials.json`, and similar files
+2. **File paths required** — Every finding must reference specific file paths
+3. **Be prescriptive** — "Use camelCase for functions" not "some functions use camelCase"
+4. **Break down large contexts** — Run multiple `brv curate` commands rather than one massive one
+5. **Let ByteRover read files** — Use `-f` flags to let ByteRover read files directly (max 5 per command)
+6. **Be specific in queries** — Use precise questions for faster, more relevant results
+7. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.claude/skills/byterover-plan/SKILL.md
+++ b/.claude/skills/byterover-plan/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: byterover-plan
+description: "Create structured implementation plans informed by existing knowledge. Queries architecture, conventions, and related implementations, then produces a goal-backward task breakdown with dependencies. Stores the plan via brv curate."
+---
+
+# ByteRover Context-Aware Planning
+
+A structured workflow for creating implementation plans that leverage ByteRover's existing knowledge. Uses goal-backward methodology to derive concrete tasks from desired outcomes.
+
+## When to Use
+
+- Before implementing a new feature
+- When tackling a complex task that needs decomposition
+- When planning a refactor across multiple files
+- When scope is unclear and needs structured analysis
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+The user must describe what they want to build or change.
+
+## Process
+
+### Phase 1: Gather Existing Context
+
+Query the knowledge base for everything relevant to the planned work:
+
+```bash
+brv query "What is the architecture and structure of [affected area]?"
+brv query "What conventions and patterns are used for [type of work: API, UI, data, etc.]?"
+brv query "Are there existing implementations similar to [planned feature]?"
+brv query "What concerns or tech debt exist in [affected area]?"
+brv query "What testing approach is used for [type of work]?"
+```
+
+Adapt queries to the specific task. The goal is to understand:
+- What patterns already exist that should be followed
+- What concerns or constraints exist in the affected area
+- What similar work has been done before
+
+### Phase 2: Goal-Backward Analysis
+
+Start from the desired outcome, not from tasks:
+
+**1. State the goal as an outcome:**
+> "When this is done, [observable result]"
+
+**2. Derive observable truths (3-7):**
+For each truth, ask: "What must be TRUE for this outcome to exist?"
+
+Example:
+> Goal: "Users can reset their password via email"
+> - Truth 1: Password reset endpoint exists and validates tokens
+> - Truth 2: Email service sends reset links with time-limited tokens
+> - Truth 3: Reset form accepts new password and calls the endpoint
+> - Truth 4: Tests verify the full flow (request → email → reset → login)
+
+**3. For each truth, derive required artifacts:**
+- Specific files to create or modify
+- Specific wiring (exports → imports, API → consumer)
+- Specific tests
+
+### Phase 3: Task Breakdown
+
+Decompose into concrete, sequenced tasks (3-7 per plan):
+
+For each task, specify:
+
+```
+Task: [Name]
+Files: [Exact paths to create/modify]
+Action: [What to implement and how — reference existing patterns from Phase 1]
+Verify: [How to prove this task is complete — run test, check behavior]
+Done: [Acceptance criteria — observable outcome]
+Dependencies: [Which tasks must complete first]
+```
+
+**Sizing guidance:**
+- Each task should be completable in 15-60 minutes
+- If a task would take longer, break it down further
+- Keep total plan to 3-7 tasks (if more needed, create multiple plans)
+
+**Ordering rules:**
+- Data models and interfaces first
+- Implementation before tests (but tests in same plan)
+- Backend before frontend for full-stack features
+
+### Phase 4: Risk and Concern Check
+
+Query known issues in the affected area:
+
+```bash
+brv query "What known issues or tech debt exist in [affected files/modules]?"
+brv query "What are the common pitfalls for [type of work]?"
+```
+
+For each concern that overlaps with the plan:
+- Assess whether the plan addresses it or makes it worse
+- Adjust tasks if needed to mitigate risks
+- Note unresolvable risks for the user
+
+### Phase 5: Store the Plan
+
+Curate the complete plan for future reference:
+
+```bash
+brv curate "Implementation plan for [feature name]: [number] tasks covering [brief scope]. Goal: [outcome]. Key files: [main files]. Approach: [architecture decision]" -f [key files referenced in plan]
+```
+
+If the plan is large, break into multiple curate commands:
+
+```bash
+brv curate "Plan [feature] task 1-3: [summary of first tasks]" -f [relevant files]
+brv curate "Plan [feature] task 4-7: [summary of remaining tasks]" -f [relevant files]
+```
+
+### Completion
+
+Present the plan to the user:
+
+1. **Goal** — What this achieves (outcome statement)
+2. **Context used** — What knowledge informed the plan (patterns followed, concerns addressed)
+3. **Tasks** — Ordered list with files, actions, and verification
+4. **Dependencies** — Which tasks depend on others
+5. **Risks** — Known concerns and mitigations
+6. **Estimated scope** — Number of files, rough complexity
+
+Ask the user to review and approve before execution.
+
+## Important Rules
+
+1. **Plans must be executable** — Specific enough that a different agent could implement without clarification
+2. **Every task needs file paths** — No vague "update the service" — specify exactly which files
+3. **Goal-backward, not forward** — Derive tasks from outcomes, don't list tasks and hope they achieve the goal
+4. **Reuse existing patterns** — Reference patterns from the knowledge base instead of inventing new ones
+5. **Right-size tasks** — 3-7 tasks per plan, 15-60 minutes each
+6. **Store the plan** — Always curate the plan via `brv curate` for future reference
+7. **Max 5 files per curate** — Break down large plans into multiple curate operations
+8. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.claude/skills/byterover-review/SKILL.md
+++ b/.claude/skills/byterover-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: byterover-review
+description: "Review code changes against stored conventions, patterns, and architecture decisions. Checks staged changes or specific files for convention violations, pattern mismatches, missing tests, and security concerns. Curates newly discovered patterns."
+---
+
+# ByteRover Code Review
+
+A structured workflow for reviewing code changes against the project's documented conventions, patterns, and architecture decisions stored in ByteRover's knowledge base.
+
+## When to Use
+
+- Before committing changes
+- During pull request reviews
+- After receiving code from other agents or developers
+- When unsure if changes follow project conventions
+
+## Prerequisites
+
+Run `brv status` first. If errors occur, instruct the user to resolve them in the brv terminal. See the byterover skill's TROUBLESHOOTING.md for details.
+
+The review needs something to review. Ask the user for one of:
+- Staged changes (default: `git diff --cached`)
+- Unstaged changes (`git diff`)
+- Specific file paths to review
+
+## Process
+
+### Phase 1: Load Project Context
+
+Query the knowledge base for all relevant standards:
+
+```bash
+brv query "What coding conventions and naming patterns are used in this project?"
+brv query "What architecture patterns and layer boundaries are documented?"
+brv query "What testing patterns and requirements are documented?"
+brv query "What error handling and security patterns are documented?"
+```
+
+If ByteRover returns little or no knowledge, note this and recommend running `byterover-explore` first. Proceed with best-effort review based on what's available.
+
+### Phase 2: Identify Changes
+
+Determine what to review:
+
+```bash
+# For staged changes (most common)
+git diff --cached --name-only
+git diff --cached
+
+# For unstaged changes
+git diff --name-only
+git diff
+
+# For specific files - read them directly
+```
+
+Categorize changed files by type:
+- **Source code** — primary review focus
+- **Test files** — check test quality and coverage
+- **Config files** — check for unintended changes
+- **Documentation** — check accuracy
+
+### Phase 3: Convention Compliance
+
+Compare each changed file against documented conventions:
+
+**Naming conventions:**
+- Variable/function names follow documented patterns (camelCase, snake_case, etc.)
+- File naming matches project conventions
+- Export naming is consistent
+
+**Import patterns:**
+- Import ordering matches documented rules
+- No circular dependencies introduced
+- Proper use of type imports where applicable
+
+**Code style:**
+- Error handling follows documented patterns
+- Logging follows documented conventions
+- Comments are meaningful (not redundant)
+
+For each violation, note:
+- File and line number
+- The convention being violated
+- The documented standard (from knowledge base)
+- Severity: **blocking** (must fix) or **suggestion** (nice to have)
+
+### Phase 4: Architecture and Pattern Check
+
+Verify changes respect documented architecture:
+
+**Layer boundaries:**
+- Do changes maintain proper layer separation?
+- Are dependencies flowing in the documented direction?
+- No business logic in presentation layer (or vice versa)
+
+**Pattern compliance:**
+- Do new components/modules follow existing patterns?
+- Are established abstractions reused rather than reinvented?
+- Does data flow match documented architecture?
+
+**API contracts:**
+- Do interface changes maintain backward compatibility?
+- Are new APIs consistent with existing ones?
+
+### Phase 5: Test and Security Check
+
+**Test coverage:**
+- Do changed source files have corresponding test files?
+- Are new functions/components tested?
+- Do test patterns match documented testing approach?
+
+**Security concerns:**
+- No hardcoded secrets, API keys, or credentials
+- Input validation for user-facing endpoints
+- No SQL injection, XSS, or command injection vectors
+- Proper authentication/authorization checks
+- No sensitive data logged or exposed
+
+### Phase 6: Curate New Patterns
+
+If the review reveals patterns not yet documented:
+
+```bash
+# New convention discovered
+brv curate "Convention: [new pattern observed across multiple files]" -f [example files]
+
+# New architectural decision
+brv curate "Architecture decision: [what was decided and why]" -f [relevant files]
+
+# New concern identified
+brv curate "Concern: [potential issue found during review]" -f [affected files]
+```
+
+### Completion
+
+Present a structured review:
+
+**Summary:** X blocking issues, Y suggestions, Z new patterns found
+
+**Blocking Issues (must fix):**
+- [File:line] Issue description | Convention: [source]
+
+**Suggestions (nice to have):**
+- [File:line] Suggestion | Rationale
+
+**New Patterns Curated:**
+- [Pattern description] → stored via `brv curate`
+
+**Missing Coverage:**
+- Areas where knowledge base had no guidance (recommend `byterover-explore`)
+
+## Important Rules
+
+1. **Never read secrets** — Skip `.env`, credential files, and similar
+2. **Knowledge-first** — Base reviews on documented standards, not personal preference
+3. **Distinguish severity** — Clearly separate blocking issues from suggestions
+4. **Be specific** — Reference file paths, line numbers, and the exact convention violated
+5. **Curate discoveries** — Store genuinely new patterns, not noise
+6. **Max 5 files per curate** — Break down large curate operations
+7. **No false positives** — Only flag issues where a documented standard exists or a clear security concern is present
+8. **Verify curations** — After storing critical context, run `brv curate view <logId>` to confirm what was stored (logId is printed by `brv curate` on completion). Run `brv curate view --help` to see all options.

--- a/.claude/skills/byterover/SKILL.md
+++ b/.claude/skills/byterover/SKILL.md
@@ -1,0 +1,594 @@
+---
+name: byterover
+description: "You MUST use this for gathering contexts before any work. This is a Knowledge management for AI agents. Use `brv` to store and retrieve project patterns, decisions, and architectural rules in .brv/context-tree. Uses a configured LLM provider (default: ByteRover, no API key needed) for query and curate operations."
+---
+
+# ByteRover Knowledge Management
+
+Use the `brv` CLI to manage your project's long-term memory.
+Install: `npm install -g byterover-cli`
+Knowledge is stored in `.brv/context-tree/` as human-readable Markdown files.
+
+**No authentication needed.** `brv query`, `brv curate`, and `brv vc` (local version control) work out of the box. Login is only required for remote sync (`brv vc push`/`brv vc pull`).
+
+## Workflow
+1.  **Before Thinking:** Run `brv query` to understand existing patterns.
+2.  **After Implementing:** Run `brv curate` to save new patterns/decisions.
+
+## Commands
+
+### 1. Query Knowledge
+**Overview:** Retrieve relevant context from your project's knowledge base. Uses a configured LLM provider to synthesize answers from `.brv/context-tree/` content.
+
+**Use this skill when:**
+- The user wants you to recall something
+- Your context does not contain information you need
+- You need to recall your capabilities or past actions
+- Before performing any action, to check for relevant rules, criteria, or preferences
+
+**Do NOT use this skill when:**
+- The information is already present in your current context
+- The query is about general knowledge, not stored memory
+
+```bash
+brv query "How is authentication implemented?"
+```
+
+### 2. Search Context Tree
+**Overview:** Retrieve a ranked list of matching files from `.brv/context-tree/` via pure BM25 lookup. Unlike `brv query`, this does NOT call an LLM — no synthesis, no token cost, no provider setup needed. Returns structured results with paths, scores, and excerpts.
+
+**Use this skill when:**
+- You need file paths to read rather than a synthesized answer
+- You want fast, cheap retrieval with no LLM overhead
+- You're in an automated pipeline that consumes structured results
+
+**Do NOT use this skill when:**
+- You need a natural-language answer synthesized from multiple files — use `brv query` instead
+- The information is already present in your current context
+
+```bash
+brv search "authentication patterns"
+brv search "JWT tokens" --limit 5 --scope "auth/"
+brv search "auth" --format json
+```
+
+**Flags:** `--limit N` (1-50, default 10), `--scope "domain/"` (path prefix filter), `--format json` (structured output for automation).
+
+### 3. Curate Context
+**Overview:** Analyze and save knowledge to the local knowledge base. Uses a configured LLM provider to categorize and structure the context you provide.
+
+**Use this skill when:**
+- The user wants you to remember something
+- The user intentionally curates memory or knowledge
+- There are meaningful memories from user interactions that should be persisted
+- There are important facts about what you do, what you know, or what decisions and actions you have taken
+
+**Do NOT use this skill when:**
+- The information is already stored and unchanged
+- The information is transient or only relevant to the current task, or just general knowledge
+
+```bash
+brv curate "Auth uses JWT with 24h expiry. Tokens stored in httpOnly cookies via authMiddleware.ts"
+```
+
+**Include source files** (max 5, project-scoped only):
+
+```bash
+brv curate "Authentication middleware details" -f src/middleware/auth.ts
+```
+
+**Execution mode: wait by default**
+
+Default is **blocking** — call `brv curate "..."` with no flag and wait for it to finish before continuing. Any follow-up step (query, search, read, review, next curate that builds on this one) may depend on the just-curated data being live in the context tree.
+
+```bash
+brv curate "..."                 # DEFAULT — wait until done, then continue
+brv curate "..." --detach        # Only when BOTH conditions below hold
+```
+
+**Use `--detach` only when BOTH of the following are true:**
+
+1. No remaining step in this turn will query, search, read, or reference this curated data, AND no later curate in this turn builds on it.
+2. The user explicitly said not to wait — phrases addressed *to you* like "don't wait", "don't block on this", "fire and forget", "move on without waiting". The phrase must be something the user says to the agent, not something the agent would narrate about itself. This rules out "run in background" and "run async" as triggers — agents use those phrases to self-narrate at least as often as users use them to instruct, which creates a mirror-priming loop.
+
+**If the user's phrasing is ambiguous, wait.** Detach requires an unambiguous signal. "Quick one, keep moving" is not enough.
+
+If either condition is uncertain, do not `--detach`. Wait.
+
+**Size/duration is NOT a reason to `--detach`.** A slow curate whose output the next step reads must still block. **"Looks like the last step" is also NOT a reason** — that is a guess, not evidence.
+
+**Reporting:**
+- Blocking (default) → "Saved X"
+- `--detach` → "Queued X (log: `<logId>`)" — do NOT claim "saved" until verified
+
+**Cross-turn hygiene for detached curates (CRITICAL):** before any later tool call reads data a previous `--detach` submitted, run:
+
+```bash
+brv curate view <logId> --format json
+```
+
+Only proceed when `status: completed`. If `processing`, wait or tell the user. If `error`/`cancelled`, report and consider re-curate. `--detach` errors are silent — verification before trust is mandatory.
+
+### 4. Review Pending Changes
+**Overview:** After a curate operation, some changes may require human review before being applied. Use `brv review` to list, approve, or reject pending operations.
+
+**Use this when:**
+- A curate operation reports pending reviews (shown in curate output)
+- The user wants to check, approve, or reject pending changes
+
+**Do NOT use this skill when:**
+- There are no pending reviews (check with `brv review pending` first)
+
+**Commands:**
+
+List all pending reviews for the current project:
+```bash
+brv review pending
+```
+
+Sample output:
+```
+2 operations pending review
+
+  Task: ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
+  [UPSERT · HIGH IMPACT] - path: architecture/context/context_compression_pipeline.md
+  Why:    Documenting switch to token-budget sliding window
+  After:  Context compression pipeline switching from reactive-overflow to token-budget sliding window in src/agent/infra/llm/context/compression/
+
+  [UPSERT · HIGH IMPACT] - path: architecture/tools/agent_tool_registry.md
+  Why:    Documenting tool registry rewrite with capability-based permissions
+  After:  Agent tool registry rewrite in src/agent/infra/tools/tool-registry.ts using capability-based permissions
+
+  To approve all:  brv review approve ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
+  To reject all:   brv review reject ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3
+  Per file:        brv review <approve|reject> ddcb3dc6-d957-4a56-b9c3-d0bdc04317f3 --file <path> [--file <path>]
+```
+
+Each pending task shows: operation type (ADD/UPDATE/DELETE/MERGE/UPSERT), file path, reason, and before/after summaries. High-impact operations are flagged.
+
+Approve all operations for a task (applies the changes):
+```bash
+brv review approve <taskId>
+```
+
+Reject all operations for a task (discards pending changes; restores backup for UPDATE/DELETE operations):
+```bash
+brv review reject <taskId>
+```
+
+Approve or reject specific files within a task:
+```bash
+brv review approve <taskId> --file <path> --file <path>
+brv review reject <taskId> --file <path>
+```
+File paths are relative to context tree (as shown in `brv review pending` output).
+
+**Note**: Always ask the user before approving or rejecting critical changes.
+
+**JSON output** (useful for agent-driven workflows):
+```bash
+brv review pending --format json
+brv review approve <taskId> --format json
+brv review reject <taskId> --format json
+```
+
+### 5. LLM Provider Setup
+`brv query` and `brv curate` require a configured LLM provider. Connect the default ByteRover provider (no API key needed):
+
+```bash
+brv providers connect byterover
+```
+
+To use a different provider (e.g., OpenAI, Anthropic, Google), list available options and connect with your own API key:
+
+```bash
+brv providers list
+brv providers connect openai --api-key sk-xxx --model gpt-4.1
+```
+
+### 6. Project Locations
+**Overview:** List registered projects and their context tree paths. Returns project metadata including initialization status and active state. Use `-f json` for machine-readable output.
+
+**Use this when:**
+- You need to find a project's context tree path
+- You need to check which projects are registered
+- You need to verify if a project is initialized
+
+**Do NOT use this when:**
+- You already know the project path from your current context
+- You need project content rather than metadata — use `brv query` instead
+
+```bash
+brv locations -f json
+```
+
+JSON fields: `projectPath`, `contextTreePath`, `isCurrent`, `isActive`, `isInitialized`.
+
+### 7. Version Control
+**Overview:** `brv vc` provides git-based version control for your context tree. It uses standard git semantics — branching, committing, merging, history, and conflict resolution — all working locally with no authentication required. Remote sync with a team is optional. The legacy `brv push`, `brv pull`, and `brv space` commands are deprecated — use `brv vc push`, `brv vc pull`, and `brv vc clone`/`brv vc remote add` instead.
+
+**Use this when:**
+- The user wants to track, commit, or inspect changes to the knowledge base
+- The user wants to branch, merge, or undo knowledge changes
+- The user wants to sync knowledge with a team (push/pull)
+- The user wants to connect to or clone a team space
+- The user asks about knowledge history or diffs
+
+**Do NOT use this when:**
+- The user wants to query or curate knowledge — use `brv query`/`brv curate` instead
+- The user wants to review pending curate operations — use `brv review` instead
+- Version control is not initialized and the user didn't ask to set it up
+
+**Commands:**
+
+Available commands: `init`, `status`, `add`, `commit`, `reset`, `log`, `branch`, `checkout`, `merge`, `config`, `clone`, `remote`, `fetch`, `push`, `pull`.
+
+#### First-Time Setup
+
+**Setup — local (no auth needed):**
+```bash
+brv vc init
+brv vc config user.name "Your Name"
+brv vc config user.email "you@example.com"
+```
+
+**Setup — clone a team space (requires `brv login`):**
+```bash
+brv login --api-key sample-key-string
+brv vc clone https://byterover.dev/<team>/<space>.git
+```
+
+**Setup — connect existing project to a remote (requires `brv login`):**
+```bash
+brv login --api-key sample-key-string
+brv vc remote add origin https://byterover.dev/<team>/<space>.git
+```
+
+#### Local Workflow
+
+**Check status:**
+```bash
+brv vc status
+```
+
+**Stage and commit:**
+```bash
+brv vc add .                     # stage all
+brv vc add notes.md docs/        # stage specific files
+brv vc commit -m "add authentication patterns"
+```
+
+**View history:**
+```bash
+brv vc log
+brv vc log --limit 20
+brv vc log --all
+```
+
+**Unstage or undo:**
+```bash
+brv vc reset                     # unstage all files
+brv vc reset <file>              # unstage a specific file
+brv vc reset --soft HEAD~1       # undo last commit, keep changes staged
+brv vc reset --hard HEAD~1       # discard last commit and changes
+```
+
+#### Branch Management
+
+```bash
+brv vc branch                    # list branches
+brv vc branch feature/auth       # create a branch
+brv vc branch -a                 # list all (including remote-tracking)
+brv vc branch -d feature/auth    # delete a branch
+brv vc checkout feature/auth     # switch branch
+brv vc checkout -b feature/new   # create and switch
+```
+
+**Merge:**
+```bash
+brv vc merge feature/auth        # merge into current branch
+brv vc merge --continue          # continue after resolving conflicts
+brv vc merge --abort             # abort a conflicted merge
+```
+
+**Set upstream tracking:**
+```bash
+brv vc branch --set-upstream-to origin/main
+```
+
+#### Cloud Sync (Remote Operations)
+
+Requires ByteRover authentication (`brv login`) and a configured remote.
+
+**Manage remotes:**
+```bash
+brv vc remote                    # show current remote
+brv vc remote add origin <url>   # add a remote
+brv vc remote set-url origin <url>  # update remote URL
+```
+
+**Fetch, pull, and push:**
+```bash
+brv vc fetch                     # fetch remote refs
+brv vc pull                      # fetch + merge remote commits
+brv vc push                      # push commits to cloud
+brv vc push -u origin main       # push and set upstream tracking
+```
+
+**Clone a space:**
+```bash
+brv vc clone https://byterover.dev/<team>/<space>.git
+```
+
+### 8. Swarm Query
+**Overview:** Search across all active memory providers simultaneously — ByteRover context tree, Obsidian vault, Local Markdown folders, GBrain, and Memory Wiki. Results are fused via Reciprocal Rank Fusion (RRF) and ranked by provider weight and relevance. No LLM call — pure algorithmic search.
+
+**Use this skill when:**
+- You need to search across multiple knowledge sources at once
+- The user has configured multiple memory providers (check with `brv swarm status`)
+- You want results from Obsidian notes, GBrain entities, or wiki pages alongside ByteRover context
+
+**Do NOT use this skill when:**
+- The user only has ByteRover configured — use `brv query` instead (it synthesizes via LLM)
+- You need an LLM-synthesized answer — `brv swarm query` returns raw search results, not synthesized text
+
+```bash
+brv swarm query "How does JWT refresh work?"
+```
+
+Output:
+```
+Swarm Query: "How does JWT refresh work?"
+Type: factual | Providers: 4 queried | Latency: 398ms
+──────────────────────────────────────────────────
+1. [memory-wiki] sources/jwt-token-lifecycle.md    score: 0.0150  [keyword]
+   # JWT Token Lifecycle ...
+2. [obsidian] SwarmTestData/Authentication System.md    score: 0.0142  [keyword]
+   # Authentication System ...
+3. [gbrain] alex-chen    score: 0.0117  [semantic]
+   # Alex Chen — Senior Backend Engineer ...
+```
+
+**With explain mode** (shows classification, provider selection, enrichment):
+```bash
+brv swarm query "authentication patterns" --explain
+```
+
+Output:
+```
+Classification: factual
+Provider selection: 4 of 4 available
+  ✓ byterover    (healthy, selected, 0 results, 14ms)
+  ✓ obsidian    (healthy, selected, 5 results, 91ms)
+  ✓ memory-wiki    (healthy, selected, 2 results, 15ms)
+  ✓ gbrain    (healthy, selected, 1 results, 260ms)
+Enrichment:
+  byterover → obsidian
+  byterover → memory-wiki
+Results: 8 raw → 7 after RRF fusion + precision filtering
+```
+
+**JSON output:**
+```bash
+brv swarm query "rate limiting" --format json
+```
+
+Output:
+```json
+{
+  "meta": {
+    "queryType": "factual",
+    "totalLatencyMs": 340,
+    "providers": {
+      "byterover": { "selected": true, "resultCount": 0 },
+      "obsidian": { "selected": true, "resultCount": 5 },
+      "gbrain": { "selected": true, "resultCount": 1 },
+      "memory-wiki": { "selected": true, "resultCount": 1 }
+    }
+  },
+  "results": [
+    { "provider": "memory-wiki", "providerType": "memory-wiki", "score": 0.015, "content": "# Rate Limiting ..." }
+  ]
+}
+```
+
+**Limit results:**
+```bash
+brv swarm query "testing strategy" -n 5
+```
+
+**Flags:** `--explain` (show routing details), `--format json` (structured output), `-n <value>` (max results).
+
+### 9. Swarm Curate
+**Overview:** Store knowledge in the best available external memory provider. ByteRover automatically classifies the content type and routes accordingly: entities (people, orgs) go to GBrain, notes (meeting notes, TODOs) go to Local Markdown, general content goes to the first writable provider. Falls back to ByteRover context tree if no external providers are available.
+
+**Use this skill when:**
+- You want to store knowledge in an external provider (GBrain, Local Markdown, Memory Wiki)
+- The user has configured writable swarm providers
+
+**Do NOT use this skill when:**
+- You want to store in ByteRover's context tree specifically — use `brv curate` instead
+- No swarm providers are configured — use `brv curate` instead
+
+```bash
+brv swarm curate "Jane Smith is the CTO of TechCorp"
+```
+
+Output:
+```
+Stored to gbrain as concept/jane-smith-cto
+```
+
+**Target a specific provider:**
+```bash
+brv swarm curate "meeting notes: decided on JWT" --provider local-markdown:notes
+```
+
+Output:
+```
+Stored to local-markdown:notes as note-1776052527043.md
+```
+
+```bash
+brv swarm curate "Architecture uses event sourcing" --provider gbrain
+```
+
+Output:
+```
+Stored to gbrain as concept/event-sourcing-architecture
+```
+
+**JSON output:**
+```bash
+brv swarm curate "Test content" --format json
+```
+
+Output:
+```json
+{
+  "id": "note-1776052594462.md",
+  "provider": "local-markdown:project-docs",
+  "success": true,
+  "latencyMs": 1
+}
+```
+
+**Flags:** `--provider <id>` (target specific provider), `--format json` (structured output).
+
+### 10. Swarm Status
+**Overview:** Check provider health and write targets before running swarm query or curate. Use this to verify which providers are available and operational.
+
+**Use this skill when:**
+- Before running `brv swarm query` or `brv swarm curate` to check available providers
+- Diagnosing why swarm results are missing from a specific provider
+
+```bash
+brv swarm status
+```
+
+Output:
+```
+Memory Swarm Health Check
+════════════════════════════════════════
+  ✓ ByteRover       context-tree (always on)
+  ✓ Obsidian        /Users/you/Documents/MyObsidian
+  ✓ Local .md       1 folder(s)
+  ✓ GBrain          /Users/you/workspaces/gbrain
+  ✓ Memory Wiki     /Users/you/.openclaw/wiki/main
+
+Write Targets:
+  gbrain (entity, general)
+  local-markdown:project-docs (note, general)
+
+Swarm is operational (5/5 providers configured).
+```
+
+### 11. Query and Curate History
+**Overview:** Inspect past query and curate operations. Use `brv query-log view` to review query history, `brv curate view` to review curate history, and `brv query-log summary` to see aggregated recall metrics. Supports filtering by time, status, tier, and detailed per-operation output.
+
+**Use this skill when:**
+- You want to review what was queried or curated previously
+- You need to inspect a specific operation by logId
+- You want to filter history by time window or completion status
+- You want to collect data for analysis or debugging
+- You want to know what knowledge was added, updated, or deleted over time
+- You want aggregated metrics on query recall, cache hit rate, or knowledge gaps
+
+**Do NOT use this skill when:**
+- You want to run a new query — use `brv query` instead
+- You want to curate new knowledge — use `brv curate` instead
+
+**View curate history:** to check past curations
+- Show recent entries (last 10)
+```bash
+brv curate view
+```
+- Full detail for a specific entry: all files and operations performed (logId is printed by `brv curate` on completion, e.g. `cur-1739700001000`)
+```bash
+brv curate view cur-1739700001000
+```
+- List entries with file operations visible (no logId needed)
+```bash
+brv curate view --detail
+```
+- Filter by time and status
+```bash
+brv curate view --since 1h --status completed --limit 1000
+```
+- For all filter options
+```bash
+brv curate view --help
+```
+
+**View query history:** to check past queries
+- Show recent entries (last 10)
+```bash
+brv query-log view
+```
+- Full detail for a specific entry: matched docs and search metadata (logId is printed by `brv query` on completion, e.g. `qry-1739700001000`)
+```bash
+brv query-log view qry-1739700001000
+```
+- List entries with matched docs visible (no logId needed)
+```bash
+brv query-log view --detail
+```
+- Filter by time, status, or resolution tier (0=exact cache, 1=fuzzy cache, 2=direct search, 3=optimized LLM, 4=full agentic)
+```bash
+brv query-log view --since 1h --status completed --limit 1000
+brv query-log view --tier 0 --tier 1
+```
+- For all filter options
+```bash
+brv query-log view --help
+```
+
+**View query recall metrics:** to see aggregated stats across recent queries
+- Summary for the last 24 hours (default)
+```bash
+brv query-log summary
+```
+- Summary for a specific time window
+```bash
+brv query-log summary --last 7d
+brv query-log summary --since 2026-04-01 --before 2026-04-03
+```
+- Narrative format (human-readable prose report)
+```bash
+brv query-log summary --format narrative
+```
+- For all options
+```bash
+brv query-log summary --help
+```
+
+## Data Handling
+
+**Storage**: All knowledge is stored as Markdown files in `.brv/context-tree/` within the project directory. Files are human-readable and version-controllable.
+
+**File access**: The `-f` flag on `brv curate` reads files from the current project directory only. Paths outside the project root are rejected. Maximum 5 files per command, text and document formats only.
+
+**LLM usage**: `brv query` and `brv curate` send context to a configured LLM provider for processing. The LLM sees the query or curate text and any included file contents. No data is sent to ByteRover servers unless you explicitly run `brv vc push`.
+
+**Cloud sync**: `brv vc push` and `brv vc pull` require authentication (`brv login`) and sync knowledge with ByteRover's cloud service via git. All other commands operate without ByteRover authentication.
+
+## Error Handling
+**User Action Required:**
+You MUST show this troubleshooting guide to users when errors occur.
+
+"Not authenticated" | Run `brv login --help` for more details.
+"No provider connected" | Run `brv providers connect byterover` (free, no key needed).
+"Connection failed" / "Instance crashed" | User should kill brv process.
+"Token has expired" / "Token is invalid" | Run `brv login` again to re-authenticate.
+"Billing error" / "Rate limit exceeded" | User should check account credits or wait before retrying.
+
+**Agent-Fixable Errors:**
+You MUST handle these errors gracefully and retry the command after fixing.
+
+"Missing required argument(s)." | Run `brv <command> --help` to see usage instructions.
+"Maximum 5 files allowed" | Reduce to 5 or fewer `-f` flags per curate.
+"File does not exist" | Verify path with `ls`, use relative paths from project root.
+"File type not supported" | Only text, image, PDF, and office files are supported.
+
+### Quick Diagnosis
+Run `brv status` to check authentication, project, and provider state.

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ ito-rs/.bacon/
 .ito/modules
 .ito/workflows
 .ito/audit
+
+# ByteRover local context tree (developer-local cache; cloud sync is out of scope)
+.brv/


### PR DESCRIPTION
## Summary

Adds ByteRover as the first concrete agent-memory provider for this repo,
and curates Ito's canonical knowledge into the local ByteRover context tree
so \`brv query\` / \`brv search\` return useful results out of the box.

- Installs the Claude Code agent-skill connector (\`.claude/skills/byterover/\`)
- Installs the four ByteRover hub skills for Claude Code and mirrors them
  into \`.agents/skills/byterover/\` so every non-Claude harness that reads
  \`.agents/skills/\` can discover them:
  - \`byterover-review\`
  - \`byterover-plan\`
  - \`byterover-explore\`
  - \`byterover-audit\`
- Authors \`.agents/skills/byterover/README.md\` documenting the install
  steps, the bootstrap curation commands, and the explicit exclusion of
  cloud sync.
- Bootstrap curation via \`brv curate\` over \`.ito/specs/\`, \`docs/\`,
  \`.ito/changes/archive/\`, \`.ito/modules/\`, plus \`AGENTS.md\`,
  \`.ito/AGENTS.md\`, \`.ito/architecture.md\`.
- Gitignores \`.brv/\` (developer-local context-tree cache).

## Local-only

No workflow, skill, or instruction template added by this change
requires \`brv login\`, \`brv push\`, \`brv pull\`, or \`brv vc …\`. The only
mentions of those commands are explicit "intentionally out of scope"
notes.

## Module 029 — agent-memory

This is the first of two changes under a new module \`029_agent-memory\`:

- **029-01_add-byterover-integration** (this PR) — wire ByteRover in.
- **029-02_agent-memory-abstraction** — follow-on, proposal-only: make
  agent memory a first-class, provider-agnostic concept in Ito (config
  store/search commands or skill reference; apply/finish instruction
  reminders to capture memories; finish wrap-up to refresh archive and
  specs). No default provider.

Both proposal packages pass \`ito validate --strict\`.

## Review notes

- Proposal package lives in the coordination-branch store at
  \`.ito/changes/029-01_add-byterover-integration/\` (and \`029-02…/\` for the
  follow-on). Not part of this PR's git diff.
- Codex review ran against both proposals before implementation and
  applied high-confidence edits (placeholder-semantics, folder-vs-file
  curate mode, finish wrap-up de-duping the archive prompt, etc.). Both
  Codex verdicts: approve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive skill documentation for ByteRover, including workflows for exploring codebases, auditing knowledge freshness, planning implementations, and conducting code reviews.
  * New skill guides available across both agent harnesses and Claude Code environments.

* **Chores**
  * Updated configuration to exclude ByteRover artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->