### PR TITLE
feat(012-06): enforce change worktree guidance

### DIFF
--- a/docs/presentations/march-2026/ito-lifecycle-slide-deck.md
+++ b/docs/presentations/march-2026/ito-lifecycle-slide-deck.md
@@ -1,6 +1,6 @@
 # Ito: Change-Driven Development for AI Agents
 
-### A structured workflow for long-running, multi-session AI coding via agents
+## A structured workflow for long-running, multi-session AI coding via agents
 
 ---
 

--- a/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
@@ -42,31 +42,38 @@ Use `ito path ...` to get absolute paths at runtime (do not hardcode absolute pa
 **Default branch:** `{{ default_branch }}`
 **Integration mode:** `{{ integration_mode }}`
 
+Worktree rules:
+
+- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
+- Do not reuse one worktree for two changes.
+- If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+
 {% if strategy == "checkout_subdir" %}
 This project uses in-repo worktrees under a dedicated subdirectory:
 
 ```bash
-.{{ layout_dir_name }}/<change-name>/
+.{{ layout_dir_name }}/<full-change-id>/
 ```
 
 To create a worktree for a change:
 
 ```bash
 mkdir -p ".{{ layout_dir_name }}"
-git worktree add ".{{ layout_dir_name }}/<change-name>" -b <change-name>
+git worktree add ".{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 {% elif strategy == "checkout_siblings" %}
 This project uses sibling-directory worktrees:
 
 ```bash
-../<project-name>-{{ layout_dir_name }}/<change-name>/
+../<project-name>-{{ layout_dir_name }}/<full-change-id>/
 ```
 
 To create a worktree for a change:
 
 ```bash
 mkdir -p "../<project-name>-{{ layout_dir_name }}"
-git worktree add "../<project-name>-{{ layout_dir_name }}/<change-name>" -b <change-name>
+git worktree add "../<project-name>-{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 {% elif strategy == "bare_control_siblings" %}
 This project uses a bare/control repo layout with worktrees as siblings:
@@ -77,14 +84,14 @@ This project uses a bare/control repo layout with worktrees as siblings:
 |-- .git                                # gitdir pointer
 |-- {{ default_branch }}/               # {{ default_branch }} branch worktree
 `-- {{ layout_dir_name }}/              # change worktrees
-    `-- <change-name>/
+    `-- <full-change-id>/
 ```
 
 To create a worktree for a change:
 
 ```bash
 mkdir -p "../{{ layout_dir_name }}"
-git worktree add "../{{ layout_dir_name }}/<change-name>" -b <change-name> {{ default_branch }}
+git worktree add "../{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 
 Always branch new change worktrees from `{{ default_branch }}`. Do not create them from the bare/control repo placeholder `HEAD`.
@@ -94,12 +101,10 @@ This project uses a custom worktree strategy. Use the configured values above.
 
 Do NOT ask the user where to create worktrees. Use the configured locations above.
 
-After the change branch is merged, clean up:
+After the change branch is merged, ask Ito for cleanup instructions:
 
 ```bash
-git worktree remove <worktree-path> 2>/dev/null || true
-git branch -d <change-name> 2>/dev/null || true
-git worktree prune
+ito agent instruction finish --change "<full-change-id>"
 ```
 {% else %}
 Worktrees are not configured for this project.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -26,7 +26,14 @@ ito sync
 {% if worktree.enabled and worktree.apply_enabled %}
 ### Worktree Setup
 
-Strategy: `{{ worktree.strategy }}` | Branch: `{{ worktree.default_branch }}` | Dir: `{{ worktree.layout_dir_name }}`
+Strategy: `{{ worktree.strategy }}` | Default branch: `{{ worktree.default_branch }}` | Dir: `{{ worktree.layout_dir_name }}`
+
+Worktree rules for this change:
+
+- Keep the main/control checkout clean; do not implement change work there.
+- Use the full change ID as the branch and primary worktree directory name: `{{ instructions.changeName }}`.
+- Do not reuse one worktree for two changes.
+- Additional worktrees for this same change must start with `{{ instructions.changeName }}` and add a suffix, for example `{{ instructions.changeName }}-review`.
 
 **Recommended**: Use `ito worktree ensure` to create and initialize the worktree in one step:
 
@@ -37,7 +44,7 @@ CHANGE_DIR=$(ito worktree ensure --change "{{ instructions.changeName | replace(
 }
 ```
 
-This creates the worktree (if absent), copies include files, and runs setup commands.
+This creates the dedicated change worktree (if absent), copies include files, and runs setup commands.
 All subsequent file operations should use `$CHANGE_DIR` as the working directory.
 
 After `ito worktree ensure`, run the sync from inside the change worktree if you did not just run it there:
@@ -70,7 +77,7 @@ if [ ! -d "$CHANGE_DIR" ]; then
 {% else %}
   WORKTREE_ROOT="$(ito path worktree-root)"
   mkdir -p "$(ito path worktrees-root)"
-  git -C "$WORKTREE_ROOT" worktree add "$CHANGE_DIR" -b "$CHANGE_NAME"
+  git -C "$WORKTREE_ROOT" worktree add "$CHANGE_DIR" -b "$CHANGE_NAME" "{{ worktree.default_branch }}"
 {% endif %}
 fi
 

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -156,7 +156,7 @@ After creating the change, get the canonical, change-scoped instructions:
 
 ```bash
 {% if worktree is defined and worktree.enabled %}
-CHANGE_DIR=$(ito worktree ensure --change <change-id>)
+CHANGE_DIR=$(ito worktree ensure --change "<change-id>")
 cd "$CHANGE_DIR"
 {% endif %}
 ito agent instruction proposal --change <change-id>

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -118,6 +118,15 @@ Sub-modules group related changes within a module. Sub-module IDs use the format
 
 Only proceed here after the user has confirmed their module (or sub-module) choice.
 
+{% if worktree is defined and worktree.enabled %}
+Create the change ID first, then create and use a **new** worktree before editing proposal artifacts:
+
+- Keep the main/control checkout clean; do not edit proposal, spec, design, or task files there.
+- Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
+- Do not reuse a worktree from another change.
+- If you need more than one worktree for the same change, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+{% endif %}
+
 ```bash
 # For a regular module:
 ito create change "<change-name>" --module <module-id> --schema <schema>
@@ -146,10 +155,18 @@ ito create change "add-oauth-provider" --sub-module 001.02
 After creating the change, get the canonical, change-scoped instructions:
 
 ```bash
+{% if worktree is defined and worktree.enabled %}
+CHANGE_DIR=$(ito worktree ensure --change <change-id>)
+cd "$CHANGE_DIR"
+{% endif %}
 ito agent instruction proposal --change <change-id>
 ito agent instruction specs --change <change-id>
 ito agent instruction tasks --change <change-id>
 ```
+
+{% if worktree is defined and worktree.enabled %}
+Run all subsequent file operations from `$CHANGE_DIR`.
+{% endif %}
 
 Follow the printed instructions exactly.
 

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
@@ -11,7 +11,14 @@ Work directly in the current checkout.
 
 ### Ensure Worktree
 
-Run the following to create and initialize the change worktree (idempotent — safe to re-run):
+Run the following to create and initialize the dedicated change worktree (idempotent — safe to re-run):
+
+Worktree rules:
+
+- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Use the full change ID as the branch and primary worktree directory name.
+- Do not reuse one worktree for two changes.
+- Extra worktrees for the same change must start with the full change ID and add a suffix.
 
 ```bash
 {% if change %}

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
@@ -47,6 +47,13 @@ To enable worktrees for *this developer*, create/update {% if worktree.ito_root 
 {% else %}
 Use the commands below for the configured strategy.
 
+Change worktree rules:
+
+- Keep the main/control checkout clean; do not create proposals or implement changes there.
+- Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
+- Do not reuse one worktree for two changes.
+- If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+
 Helpful path commands:
 
 - `ito path project-root` (stable root shared across worktrees)
@@ -65,7 +72,7 @@ Worktree root: `{{ worktree.worktree_root }}`
 {% endif %}
 
 ```bash
-BRANCH_NAME="<change-name>"
+BRANCH_NAME="<full-change-id>"
 WORKTREE_ROOT="$(ito path worktree-root)"
 WORKTREES_ROOT="$(ito path worktrees-root)"
 mkdir -p "$WORKTREES_ROOT"
@@ -76,7 +83,7 @@ LAYOUT_DIR_NAME='{{ worktree.layout_dir_name | replace("'", "'\"'\"'") }}'
 WORKTREES_IGNORE="${LAYOUT_DIR_NAME%/}/"
 grep -qxF "$WORKTREES_IGNORE" "$GITIGNORE_PATH" 2>/dev/null || printf '%s\n' "$WORKTREES_IGNORE" >> "$GITIGNORE_PATH"
 
