### PR TITLE
Sync coordination state at workflow boundaries

### DIFF
--- a/ito-rs/crates/ito-cli/src/app/archive.rs
+++ b/ito-rs/crates/ito-cli/src/app/archive.rs
@@ -1,5 +1,6 @@
 use crate::cli::ArchiveArgs;
 use crate::cli_error::{CliError, CliResult, fail, to_cli_error};
+use crate::commands::sync::best_effort_sync_coordination;
 use crate::runtime::Runtime;
 use ito_config::load_cascading_project_config;
 use ito_config::types::{ArchiveMainIntegrationMode, CoordinationStorage, ItoConfig};
@@ -103,6 +104,8 @@ pub(crate) fn handle_archive(rt: &Runtime, args: &[String]) -> CliResult<()> {
     }
 
     let ito_path = rt.ito_path();
+    best_effort_sync_coordination(rt, "before archive");
+
     let changes_dir = core_paths::changes_dir(ito_path);
     let repository_runtime = rt.repository_runtime().map_err(to_cli_error)?;
 

--- a/ito-rs/crates/ito-cli/src/app/instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/instructions.rs
@@ -302,6 +302,8 @@ then re-run:\n\n\
     }
 
     if artifact == "finish" {
+        best_effort_sync_coordination(rt, "before finish instructions");
+
         let ctx = rt.ctx();
         let ito_path = rt.ito_path();
         let project_root = ito_path.parent().unwrap_or(ito_path);
@@ -333,6 +335,8 @@ then re-run:\n\n\
     }
 
     if artifact == "archive" {
+        best_effort_sync_coordination(rt, "before archive instructions");
+
         let runtime = rt.repository_runtime().map_err(to_cli_error)?;
         let ctx = rt.ctx();
         let ito_path = rt.ito_path();
@@ -409,6 +413,9 @@ then re-run:\n\n\
     }
     let ctx = rt.ctx();
     let ito_path = rt.ito_path();
+    if sync_before_change_resolution(artifact) {
+        best_effort_sync_coordination(rt, &format!("before {artifact} instructions"));
+    }
     let runtime = rt.repository_runtime().map_err(to_cli_error)?;
     let change_repo = runtime.repositories().changes.as_ref();
     let change = change.expect("checked above");
@@ -437,8 +444,6 @@ then re-run:\n\n\
     if artifact == "apply" {
         // Match TS/ora: spinner output is written to stderr.
         eprintln!("- Generating apply instructions...");
-
-        best_effort_sync_coordination(rt, "before apply instructions");
 
         let apply = match core_templates::compute_apply_instructions(
             ito_path,
@@ -590,6 +595,10 @@ fn load_coordination_branch_settings(
     resolve_coordination_branch_settings(&merged)
 }
 
+fn sync_before_change_resolution(artifact: &str) -> bool {
+    artifact == "apply" || artifact == "proposal"
+}
+
 fn json_get<'a>(root: &'a serde_json::Value, keys: &[&str]) -> Option<&'a serde_json::Value> {
     let mut cur = root;
     for k in keys {
@@ -723,6 +732,8 @@ fn archive_instruction_config_from_merged(
 }
 
 fn handle_new_proposal_guide(rt: &Runtime, want_json: bool) -> CliResult<()> {
+    best_effort_sync_coordination(rt, "before proposal instructions");
+
     #[derive(serde::Serialize)]
     struct ModuleEntry {
         id: String,

--- a/ito-rs/crates/ito-cli/src/app/instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/instructions.rs
@@ -596,7 +596,7 @@ fn load_coordination_branch_settings(
 }
 
 fn sync_before_change_resolution(artifact: &str) -> bool {
-    artifact == "apply" || artifact == "proposal"
+    artifact == "apply" || artifact == "proposal" || artifact == "review"
 }
 
 fn json_get<'a>(root: &'a serde_json::Value, keys: &[&str]) -> Option<&'a serde_json::Value> {

--- a/ito-rs/crates/ito-cli/src/commands/create.rs
+++ b/ito-rs/crates/ito-cli/src/commands/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::{CreateAction, CreateArgs, NewAction, NewArgs};
 use crate::cli_error::{CliResult, fail, to_cli_error};
-use crate::commands::sync::{best_effort_sync_coordination, best_effort_sync_coordination_bg};
+use crate::commands::sync::best_effort_sync_coordination;
 use crate::runtime::Runtime;
 use crate::util::{parse_string_flag, split_csv};
 use ito_config::{load_cascading_project_config, resolve_coordination_branch_settings};
@@ -252,7 +252,7 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                 ito_path,
                 &format!("chore: create module {}", r.folder_name),
             );
-            best_effort_sync_coordination_bg(rt, "after module create");
+            best_effort_sync_coordination(rt, "after module create");
             Ok(())
         }
         "change" => {
@@ -437,7 +437,7 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                         ito_path,
                         &format!("chore: create sub-module {}", r.sub_module_id),
                     );
-                    best_effort_sync_coordination_bg(rt, "after sub-module create");
+                    best_effort_sync_coordination(rt, "after sub-module create");
                     Ok(())
                 }
                 Err(e) => Err(to_cli_error(e)),