-git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}"
+git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}" "{{ worktree.default_branch }}"
 ```
 {% elif worktree.strategy == "checkout_siblings" %}
 #### Strategy: `checkout_siblings`
@@ -90,12 +97,12 @@ Worktree root: `{{ worktree.worktree_root }}`
 {% endif %}
 
 ```bash
-BRANCH_NAME="<change-name>"
+BRANCH_NAME="<full-change-id>"
 WORKTREE_ROOT="$(ito path worktree-root)"
 WORKTREES_ROOT="$(ito path worktrees-root)"
 mkdir -p "$WORKTREES_ROOT"
 
-git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}"
+git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}" "{{ worktree.default_branch }}"
 ```
 {% elif worktree.strategy == "bare_control_siblings" %}
 #### Strategy: `bare_control_siblings`
@@ -111,7 +118,7 @@ Worktree root: `{{ worktree.worktree_root }}`
 Run git worktree commands against the bare/control root, but create each change worktree from `{{ worktree.default_branch }}` rather than the bare placeholder `HEAD`.
 
 ```bash
-BRANCH_NAME="<change-name>"
+BRANCH_NAME="<full-change-id>"
 PROJECT_ROOT="$(ito path project-root)"
 WORKTREES_ROOT="$(ito path worktrees-root)"
 mkdir -p "$WORKTREES_ROOT"
@@ -131,7 +138,7 @@ Commit on the worktree branch, then merge into `{{ worktree.default_branch }}`.
 #### Cleanup
 
 ```bash
-ito agent instruction finish --change "<change-name>"
+ito agent instruction finish --change "<full-change-id>"
 ```
 
 If a worktree is locked, assume it was locked on purpose; do NOT unlock/remove it unless the user explicitly asks.

--- a/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
@@ -17,33 +17,40 @@ Git worktrees create isolated workspaces that share the same repository, allowin
 **Default branch:** `{{ default_branch }}`
 **Integration mode:** `{{ integration_mode }}`
 
+## Change Worktree Rules
+
+- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
+- Do not reuse one worktree for two changes.
+- If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+
 ## Worktree Location
 
 {% if strategy == "checkout_subdir" %}
 Worktrees live under:
 
 ```bash
-.{{ layout_dir_name }}/<change-name>/
+.{{ layout_dir_name }}/<full-change-id>/
 ```
 
 Create a worktree:
 
 ```bash
 mkdir -p ".{{ layout_dir_name }}"
-git worktree add ".{{ layout_dir_name }}/<change-name>" -b <change-name>
+git worktree add ".{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 {% elif strategy == "checkout_siblings" %}
 Worktrees live under a sibling directory:
 
 ```bash
-../<project-name>-{{ layout_dir_name }}/<change-name>/
+../<project-name>-{{ layout_dir_name }}/<full-change-id>/
 ```
 
 Create a worktree:
 
 ```bash
 mkdir -p "../<project-name>-{{ layout_dir_name }}"
-git worktree add "../<project-name>-{{ layout_dir_name }}/<change-name>" -b <change-name>
+git worktree add "../<project-name>-{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 {% elif strategy == "bare_control_siblings" %}
 Worktrees live under the bare/control layout:
@@ -51,14 +58,14 @@ Worktrees live under the bare/control layout:
 ```bash
 ../
 |-- {{ default_branch }}/
-`-- {{ layout_dir_name }}/<change-name>/
+`-- {{ layout_dir_name }}/<full-change-id>/
 ```
 
 Create a worktree:
 
 ```bash
 mkdir -p "../{{ layout_dir_name }}"
-git worktree add "../{{ layout_dir_name }}/<change-name>" -b <change-name> {{ default_branch }}
+git worktree add "../{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
 ```
 
 Always branch new change worktrees from `{{ default_branch }}`. Never use the bare/control repo placeholder `HEAD` as the checkout source.