--- a/ito-rs/crates/ito-cli/src/commands/create.rs
+++ b/ito-rs/crates/ito-cli/src/commands/create.rs
@@ -1,6 +1,6 @@
 use crate::cli::{CreateAction, CreateArgs, NewAction, NewArgs};
 use crate::cli_error::{CliResult, fail, to_cli_error};
-use crate::commands::sync::best_effort_sync_coordination;
+use crate::commands::sync::{best_effort_sync_coordination, best_effort_sync_coordination_bg};
 use crate::runtime::Runtime;
 use crate::util::{parse_string_flag, split_csv};
 use ito_config::{load_cascading_project_config, resolve_coordination_branch_settings};
@@ -30,13 +30,9 @@ fn guard_local_only(rt: &Runtime, operation: &str) -> CliResult<()> {
     Ok(())
 }
 
-fn auto_commit_after_change_creation(ito_path: &Path, change_id: &str) {
+fn auto_commit_after_coordination_mutation(ito_path: &Path, message: &str) {
     let project_root = ito_path.parent().unwrap_or(ito_path);
-    if let Err(err) = maybe_auto_commit_coordination(
-        project_root,
-        ito_path,
-        &format!("chore: create change {change_id}"),
-    ) {
+    if let Err(err) = maybe_auto_commit_coordination(project_root, ito_path, message) {
         eprintln!("Warning: auto-commit to coordination worktree failed: {err}");
     }
 }
@@ -221,6 +217,8 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                 .unwrap_or_default();
             let description = parse_string_flag(args, "--description");
 
+            best_effort_sync_coordination(rt, "before module create");
+
             let r = core_create::create_module(
                 ito_path,
                 name,
@@ -250,6 +248,11 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
             println!("Created module: {}", r.folder_name);
             println!("  Path: {}", r.module_dir.display());
             println!("  Edit: {}", r.module_dir.join("module.md").display());
+            auto_commit_after_coordination_mutation(
+                ito_path,
+                &format!("chore: create module {}", r.folder_name),
+            );
+            best_effort_sync_coordination_bg(rt, "after module create");
             Ok(())
         }
         "change" => {
@@ -383,7 +386,10 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                     }
 
                     // Best-effort auto-commit to coordination worktree.
-                    auto_commit_after_change_creation(ito_path, &r.change_id);
+                    auto_commit_after_coordination_mutation(
+                        ito_path,
+                        &format!("chore: create change {}", r.change_id),
+                    );
                     best_effort_sync_coordination(rt, "after create");
 
                     Ok(())
@@ -411,6 +417,8 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                 name, parent_module
             );
 
+            best_effort_sync_coordination(rt, "before sub-module create");
+
             match create_sub_module(ito_path, name, parent_module, description.as_deref()) {
                 Ok(r) => {
                     eprintln!(
@@ -425,6 +433,11 @@ pub(crate) fn handle_create(rt: &Runtime, args: &[String]) -> CliResult<()> {
                         r.sub_module_id
                     );
                     eprintln!("    2) ito show sub-module {}", r.sub_module_id);
+                    auto_commit_after_coordination_mutation(
+                        ito_path,
+                        &format!("chore: create sub-module {}", r.sub_module_id),
+                    );
+                    best_effort_sync_coordination_bg(rt, "after sub-module create");
                     Ok(())
                 }
                 Err(e) => Err(to_cli_error(e)),
@@ -545,7 +558,10 @@ pub(crate) fn handle_new(rt: &Runtime, args: &[String]) -> CliResult<()> {
             }
 
             // Best-effort auto-commit to coordination worktree.
-            auto_commit_after_change_creation(ito_path, &r.change_id);
+            auto_commit_after_coordination_mutation(
+                ito_path,
+                &format!("chore: create change {}", r.change_id),
+            );
             best_effort_sync_coordination(rt, "after create");
 
             Ok(())

--- a/ito-rs/crates/ito-cli/tests/instructions_more.rs
+++ b/ito-rs/crates/ito-cli/tests/instructions_more.rs
@@ -21,6 +21,7 @@ fn agent_instruction_proposal_without_change_prints_new_proposal_guide() {
 
     assert_eq!(out.code, 0);
     assert!(out.stdout.contains("Create a New Proposal"));
+    assert!(out.stdout.contains("ito sync"));
     assert!(out.stdout.contains("ito create change"));
     assert!(out.stdout.contains("Known modules at instruction time"));
     let lower = out.stdout.to_lowercase();
@@ -270,6 +271,7 @@ fn agent_instruction_archive_without_change_prints_generic_guidance() {
         "stdout={}",
         out.stdout
     );
+    assert!(out.stdout.contains("ito sync"), "stdout={}", out.stdout);
     assert!(
         out.stdout.contains("000-01_test-change"),
         "expected available change hint in generic mode; stdout={}",
@@ -310,6 +312,7 @@ fn agent_instruction_archive_with_change_prints_targeted_instruction() {
         "stdout={}",
         out.stdout
     );
+    assert!(out.stdout.contains("ito sync"), "stdout={}", out.stdout);
     assert!(
         out.stdout
             .contains("create an integration branch from `main`")
@@ -382,6 +385,7 @@ fn agent_instruction_finish_with_change_prompts_for_archive() {
         out.stdout
             .contains("ito agent instruction archive --change '000-01_test-change'")
     );
+    assert!(out.stdout.contains("ito sync"), "stdout={}", out.stdout);
 }
 
 #[test]
@@ -408,6 +412,7 @@ fn agent_instruction_apply_text_is_compact_and_has_trailing_newline() {
 
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
     assert!(out.stdout.contains("## Apply: 000-01_test-change"));
+    assert!(out.stdout.contains("ito sync"), "stdout={}", out.stdout);
     assert!(out.stdout.contains("### Testing Policy"));
     assert!(!out.stdout.contains("\n\n\n"), "stdout={}", out.stdout);
     assert!(out.stdout.ends_with('\n'), "stdout={}", out.stdout);

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -15,6 +15,14 @@ Use the ito-continue-change skill to create these first.
 {% endfor %}
 
 {% endif %}
+### Coordination Sync
+
+`ito agent instruction apply` refreshes coordination state before rendering. If you are using these instructions later, or after switching worktrees, refresh again before editing. `ito sync` is a no-op unless coordination-worktree storage is active, and it rate-limits pushes to avoid excessive remote updates.
+
+```bash
+ito sync
+```
+
 {% if worktree.enabled and worktree.apply_enabled %}
 ### Worktree Setup
 
@@ -31,6 +39,13 @@ CHANGE_DIR=$(ito worktree ensure --change "{{ instructions.changeName | replace(
 
 This creates the worktree (if absent), copies include files, and runs setup commands.
 All subsequent file operations should use `$CHANGE_DIR` as the working directory.
+
+After `ito worktree ensure`, run the sync from inside the change worktree if you did not just run it there:
+
+```bash
+cd "$CHANGE_DIR"
+ito sync
+```
 
 <details>
 <summary>Manual setup (alternative)</summary>
@@ -61,7 +76,7 @@ fi
 
 echo "Working directory: $CHANGE_DIR"
 ```
-Before starting implementation, synchronize coordination state:
+Synchronize coordination state from inside the change worktree before editing:
 
 ```bash
 cd "$CHANGE_DIR"

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/archive.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/archive.md.j2
@@ -6,10 +6,13 @@
 Run the following to archive this change:
 
 ```bash
-# 1. Ensure audit log is in sync before archiving
+# 1. Refresh coordination state if you did not just generate these instructions
+ito sync
+
+# 2. Ensure audit log is in sync before archiving
 ito audit reconcile --change {{ change }}
 
-# 2. Archive the change (merges spec deltas into main specs)
+# 3. Archive the change (merges spec deltas into main specs)
 ito archive {{ change }} --yes
 ```
 
@@ -60,6 +63,9 @@ Mode `{{ archive.main_integration_mode }}` is unrecognized. Set a valid mode wit
 ### Commands
 
 ```bash
+# Refresh coordination state first if you did not just generate these instructions
+ito sync
+
 # Archive a specific change
 ito archive <change-id> --yes
 

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/finish.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/finish.md.j2
@@ -16,6 +16,16 @@ Use this after a change branch has been integrated (PR merged or local merge) an
 - `worktrees.default_branch`: `{{ worktree.default_branch }}`
 - `changes.archive.main_integration_mode`: `{{ archive.main_integration_mode }}`
 
+{% if archive.coordination_storage == "worktree" %}
+### Coordination Sync
+
+`ito agent instruction finish` refreshes coordination state before rendering. If you are using these instructions later, refresh again before deciding whether to archive or clean up. `ito sync` rate-limits pushes, but still fetches coordination updates.
+
+```bash
+ito sync
+```
+
+{% endif %}
 ### Archive Prompt
 
 If this is a completed Ito change, ask the user:

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -13,6 +13,14 @@ Do NOT jump straight into creating files. First, make sure you understand what t
 
 If the user's request is already precise and well-scoped, a quick confirmation is enough — don't over-interview.
 
+## Step 0: Synchronize Coordination State
+
+`ito agent instruction proposal` refreshes coordination state before rendering this guide. If you are using this guide later, refresh again before listing modules or creating proposal state. `ito sync` is a no-op unless coordination-worktree storage is active, and it rate-limits pushes to avoid excessive remote updates.
+
+```bash
+ito sync
+```
+
 ## Step 1: Choose a Schema
 
 Before creating the change, pick the workflow schema.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -432,8 +432,15 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
     assert!(out.contains(
         "git -C \"$PROJECT_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
     ));
-    assert!(out.contains("Before starting implementation, synchronize coordination state:"));
+    assert!(out.contains("refreshes coordination state before rendering"));
     assert!(out.contains("ito sync"));
+    let sync_pos = out.find("ito sync").expect("sync instruction");
+    let details_pos = out.find("<details>").expect("manual details");
+    assert!(
+        sync_pos < details_pos,
+        "sync should be in the recommended setup path"
+    );
+    assert_eq!(out[..details_pos].matches("\nito sync\n").count(), 2);
 }
 
 #[test]
@@ -475,6 +482,8 @@ fn archive_template_renders_generic_guidance_without_change() {
     .unwrap();
 
     assert!(out.contains("ito archive"));
+    assert!(out.contains("ito sync"));
+    assert_eq!(out.matches("\nito sync\n").count(), 1);
     assert!(out.contains("ito audit reconcile"));
     assert!(out.contains("Default archive main integration mode: `pull_request`"));
     // generic mode must NOT look like a targeted command
@@ -511,6 +520,8 @@ fn archive_template_renders_targeted_instruction_with_change() {
 
     assert!(out.contains("009-02_event-sourced-audit-log"));
     assert!(out.contains("ito archive 009-02_event-sourced-audit-log --yes"));
+    assert!(out.contains("ito sync"));
+    assert_eq!(out.matches("\nito sync\n").count(), 1);
     assert!(out.contains("ito audit reconcile --change 009-02_event-sourced-audit-log"));
     assert!(out.contains("Configured mode: `pull_request_auto_merge`"));
     assert!(out.contains("request auto-merge"));
@@ -561,6 +572,7 @@ fn finish_template_prompts_for_archive() {
     #[derive(Serialize)]
     struct ArchiveCfg {
         main_integration_mode: &'static str,
+        coordination_storage: &'static str,
     }
 
     #[derive(Serialize)]
@@ -581,6 +593,7 @@ fn finish_template_prompts_for_archive() {
             },
             archive: ArchiveCfg {
                 main_integration_mode: "pull_request",
+                coordination_storage: "worktree",
             },
             change: Some("025-09_add-worktree-sync-command".to_string()),
         },
@@ -588,6 +601,8 @@ fn finish_template_prompts_for_archive() {
     .unwrap();
 
     assert!(out.contains("Do you want to archive this change now?"));
+    assert!(out.contains("ito sync"));
+    assert_eq!(out.matches("\nito sync\n").count(), 1);
     assert!(
         out.contains("ito agent instruction archive --change '025-09_add-worktree-sync-command'")
     );


### PR DESCRIPTION
## Summary
- Sync coordination state before proposal/apply/archive/finish instruction reads and before archive execution mutates state.
- Add sync guidance to agent instruction templates without requiring immediate duplicate syncs.
- Sync module and sub-module creation around coordination mutations, using background sync after writes.

## Verification
- `cargo test -p ito-cli --test instructions_more agent_instruction -- --nocapture`
- `cargo test -p ito-templates --lib`
- `cargo test -p ito-cli --test create_more -- --nocapture`
- `cargo test -p ito-cli --bins`
- `ito audit reconcile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordination synchronization (ito sync) added before key workflows: archive, finish, apply, and proposal generation; create flows now include coordination refresh and post-create auto-commit behavior.
* **Documentation**
  * Instruction templates updated to recommend running ito sync in apply, archive, finish, and new-proposal guides.
* **Tests**
  * Tests updated to assert synchronization guidance appears in rendered instruction output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->