@@ -85,10 +92,10 @@ If you need absolute paths (for logs, scripts, or agent instructions), use:
 
 ## Cleanup
 
-After the branch is merged:
+After the branch is merged, ask Ito for cleanup instructions:
 
 ```bash
-ito agent instruction finish --change "<branch-name>"
+ito agent instruction finish --change "<full-change-id>"
 ```
 
 If a worktree is locked, assume it was locked on purpose; do NOT unlock/remove it unless the user explicitly asks.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -293,6 +293,11 @@ fn worktrees_template_bare_control_siblings_branches_from_default_branch() {
     };
 
     let out = render_instruction_template("agent/worktrees.md.j2", &ctx).unwrap();
+    assert!(out.contains("Keep the main/control checkout clean"));
+    assert!(
+        out.contains("Use the full change ID as the branch and primary worktree directory name")
+    );
+    assert!(out.contains("Do not reuse one worktree for two changes"));
     assert!(out.contains(
         "git -C \"$PROJECT_ROOT\" worktree add \"$WORKTREES_ROOT/${BRANCH_NAME}\" -b \"${BRANCH_NAME}\" \"develop\""
     ));
@@ -438,6 +443,11 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
     };
 
     let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert!(out.contains("Use the full change ID as the branch and primary worktree directory name: `000-01_test-change`"));
+    assert!(out.contains("Do not reuse one worktree for two changes"));
+    assert!(out.contains(
+        "Additional worktrees for this same change must start with `000-01_test-change`"
+    ));
     assert!(out.contains(
         "git -C \"$PROJECT_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
     ));
@@ -450,6 +460,179 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
         "sync should be in the recommended setup path"
     );
     assert_eq!(out[..details_pos].matches("\nito sync\n").count(), 2);
+}
+
+#[test]
+fn apply_template_checkout_subdir_branches_from_default_branch() {
+    #[derive(Serialize)]
+    struct InstructionsCtx {
+        #[serde(rename = "changeName")]
+        change_name: &'static str,
+        #[serde(rename = "schemaName")]
+        schema_name: &'static str,
+        state: &'static str,
+        #[serde(rename = "missingArtifacts")]
+        missing_artifacts: Vec<&'static str>,
+        instruction: &'static str,
+        #[serde(rename = "tracksFile")]
+        tracks_file: bool,
+        #[serde(rename = "tracksPath")]
+        tracks_path: &'static str,
+        #[serde(rename = "tracksFormat")]
+        tracks_format: &'static str,
+        progress: ProgressCtx,
+        tasks: Vec<&'static str>,
+    }
+
+    #[derive(Serialize)]
+    struct ProgressCtx {
+        total: usize,
+        complete: usize,
+    }
+
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+        apply_enabled: bool,
+        strategy: &'static str,
+        default_branch: &'static str,
+        layout_dir_name: &'static str,
+        integration_mode: &'static str,
+        copy_from_main: Vec<&'static str>,
+        setup_commands: Vec<&'static str>,
+    }
+
+    #[derive(Serialize)]
+    struct TestingPolicyCtx {
+        tdd_workflow: &'static str,
+        coverage_target_percent: u64,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        instructions: InstructionsCtx,
+        context_files: Vec<&'static str>,
+        worktree: WorktreeCtx,
+        tracking_errors: Vec<&'static str>,
+        tracking_warnings: Vec<&'static str>,
+        testing_policy: TestingPolicyCtx,
+        user_guidance: &'static str,
+    }
+
+    let ctx = Ctx {
+        instructions: InstructionsCtx {
+            change_name: "000-01_test-change",
+            schema_name: "spec-driven",
+            state: "ready",
+            missing_artifacts: Vec::new(),
+            instruction: "Implement the change.",
+            tracks_file: false,
+            tracks_path: "",
+            tracks_format: "",
+            progress: ProgressCtx {
+                total: 0,
+                complete: 0,
+            },
+            tasks: Vec::new(),
+        },
+        context_files: Vec::new(),
+        worktree: WorktreeCtx {
+            enabled: true,
+            apply_enabled: true,
+            strategy: "checkout_subdir",
+            default_branch: "develop",
+            layout_dir_name: "ito-worktrees",
+            integration_mode: "commit_pr",
+            copy_from_main: Vec::new(),
+            setup_commands: Vec::new(),
+        },
+        tracking_errors: Vec::new(),
+        tracking_warnings: Vec::new(),
+        testing_policy: TestingPolicyCtx {
+            tdd_workflow: "red-green-refactor",
+            coverage_target_percent: 80,
+        },
+        user_guidance: "",
+    };
+
+    let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert!(out.contains("Default branch: `develop`"));
+    assert!(out.contains(
+        "git -C \"$WORKTREE_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
+    ));
+}
+
+#[test]
+fn new_proposal_template_moves_to_worktree_after_create() {
+    #[derive(Serialize)]
+    struct ModuleCtx {
+        id: &'static str,
+        name: &'static str,
+    }
+
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        modules: Vec<ModuleCtx>,
+        worktree: WorktreeCtx,
+    }
+
+    let out = render_instruction_template(
+        "agent/new-proposal.md.j2",
+        &Ctx {
+            modules: vec![ModuleCtx {
+                id: "012",
+                name: "git-worktrees",
+            }],
+            worktree: WorktreeCtx { enabled: true },
+        },
+    )
+    .unwrap();
+
+    assert!(out.contains("Create the change ID first"));
+    assert!(out.contains("CHANGE_DIR=$(ito worktree ensure --change <change-id>)"));
+    assert!(out.contains("cd \"$CHANGE_DIR\""));
+    assert!(out.contains("Run all subsequent file operations from `$CHANGE_DIR`"));
+}
+
+#[test]
+fn worktree_init_template_includes_fresh_worktree_rules() {
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+        init_include: Vec<&'static str>,
+        init_setup: Vec<&'static str>,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        worktree: WorktreeCtx,
+        change: &'static str,
+    }
+
+    let out = render_instruction_template(
+        "agent/worktree-init.md.j2",
+        &Ctx {
+            worktree: WorktreeCtx {
+                enabled: true,
+                init_include: Vec::new(),
+                init_setup: Vec::new(),
+            },
+            change: "012-06_example-change",
+        },
+    )
+    .unwrap();
+
+    assert!(out.contains("Worktree rules:"));
+    assert!(
+        out.contains("Use the full change ID as the branch and primary worktree directory name")
+    );
+    assert!(out.contains("Do not reuse one worktree for two changes"));
+    assert!(out.contains("WORKTREE_PATH=$(ito worktree ensure --change '012-06_example-change')"));
 }
 
 #[test]

--- a/ito-rs/crates/ito-templates/src/project_templates.rs
+++ b/ito-rs/crates/ito-templates/src/project_templates.rs
@@ -185,11 +185,18 @@ mod tests {
 
         assert!(text.contains("## Worktree Workflow"));
         assert!(text.contains("**Strategy:** `checkout_subdir`"));
+        assert!(text.contains("Keep the main/control checkout clean"));
         assert!(
-            text.contains("git worktree add \".ito-worktrees/<change-name>\" -b <change-name>")
+            text.contains(
+                "Use the full change ID as the branch and primary worktree directory name"
+            )
         );
+        assert!(text.contains("Do not reuse one worktree for two changes"));
+        assert!(text.contains(
+            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+        ));
         assert!(
-            text.contains(".ito-worktrees/<change-name>/"),
+            text.contains(".ito-worktrees/<full-change-id>/"),
             "should contain repo-relative worktree path"
         );
         assert!(
@@ -217,11 +224,18 @@ mod tests {
         let text = String::from_utf8(rendered).unwrap();
 
         assert!(text.contains("**Strategy:** `checkout_siblings`"));
+        assert!(text.contains("Keep the main/control checkout clean"));
+        assert!(
+            text.contains(
+                "Use the full change ID as the branch and primary worktree directory name"
+            )
+        );
+        assert!(text.contains("Do not reuse one worktree for two changes"));
         assert!(text.contains(
-            "git worktree add \"../<project-name>-worktrees/<change-name>\" -b <change-name>"
+            "git worktree add \"../<project-name>-worktrees/<full-change-id>\" -b <full-change-id> develop"
         ));
         assert!(
-            text.contains("../<project-name>-worktrees/<change-name>/"),
+            text.contains("../<project-name>-worktrees/<full-change-id>/"),
             "should contain repo-relative sibling worktree path"
         );
         assert!(
@@ -251,11 +265,9 @@ mod tests {
         assert!(text.contains("**Strategy:** `bare_control_siblings`"));
         assert!(text.contains(".bare/"));
         assert!(text.contains("ito-worktrees/"));
-        assert!(
-            text.contains(
-                "git worktree add \"../ito-worktrees/<change-name>\" -b <change-name> main"
-            )
-        );
+        assert!(text.contains(
+            "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+        ));
         assert!(text.contains("Do not create them from the bare/control repo placeholder `HEAD`"));
         let layout_line = text
             .lines()

--- a/ito-rs/crates/ito-templates/src/project_templates.rs
+++ b/ito-rs/crates/ito-templates/src/project_templates.rs
@@ -263,6 +263,13 @@ mod tests {
         let text = String::from_utf8(rendered).unwrap();
 
         assert!(text.contains("**Strategy:** `bare_control_siblings`"));
+        assert!(text.contains("Keep the main/control checkout clean"));
+        assert!(
+            text.contains(
+                "Use the full change ID as the branch and primary worktree directory name"
+            )
+        );
+        assert!(text.contains("Do not reuse one worktree for two changes"));
         assert!(text.contains(".bare/"));
         assert!(text.contains("ito-worktrees/"));
         assert!(text.contains(

--- a/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
+++ b/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
@@ -204,7 +204,7 @@ fn disabled_ctx() -> WorktreeTemplateContext {
 /// Verifies that AGENTS.md renders appropriate worktree instructions and paths for the `checkout_subdir` strategy.
 ///
 /// Ensures the rendered text includes the "Worktree Workflow" section, the configured strategy label,
-/// a repository-relative `.ito-worktrees/<change-name>/` worktree path and the corresponding `git worktree add` example,
+/// a repository-relative `.ito-worktrees/<full-change-id>/` worktree path and the corresponding `git worktree add` example,
 /// and that it does not contain raw template syntax, discovery heuristics, or an embedded absolute project root.
 ///
 /// # Examples
@@ -213,7 +213,7 @@ fn disabled_ctx() -> WorktreeTemplateContext {
 /// let ctx = checkout_subdir_ctx();
 /// let text = render_text(agents_md_bytes(), &ctx);
 /// assert!(text.contains("**Strategy:** `checkout_subdir`"));
-/// assert!(text.contains(".ito-worktrees/<change-name>/"));
+/// assert!(text.contains(".ito-worktrees/<full-change-id>/"));
 /// ```
 #[test]
 fn agents_md_checkout_subdir() {
@@ -222,11 +222,20 @@ fn agents_md_checkout_subdir() {
 
     assert!(text.contains("## Worktree Workflow"));
     assert!(text.contains("**Strategy:** `checkout_subdir`"));
-    assert!(text.contains("git worktree add \".ito-worktrees/<change-name>\" -b <change-name>"));
+    assert!(
+        text.contains(
+            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+        )
+    );
+    assert!(text.contains("Keep the main/control checkout clean"));
+    assert!(
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
+    );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
     assert!(!text.contains("{{"), "should not contain raw jinja");
     assert_no_discovery_heuristics(&text, "agents_md_checkout_subdir");
     assert!(
-        text.contains(".ito-worktrees/<change-name>/"),
+        text.contains(".ito-worktrees/<full-change-id>/"),
         "should show repo-relative worktree path"
     );
     assert_no_absolute_project_root(&text, &ctx.project_root, "agents_md_checkout_subdir");
@@ -238,13 +247,18 @@ fn agents_md_checkout_siblings() {
     let text = render_text(agents_md_bytes(), &ctx);
 
     assert!(text.contains("**Strategy:** `checkout_siblings`"));
+    assert!(text.contains("Keep the main/control checkout clean"));
     assert!(
-        text.contains("git worktree add \"../<project-name>-wt/<change-name>\" -b <change-name>")
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
+    assert!(text.contains(
+        "git worktree add \"../<project-name>-wt/<full-change-id>\" -b <full-change-id> develop"
+    ));
     assert!(!text.contains("{{"), "should not contain raw jinja");
     assert_no_discovery_heuristics(&text, "agents_md_checkout_siblings");
     assert!(
-        text.contains("../<project-name>-wt/<change-name>/"),
+        text.contains("../<project-name>-wt/<full-change-id>/"),
         "should show repo-relative sibling worktree path"
     );
     assert_no_absolute_project_root(&text, &ctx.project_root, "agents_md_checkout_siblings");
@@ -270,11 +284,16 @@ fn agents_md_bare_control_siblings() {
     let text = render_text(agents_md_bytes(), &ctx);
 
     assert!(text.contains("**Strategy:** `bare_control_siblings`"));
+    assert!(text.contains("Keep the main/control checkout clean"));
+    assert!(
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
+    );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
     assert!(text.contains(".bare/"));
     assert!(text.contains("ito-worktrees/"));
-    assert!(
-        text.contains("git worktree add \"../ito-worktrees/<change-name>\" -b <change-name> main")
-    );
+    assert!(text.contains(
+        "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+    ));
     assert!(text.contains("Do not create them from the bare/control repo placeholder `HEAD`"));
     assert!(!text.contains("{{"), "should not contain raw jinja");
     assert_no_discovery_heuristics(&text, "agents_md_bare_control_siblings");
@@ -309,7 +328,16 @@ fn skill_checkout_subdir() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `checkout_subdir`"));
-    assert!(text.contains("git worktree add \".ito-worktrees/<change-name>\" -b <change-name>"));
+    assert!(
+        text.contains(
+            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+        )
+    );
+    assert!(text.contains("Keep the main/control checkout clean"));
+    assert!(
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
+    );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
     assert!(!text.contains("{{"), "should not contain raw jinja");
     assert_no_discovery_heuristics(&text, "skill_checkout_subdir");
     assert_no_absolute_project_root(&text, &ctx.project_root, "skill_checkout_subdir");
@@ -321,9 +349,14 @@ fn skill_checkout_siblings() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `checkout_siblings`"));
+    assert!(text.contains("Keep the main/control checkout clean"));
     assert!(
-        text.contains("git worktree add \"../<project-name>-wt/<change-name>\" -b <change-name>")
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
+    assert!(text.contains(
+        "git worktree add \"../<project-name>-wt/<full-change-id>\" -b <full-change-id> develop"
+    ));
     assert!(!text.contains("{{"), "should not contain raw jinja");
     assert_no_discovery_heuristics(&text, "skill_checkout_siblings");
     assert_no_absolute_project_root(&text, &ctx.project_root, "skill_checkout_siblings");
@@ -351,10 +384,15 @@ fn skill_bare_control_siblings() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `bare_control_siblings`"));
-    assert!(text.contains("ito-worktrees/"));
+    assert!(text.contains("Keep the main/control checkout clean"));
     assert!(
-        text.contains("git worktree add \"../ito-worktrees/<change-name>\" -b <change-name> main")
+        text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
+    assert!(text.contains("Do not reuse one worktree for two changes"));
+    assert!(text.contains("ito-worktrees/"));
+    assert!(text.contains(
+        "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
+    ));
     assert!(
         text.contains("Never use the bare/control repo placeholder `HEAD` as the checkout source")
     );


### PR DESCRIPTION
## Summary
- Require worktree-enabled guidance to keep main/control clean and use full change IDs for branch/worktree names.
- Pin all generated worktree creation examples to the configured default branch.
- Add rendering coverage for proposal/apply/worktree-init/worktree guidance across strategies.

## Verification
- `cargo test -p ito-templates`
- `cargo clippy -p ito-templates --all-targets -- -D warnings`

## Notes
- Full `make check` is currently blocked by pre-existing repo-wide issues unrelated to this change: markdownlint in `.agents/skills/byterover/SKILL.md`, clippy/doc/max-line/cargo-deny/coverage setup failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated worktree naming conventions to require full change identifiers including module prefixes.
  * Enhanced guidance on worktree governance rules: keeping primary checkout clean, preventing reuse across changes, and conventions for multi-worktree scenarios.
  * Refined instruction templates for agent operations regarding worktree setup and cleanup steps.

* **Tests**
  * Added test coverage validating new worktree naming and governance constraints across instruction templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->