### PR TITLE
feat(029-02): agent memory abstraction (capture/search/query)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -196,6 +196,122 @@ Change coordination settings live under `changes.coordination_branch`:
 - `changes.coordination_branch.enabled`
 - `changes.coordination_branch.name`
 
+### Agent memory
+
+Agent memory is configured under the optional top-level `memory` section,
+keyed by operation name. Each operation (`capture`, `search`, `query`) is
+*independently optional* and picks one of two shapes:
+
+- **`command` shape** — Ito renders a shell command line, substituting
+  the operation's input placeholders at instruction-emission time.
+- **`skill` shape** — Ito directs the agent to invoke an installed skill
+  with structured inputs and an opaque `options` payload.
+
+There is **no default provider**. A freshly initialized Ito project has
+no `memory` section; running `ito agent instruction memory-capture` (or
+`memory-search` / `memory-query`) on it prints provider-setup guidance
+rather than failing.
+
+#### Command-shape placeholder rules
+
+When `kind` is `"command"`, Ito substitutes a fixed set of placeholders
+into the configured `command` template:
+
+| Placeholder | Type | Render rule |
+| --- | --- | --- |
+| `{context}` | scalar string (capture) | shell-quoted, empty when unset |
+| `{query}` | scalar string (search, query) | shell-quoted |
+| `{scope}` | scalar string (search) | shell-quoted, empty when unset |
+| `{limit}` | integer (search) | decimal literal; default `10` for `memory-search` |
+| `{files}` | list of paths (capture) | expands to repeated `--file 'path'` flags |
+| `{folders}` | list of paths (capture) | expands to repeated `--folder 'path'` flags |
+
+Unknown `{placeholder}` tokens are preserved literally — Ito does not
+emit a validation error for them.
+
+The rendered output is executable as-is; the agent does not perform
+further substitution.
+
+#### Worked example: command shape (generic)
+
+```jsonc
+{
+  "memory": {
+    "capture": {
+      "kind": "command",
+      "command": "<your-cli> store \"{context}\" {files} {folders}"
+    },
+    "search": {
+      "kind": "command",
+      "command": "<your-cli> search \"{query}\" --limit {limit}"
+    },
+    "query": {
+      "kind": "command",
+      "command": "<your-cli> ask \"{query}\""
+    }
+  }
+}
+```
+
+(Replace `<your-cli>` with whatever the configured backend is — for
+example, the ByteRover integration shipped by change
+`029-01_add-byterover-integration` configures `brv curate / brv search /
+brv query` via this exact shape.)
+
+#### Worked example: skill shape (generic)
+
+```jsonc
+{
+  "memory": {
+    "capture": {
+      "kind": "skill",
+      "skill": "ito-memory-markdown",
+      "options": { "root": ".ito/memories" }
+    },
+    "search": {
+      "kind": "skill",
+      "skill": "ito-memory-markdown"
+    }
+  }
+}
+```
+
+Ito does not interpret the `options` map — it is passed through
+verbatim to the configured skill, so each skill defines its own option
+schema.
+
+#### Mixing shapes
+
+Operations are configured independently, so `capture` may use a skill
+while `search` and `query` use inline commands:
+
+```jsonc
+{
+  "memory": {
+    "capture": { "kind": "skill", "skill": "ito-memory-markdown" },
+    "search":  { "kind": "command", "command": "rg \"{query}\" .ito/memories" }
+    // query intentionally omitted — `memory-query` will print setup
+    // guidance until configured.
+  }
+}
+```
+
+#### Apply / finish reminders
+
+When `memory.capture` is configured, both
+`ito agent instruction apply --change <id>` and
+`ito agent instruction finish --change <id>` append a *Capture memories*
+reminder section. The reminder tells the agent what to capture
+(decisions, gotchas, patterns) and how to invoke
+`ito agent instruction memory-capture`. The reminder is omitted when
+`memory.capture` is unconfigured, regardless of whether `search` or
+`query` are configured.
+
+`finish` also always appends a *Refresh archive and specs* wrap-up
+reminder covering specs / docs / archive checks. The archive check is
+suppressed when finish has already prompted to run `ito archive`, so the
+agent never sees the archive step listed twice in one finish output.
+
 ## Ito Directory Name (`projectPath`)
 
 `projectPath` controls the Ito working directory name (defaults to `.ito`).

--- a/ito-rs/crates/ito-cli/src/app/instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/instructions.rs
@@ -420,6 +420,10 @@ then re-run:\n\n\
         return emit_instruction(want_json, "archive", instruction);
     }
 
+    if super::memory_instructions::try_handle(rt, artifact, args, want_json)? {
+        return Ok(());
+    }
+
     let change = parse_string_flag(args, "--change");
     if change.as_deref().unwrap_or("").is_empty() {
         // Special case: proposal without --change outputs creation guide

--- a/ito-rs/crates/ito-cli/src/app/instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/instructions.rs
@@ -3,7 +3,11 @@ use crate::cli_error::{CliResult, fail, to_cli_error};
 use crate::commands::sync::best_effort_sync_coordination;
 use crate::runtime::Runtime;
 use crate::util::parse_string_flag;
-use ito_config::types::{ItoConfig, MemoryConfig, MemoryOpConfig, WorktreeInitConfig, WorktreeStrategy};
+use ito_config::types::{ItoConfig, WorktreeInitConfig, WorktreeStrategy};
+
+use super::memory_instructions::{
+    MemoryTemplateConfig, memory_template_config_from_merged,
+};
 use ito_config::{load_cascading_project_config, resolve_coordination_branch_settings};
 use ito_core::harness_context;
 use ito_core::templates as core_templates;
@@ -1123,38 +1127,7 @@ fn print_apply_instructions_text(
     print!("{out}");
 }
 
-#[derive(Debug, Clone, Default, serde::Serialize)]
-struct MemoryOpTemplateState {
-    /// Whether this operation has a configured provider.
-    configured: bool,
-}
 
-#[derive(Debug, Clone, Default, serde::Serialize)]
-struct MemoryTemplateConfig {
-    capture: MemoryOpTemplateState,
-    search: MemoryOpTemplateState,
-    query: MemoryOpTemplateState,
-}
-
-fn memory_template_config_from_merged(merged: &serde_json::Value) -> MemoryTemplateConfig {
-    let typed: ItoConfig = serde::Deserialize::deserialize(merged).unwrap_or_default();
-    let memory: Option<MemoryConfig> = typed.memory;
-    let configured = |op: &Option<MemoryOpConfig>| op.is_some();
-    match memory {
-        Some(m) => MemoryTemplateConfig {
-            capture: MemoryOpTemplateState {
-                configured: configured(&m.capture),
-            },
-            search: MemoryOpTemplateState {
-                configured: configured(&m.search),
-            },
-            query: MemoryOpTemplateState {
-                configured: configured(&m.query),
-            },
-        },
-        None => MemoryTemplateConfig::default(),
-    }
-}
 
 fn collect_missing_dependencies(
     instructions: &core_templates::InstructionsResponse,

--- a/ito-rs/crates/ito-cli/src/app/instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/instructions.rs
@@ -3,7 +3,7 @@ use crate::cli_error::{CliResult, fail, to_cli_error};
 use crate::commands::sync::best_effort_sync_coordination;
 use crate::runtime::Runtime;
 use crate::util::parse_string_flag;
-use ito_config::types::{ItoConfig, WorktreeInitConfig, WorktreeStrategy};
+use ito_config::types::{ItoConfig, MemoryConfig, MemoryOpConfig, WorktreeInitConfig, WorktreeStrategy};
 use ito_config::{load_cascading_project_config, resolve_coordination_branch_settings};
 use ito_core::harness_context;
 use ito_core::templates as core_templates;
@@ -340,6 +340,7 @@ then re-run:\n\n\
         let cfg = load_cascading_project_config(project_root, ito_path, ctx);
         let worktree = worktree_config_from_merged_with_paths(&cfg.merged, project_root, ito_path);
         let archive = archive_instruction_config_from_merged(&cfg.merged)?;
+        let memory = memory_template_config_from_merged(&cfg.merged);
         let change = parse_string_flag(args, "--change")
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
@@ -348,7 +349,15 @@ then re-run:\n\n\
         struct Ctx {
             worktree: WorktreeConfig,
             archive: ArchiveInstructionConfig,
+            memory: MemoryTemplateConfig,
             change: Option<String>,
+            /// Always `true` today: the existing archive prompt always renders.
+            ///
+            /// Reserved for future logic that suppresses the prompt when the
+            /// change is already archived; templates SHOULD use this flag to
+            /// decide whether the wrap-up reminder also lists the archive
+            /// step (`{% if not archive_prompt_rendered %}`).
+            archive_prompt_rendered: bool,
         }
 
         let instruction = ito_templates::instructions::render_instruction_template(
@@ -356,7 +365,9 @@ then re-run:\n\n\
             &Ctx {
                 worktree,
                 archive,
+                memory,
                 change,
+                archive_prompt_rendered: true,
             },
         )
         .map_err(|e| to_cli_error(format!("failed to render finish instruction: {e}")))?;
@@ -506,11 +517,15 @@ then re-run:\n\n\
         }
 
         let worktree_config = load_worktree_config(project_root, ito_path, ctx);
+        let memory_template = memory_template_config_from_merged(
+            &load_cascading_project_config(project_root, ito_path, ctx).merged,
+        );
         print_apply_instructions_text(
             &apply,
             &testing_policy,
             user_guidance.as_deref(),
             &worktree_config,
+            memory_template,
         );
         return Ok(());
     }
@@ -1069,6 +1084,7 @@ fn print_apply_instructions_text(
     testing_policy: &TestingPolicy,
     user_guidance: Option<&str>,
     worktree_config: &WorktreeConfig,
+    memory: MemoryTemplateConfig,
 ) {
     #[derive(serde::Serialize)]
     struct Ctx {
@@ -1079,6 +1095,7 @@ fn print_apply_instructions_text(
         tracking_warnings: Option<usize>,
         user_guidance: Option<String>,
         worktree: WorktreeConfig,
+        memory: MemoryTemplateConfig,
     }
 
     let context_files = collect_context_files(&instructions.context_files);
@@ -1097,12 +1114,46 @@ fn print_apply_instructions_text(
         tracking_warnings,
         user_guidance,
         worktree: worktree_config.clone(),
+        memory,
     };
 
     let out = ito_templates::instructions::render_instruction_template("agent/apply.md.j2", &ctx)
         .expect("apply instruction template should render");
 
     print!("{out}");
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+struct MemoryOpTemplateState {
+    /// Whether this operation has a configured provider.
+    configured: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+struct MemoryTemplateConfig {
+    capture: MemoryOpTemplateState,
+    search: MemoryOpTemplateState,
+    query: MemoryOpTemplateState,
+}
+
+fn memory_template_config_from_merged(merged: &serde_json::Value) -> MemoryTemplateConfig {
+    let typed: ItoConfig = serde::Deserialize::deserialize(merged).unwrap_or_default();
+    let memory: Option<MemoryConfig> = typed.memory;
+    let configured = |op: &Option<MemoryOpConfig>| op.is_some();
+    match memory {
+        Some(m) => MemoryTemplateConfig {
+            capture: MemoryOpTemplateState {
+                configured: configured(&m.capture),
+            },
+            search: MemoryOpTemplateState {
+                configured: configured(&m.search),
+            },
+            query: MemoryOpTemplateState {
+                configured: configured(&m.query),
+            },
+        },
+        None => MemoryTemplateConfig::default(),
+    }
 }
 
 fn collect_missing_dependencies(

--- a/ito-rs/crates/ito-cli/src/app/memory_instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/memory_instructions.rs
@@ -16,12 +16,63 @@
 use std::collections::BTreeMap;
 
 use ito_config::load_cascading_project_config;
-use ito_config::types::ItoConfig;
+use ito_config::types::{ItoConfig, MemoryConfig, MemoryOpConfig};
 use ito_core::memory::{
     self, CaptureInputs, Operation, QueryInputs, RenderedInstruction, SearchInputs,
 };
 use serde::Serialize;
 use serde_json::Value;
+
+/// Per-operation flag exposed to the apply / finish instruction templates.
+///
+/// Templates use `{% if memory.<op>.configured %}` guards to decide whether
+/// to render memory-related reminders.
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct MemoryOpTemplateState {
+    /// `true` when the operation has a configured provider (`skill` or `command`).
+    pub(crate) configured: bool,
+}
+
+/// Memory state surfaced to instruction templates.
+///
+/// Each operation tracks whether it is configured. The `instructions.rs`
+/// renderers feed this into the `apply.md.j2` and `finish.md.j2` contexts
+/// so the templates can independently decide which reminders to show.
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct MemoryTemplateConfig {
+    pub(crate) capture: MemoryOpTemplateState,
+    pub(crate) search: MemoryOpTemplateState,
+    pub(crate) query: MemoryOpTemplateState,
+}
+
+/// Build a [`MemoryTemplateConfig`] from a merged Ito config value.
+///
+/// Returns the all-`false` default when the merged config either has no
+/// `memory` section or fails to deserialize as [`ItoConfig`]. The latter is
+/// rare (the strict `ito validate` command would surface it first), so we
+/// degrade silently here and let the template render the not-configured
+/// branch rather than failing instruction generation.
+pub(crate) fn memory_template_config_from_merged(
+    merged: &serde_json::Value,
+) -> MemoryTemplateConfig {
+    let typed: ItoConfig = serde::Deserialize::deserialize(merged).unwrap_or_default();
+    let memory: Option<MemoryConfig> = typed.memory;
+    let configured = |op: &Option<MemoryOpConfig>| op.is_some();
+    match memory {
+        Some(m) => MemoryTemplateConfig {
+            capture: MemoryOpTemplateState {
+                configured: configured(&m.capture),
+            },
+            search: MemoryOpTemplateState {
+                configured: configured(&m.search),
+            },
+            query: MemoryOpTemplateState {
+                configured: configured(&m.query),
+            },
+        },
+        None => MemoryTemplateConfig::default(),
+    }
+}
 
 use crate::cli_error::{CliResult, fail, to_cli_error};
 use crate::runtime::Runtime;

--- a/ito-rs/crates/ito-cli/src/app/memory_instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/memory_instructions.rs
@@ -1,0 +1,271 @@
+//! Memory instruction artifacts (`memory-capture`, `memory-search`,
+//! `memory-query`).
+//!
+//! Each artifact:
+//!
+//! 1. Parses operation-specific flags from the raw arg list.
+//! 2. Loads the merged Ito config and extracts `memory.<op>` if present.
+//! 3. Renders one of three branches via [`ito_core::memory`]:
+//!    - `Command` — emits the rendered shell command line.
+//!    - `Skill`   — emits a "invoke this skill with these inputs" directive.
+//!    - `NotConfigured` — emits operator setup guidance.
+//!
+//! Output is plain text by default, or a JSON envelope when `--json` is
+//! present.
+
+use std::collections::BTreeMap;
+
+use ito_config::load_cascading_project_config;
+use ito_config::types::ItoConfig;
+use ito_core::memory::{
+    self, CaptureInputs, Operation, QueryInputs, RenderedInstruction, SearchInputs,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::cli_error::{CliResult, fail, to_cli_error};
+use crate::runtime::Runtime;
+use crate::util::{parse_repeated_string_flag, parse_string_flag};
+
+/// Dispatch any memory-* instruction. Returns `Ok(true)` if the artifact
+/// matched a memory artifact (and was handled), `Ok(false)` if no match (so
+/// the caller can keep looking).
+pub(crate) fn try_handle(
+    rt: &Runtime,
+    artifact: &str,
+    args: &[String],
+    want_json: bool,
+) -> CliResult<bool> {
+    match artifact {
+        "memory-capture" => {
+            handle_memory_capture(rt, args, want_json)?;
+            Ok(true)
+        }
+        "memory-search" => {
+            handle_memory_search(rt, args, want_json)?;
+            Ok(true)
+        }
+        "memory-query" => {
+            handle_memory_query(rt, args, want_json)?;
+            Ok(true)
+        }
+        _ => Ok(false),
+    }
+}
+
+fn handle_memory_capture(rt: &Runtime, args: &[String], want_json: bool) -> CliResult<()> {
+    let inputs = CaptureInputs {
+        context: parse_string_flag(args, "--context"),
+        files: parse_repeated_string_flag(args, "--file"),
+        folders: parse_repeated_string_flag(args, "--folder"),
+    };
+    let config = load_memory_config(rt)?;
+    let rendered = memory::render_capture(config.as_ref(), &inputs);
+    emit_rendered(rendered, "memory-capture", want_json)
+}
+
+fn handle_memory_search(rt: &Runtime, args: &[String], want_json: bool) -> CliResult<()> {
+    let Some(query) = parse_string_flag(args, "--query") else {
+        return fail("Missing required option --query for memory-search");
+    };
+    let limit = match parse_string_flag(args, "--limit") {
+        Some(s) => match s.parse::<u64>() {
+            Ok(n) if n > 0 => Some(n),
+            _ => {
+                return fail(format!(
+                    "Invalid value for --limit ('{s}'). Provide a positive integer."
+                ));
+            }
+        },
+        None => None,
+    };
+    let inputs = SearchInputs {
+        query,
+        limit,
+        scope: parse_string_flag(args, "--scope"),
+    };
+    let config = load_memory_config(rt)?;
+    let rendered = memory::render_search(config.as_ref(), &inputs);
+    emit_rendered(rendered, "memory-search", want_json)
+}
+
+fn handle_memory_query(rt: &Runtime, args: &[String], want_json: bool) -> CliResult<()> {
+    let Some(query) = parse_string_flag(args, "--query") else {
+        return fail("Missing required option --query for memory-query");
+    };
+    let inputs = QueryInputs { query };
+    let config = load_memory_config(rt)?;
+    let rendered = memory::render_query(config.as_ref(), &inputs);
+    emit_rendered(rendered, "memory-query", want_json)
+}
+
+fn load_memory_config(rt: &Runtime) -> CliResult<Option<ito_config::types::MemoryConfig>> {
+    let ito_path = rt.ito_path();
+    let project_root = ito_path.parent().unwrap_or(ito_path);
+    let merged = load_cascading_project_config(project_root, ito_path, rt.ctx()).merged;
+    let typed: ItoConfig = serde::Deserialize::deserialize(&merged).map_err(|e| {
+        to_cli_error(format!(
+            "Failed to parse merged Ito config while preparing memory instruction.\n\
+             \n\
+             Why: The merged config contains an invalid value or type, so the memory provider cannot be resolved.\n\
+             \n\
+             How to fix: Inspect your config files (or run `ito config check`) and correct the invalid field, then retry.\n\
+             \n\
+             Underlying error: {e}"
+        ))
+    })?;
+    Ok(typed.memory)
+}
+
+#[derive(Serialize)]
+struct OutputEnvelope<'a> {
+    artifact: &'a str,
+    branch: &'a str,
+    instruction: String,
+    skill: Option<&'a str>,
+    inputs: Option<&'a BTreeMap<String, Value>>,
+    options: Option<&'a Value>,
+    operation: Option<&'a str>,
+}
+
+fn emit_rendered(
+    rendered: RenderedInstruction,
+    artifact: &str,
+    want_json: bool,
+) -> CliResult<()> {
+    match rendered {
+        RenderedInstruction::Command { line } => {
+            let body = render_command_text(artifact, &line);
+            if want_json {
+                let env = OutputEnvelope {
+                    artifact,
+                    branch: "command",
+                    instruction: body,
+                    skill: None,
+                    inputs: None,
+                    options: None,
+                    operation: None,
+                };
+                let json = serde_json::to_string_pretty(&env)
+                    .map_err(|e| to_cli_error(format!("serializing response: {e}")))?;
+                println!("{json}");
+            } else {
+                println!("{body}");
+            }
+            Ok(())
+        }
+        RenderedInstruction::Skill {
+            skill_id,
+            inputs,
+            options,
+        } => {
+            let body = render_skill_text(artifact, &skill_id, &inputs, options.as_ref());
+            if want_json {
+                let env = OutputEnvelope {
+                    artifact,
+                    branch: "skill",
+                    instruction: body,
+                    skill: Some(&skill_id),
+                    inputs: Some(&inputs),
+                    options: options.as_ref(),
+                    operation: None,
+                };
+                let json = serde_json::to_string_pretty(&env)
+                    .map_err(|e| to_cli_error(format!("serializing response: {e}")))?;
+                println!("{json}");
+            } else {
+                println!("{body}");
+            }
+            Ok(())
+        }
+        RenderedInstruction::NotConfigured { operation } => {
+            let body = render_not_configured_text(operation);
+            if want_json {
+                let env = OutputEnvelope {
+                    artifact,
+                    branch: "not_configured",
+                    instruction: body,
+                    skill: None,
+                    inputs: None,
+                    options: None,
+                    operation: Some(operation.as_key()),
+                };
+                let json = serde_json::to_string_pretty(&env)
+                    .map_err(|e| to_cli_error(format!("serializing response: {e}")))?;
+                println!("{json}");
+            } else {
+                println!("{body}");
+            }
+            Ok(())
+        }
+    }
+}
+
+fn render_command_text(artifact: &str, line: &str) -> String {
+    let header = match artifact {
+        "memory-capture" => "Capture this memory by running:",
+        "memory-search" => "Search memory by running:",
+        "memory-query" => "Query memory by running:",
+        _ => "Run this command:",
+    };
+    format!("{header}\n\n```bash\n{line}\n```\n")
+}
+
+fn render_skill_text(
+    artifact: &str,
+    skill_id: &str,
+    inputs: &BTreeMap<String, Value>,
+    options: Option<&Value>,
+) -> String {
+    let header = match artifact {
+        "memory-capture" => "Capture this memory by invoking the configured skill:",
+        "memory-search" => "Search memory by invoking the configured skill:",
+        "memory-query" => "Query memory by invoking the configured skill:",
+        _ => "Invoke the configured skill:",
+    };
+    let mut out = format!("{header}\n\n- Skill: `{skill_id}`\n- Inputs:\n");
+    for (key, value) in inputs {
+        let pretty = serde_json::to_string(value)
+            .unwrap_or_else(|_| "<unrenderable>".to_string());
+        out.push_str(&format!("  - `{key}` = `{pretty}`\n"));
+    }
+    if let Some(options) = options {
+        let pretty = serde_json::to_string_pretty(options)
+            .unwrap_or_else(|_| "<unrenderable>".to_string());
+        out.push_str(&format!(
+            "- Options (passed through verbatim):\n```json\n{pretty}\n```\n"
+        ));
+    } else {
+        out.push_str("- Options: (none configured)\n");
+    }
+    out
+}
+
+fn render_not_configured_text(operation: Operation) -> String {
+    let op = operation.as_key();
+    let (cmd_example, skill_example) = match operation {
+        Operation::Capture => (
+            "{ \"kind\": \"command\", \"command\": \"brv curate \\\"{context}\\\" {files} {folders}\" }",
+            "{ \"kind\": \"skill\", \"skill\": \"ito-memory-markdown\", \"options\": { \"root\": \".ito/memories\" } }",
+        ),
+        Operation::Search => (
+            "{ \"kind\": \"command\", \"command\": \"brv search \\\"{query}\\\" --limit {limit}{scope}\" }",
+            "{ \"kind\": \"skill\", \"skill\": \"byterover-explore\" }",
+        ),
+        Operation::Query => (
+            "{ \"kind\": \"command\", \"command\": \"brv query \\\"{query}\\\"\" }",
+            "{ \"kind\": \"skill\", \"skill\": \"byterover-explore\" }",
+        ),
+    };
+
+    format!(
+        "Memory `{op}` is not configured.\n\n\
+Configure it by adding `memory.{op}` to your Ito config (`.ito/config.json`).\
+ The value picks one of two shapes:\n\n\
+- **Command** template — Ito renders a shell command line:\n\n\
+```json\n\"memory\": {{ \"{op}\": {cmd_example} }}\n```\n\n\
+- **Skill** delegation — Ito directs the agent to invoke an installed skill:\n\n\
+```json\n\"memory\": {{ \"{op}\": {skill_example} }}\n```\n\n\
+There is no default provider; an unconfigured operation always renders this guidance.\n",
+    )
+}

--- a/ito-rs/crates/ito-cli/src/app/mod.rs
+++ b/ito-rs/crates/ito-cli/src/app/mod.rs
@@ -4,6 +4,7 @@ mod entrypoint;
 mod grep;
 mod init;
 mod instructions;
+mod memory_instructions;
 mod list;
 mod run;
 mod show;

--- a/ito-rs/crates/ito-cli/src/cli/agent.rs
+++ b/ito-rs/crates/ito-cli/src/cli/agent.rs
@@ -46,6 +46,31 @@ pub struct AgentInstructionArgs {
     /// Output as JSON
     #[arg(long)]
     pub json: bool,
+
+    // ---- memory-* artifact inputs --------------------------------------
+    /// Free-form context for `memory-capture`
+    #[arg(long)]
+    pub context: Option<String>,
+
+    /// File path for `memory-capture` (repeatable)
+    #[arg(long = "file", action = clap::ArgAction::Append)]
+    pub file: Vec<String>,
+
+    /// Folder path for `memory-capture` (repeatable)
+    #[arg(long = "folder", action = clap::ArgAction::Append)]
+    pub folder: Vec<String>,
+
+    /// Search/query input for `memory-search` and `memory-query`
+    #[arg(long)]
+    pub query: Option<String>,
+
+    /// Limit for `memory-search` (positive integer)
+    #[arg(long)]
+    pub limit: Option<u64>,
+
+    /// Scope for `memory-search`
+    #[arg(long)]
+    pub scope: Option<String>,
 }
 
 impl AgentInstructionArgs {
@@ -60,6 +85,12 @@ impl AgentInstructionArgs {
             tool,
             schema,
             json,
+            context,
+            file,
+            folder,
+            query,
+            limit,
+            scope,
         } = self;
 
         let mut argv = vec![artifact.clone()];
@@ -77,6 +108,30 @@ impl AgentInstructionArgs {
         }
         if *json {
             argv.push("--json".to_string());
+        }
+        if let Some(v) = context {
+            argv.push("--context".to_string());
+            argv.push(v.clone());
+        }
+        for v in file {
+            argv.push("--file".to_string());
+            argv.push(v.clone());
+        }
+        for v in folder {
+            argv.push("--folder".to_string());
+            argv.push(v.clone());
+        }
+        if let Some(v) = query {
+            argv.push("--query".to_string());
+            argv.push(v.clone());
+        }
+        if let Some(v) = limit {
+            argv.push("--limit".to_string());
+            argv.push(v.to_string());
+        }
+        if let Some(v) = scope {
+            argv.push("--scope".to_string());
+            argv.push(v.clone());
         }
         argv
     }

--- a/ito-rs/crates/ito-cli/src/util.rs
+++ b/ito-rs/crates/ito-cli/src/util.rs
@@ -192,6 +192,28 @@ pub(crate) fn parse_string_flag(args: &[String], key: &str) -> Option<String> {
     None
 }
 
+/// Collect every value supplied for a repeatable flag (e.g. `--file a --file b`).
+///
+/// Accepts both `--key value` and `--key=value` forms. The returned vector
+/// preserves caller order. An empty vector is returned when the flag does
+/// not appear.
+pub(crate) fn parse_repeated_string_flag(args: &[String], key: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        if a == key {
+            if let Some(v) = iter.next() {
+                out.push(v.clone());
+            }
+            continue;
+        }
+        if let Some(v) = a.strip_prefix(&format!("{key}=")) {
+            out.push(v.to_string());
+        }
+    }
+    out
+}
+
 pub(crate) fn split_csv(raw: &str) -> Vec<String> {
     raw.split(',').map(|s| s.trim().to_string()).collect()
 }

--- a/ito-rs/crates/ito-cli/tests/agent_instruction_memory.rs
+++ b/ito-rs/crates/ito-cli/tests/agent_instruction_memory.rs
@@ -1,0 +1,373 @@
+//! Integration tests for the three memory-* agent instruction artifacts.
+//!
+//! Covers all nine cells of the {operation: capture, search, query} ×
+//! {branch: command, skill, not-configured} matrix. Each test sets up a
+//! minimal Ito project root, writes a `.ito/config.json` with the
+//! configuration under test, and asserts on the rendered output.
+
+#[path = "support/mod.rs"]
+mod fixtures;
+
+use ito_test_support::run_rust_candidate;
+use serde_json::json;
+
+fn setup_project_with_memory(memory: serde_json::Value) -> (tempfile::TempDir, tempfile::TempDir) {
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+
+    std::fs::write(repo.path().join("README.md"), "temp\n").expect("write");
+    fixtures::git_init_with_initial_commit(repo.path());
+
+    let cfg = json!({ "memory": memory });
+    fixtures::write(
+        repo.path().join(".ito/config.json"),
+        &(serde_json::to_string_pretty(&cfg).unwrap() + "\n"),
+    );
+    (repo, home)
+}
+
+fn setup_project_without_memory() -> (tempfile::TempDir, tempfile::TempDir) {
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+
+    std::fs::write(repo.path().join("README.md"), "temp\n").expect("write");
+    fixtures::git_init_with_initial_commit(repo.path());
+    fixtures::write(repo.path().join(".ito/config.json"), "{}\n");
+
+    (repo, home)
+}
+
+// ---- memory-capture ---------------------------------------------------------
+
+#[test]
+fn memory_capture_command_branch_renders_executable_command_line() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "capture": {
+            "kind": "command",
+            "command": "brv curate {context} {files} {folders}"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-capture",
+            "--context",
+            "decision X",
+            "--file",
+            "a.md",
+            "--file",
+            "b.md",
+            "--folder",
+            "docs/",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Capture this memory"), "stdout={}", out.stdout);
+    assert!(
+        out.stdout
+            .contains("brv curate 'decision X' --file 'a.md' --file 'b.md' --folder 'docs/'"),
+        "stdout={}",
+        out.stdout
+    );
+}
+
+#[test]
+fn memory_capture_skill_branch_emits_structured_inputs() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "capture": {
+            "kind": "skill",
+            "skill": "ito-memory-markdown",
+            "options": { "root": ".ito/memories" }
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-capture",
+            "--context",
+            "note",
+            "--file",
+            "x.md",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Skill: `ito-memory-markdown`"));
+    assert!(out.stdout.contains("`context` = `\"note\"`"));
+    assert!(out.stdout.contains("`files` = `[\"x.md\"]`"));
+    assert!(out.stdout.contains("\"root\""));
+}
+
+#[test]
+fn memory_capture_not_configured_branch_renders_setup_guidance() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_without_memory();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-capture", "--context", "x"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Memory `capture` is not configured"));
+    assert!(out.stdout.contains("\"kind\": \"command\""));
+    assert!(out.stdout.contains("\"kind\": \"skill\""));
+    assert!(out.stdout.contains("There is no default provider"));
+}
+
+// ---- memory-search ----------------------------------------------------------
+
+#[test]
+fn memory_search_command_branch_substitutes_query_and_default_limit() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "search": {
+            "kind": "command",
+            "command": "brv search {query} --limit {limit}"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-search",
+            "--query",
+            "coordination",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("brv search 'coordination' --limit 10"));
+}
+
+#[test]
+fn memory_search_command_branch_overrides_limit_when_supplied() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "search": {
+            "kind": "command",
+            "command": "brv search {query} --limit {limit}"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-search",
+            "--query",
+            "x",
+            "--limit",
+            "3",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("brv search 'x' --limit 3"));
+}
+
+#[test]
+fn memory_search_skill_branch_emits_structured_inputs() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "search": {
+            "kind": "skill",
+            "skill": "byterover-explore"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-search",
+            "--query",
+            "auth",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Skill: `byterover-explore`"));
+    assert!(out.stdout.contains("`query` = `\"auth\"`"));
+    assert!(out.stdout.contains("`limit` = `10`"));
+}
+
+#[test]
+fn memory_search_not_configured_branch_renders_setup_guidance() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_without_memory();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-search",
+            "--query",
+            "x",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Memory `search` is not configured"));
+}
+
+#[test]
+fn memory_search_requires_query_flag() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_without_memory();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-search"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_ne!(out.code, 0, "expected failure, stdout={}", out.stdout);
+    let combined = format!("{}{}", out.stdout, out.stderr);
+    assert!(
+        combined.contains("--query"),
+        "expected --query mention, combined={combined}"
+    );
+}
+
+// ---- memory-query -----------------------------------------------------------
+
+#[test]
+fn memory_query_command_branch_substitutes_query() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "query": {
+            "kind": "command",
+            "command": "brv query {query}"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "memory-query",
+            "--query",
+            "How does coordination work?",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out
+        .stdout
+        .contains("brv query 'How does coordination work?'"));
+}
+
+#[test]
+fn memory_query_skill_branch_emits_structured_inputs() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "query": {
+            "kind": "skill",
+            "skill": "byterover-explore"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-query", "--query", "auth"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Skill: `byterover-explore`"));
+    assert!(out.stdout.contains("`query` = `\"auth\"`"));
+}
+
+#[test]
+fn memory_query_not_configured_branch_renders_setup_guidance() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_without_memory();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-query", "--query", "x"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Memory `query` is not configured"));
+}
+
+// ---- mixed configurations ---------------------------------------------------
+
+#[test]
+fn memory_capture_renders_skill_when_only_capture_configured() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "capture": {
+            "kind": "skill",
+            "skill": "byterover-explore"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-capture", "--context", "x"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Skill: `byterover-explore`"));
+}
+
+#[test]
+fn memory_query_renders_not_configured_when_only_capture_set() {
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let (repo, home) = setup_project_with_memory(json!({
+        "capture": {
+            "kind": "command",
+            "command": "brv curate {context}"
+        }
+    }));
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["agent", "instruction", "memory-query", "--query", "x"],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Memory `query` is not configured"));
+}

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_agent_instruction_help.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_agent_instruction_help.snap
@@ -10,13 +10,19 @@ Arguments:
   <ARTIFACT>  Artifact id (e.g. bootstrap, apply, proposal)
 
 Options:
-  -c, --change <CHANGE>  Change id (directory name)
-      --no-color         Disable color output
-      --help-all         Print the full CLI reference (equivalent to `ito help --all`)
-      --tool <TOOL>      Tool name for bootstrap (opencode|claude|codex)
-      --schema <SCHEMA>  Workflow schema name
-      --json             Output as JSON
-  -h, --help             Print help
+  -c, --change <CHANGE>    Change id (directory name)
+      --no-color           Disable color output
+      --help-all           Print the full CLI reference (equivalent to `ito help --all`)
+      --tool <TOOL>        Tool name for bootstrap (opencode|claude|codex)
+      --schema <SCHEMA>    Workflow schema name
+      --json               Output as JSON
+      --context <CONTEXT>  Free-form context for `memory-capture`
+      --file <FILE>        File path for `memory-capture` (repeatable)
+      --folder <FOLDER>    Folder path for `memory-capture` (repeatable)
+      --query <QUERY>      Search/query input for `memory-search` and `memory-query`
+      --limit <LIMIT>      Limit for `memory-search` (positive integer)
+      --scope <SCOPE>      Scope for `memory-search`
+  -h, --help               Print help
 
 Artifacts:
   bootstrap                          Generate a tool bootstrap preamble

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_all.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_all.snap
@@ -532,6 +532,24 @@ Options:
       --json
           Output as JSON
 
+      --context <CONTEXT>
+          Free-form context for `memory-capture`
+
+      --file <FILE>
+          File path for `memory-capture` (repeatable)
+
+      --folder <FOLDER>
+          Folder path for `memory-capture` (repeatable)
+
+      --query <QUERY>
+          Search/query input for `memory-search` and `memory-query`
+
+      --limit <LIMIT>
+          Limit for `memory-search` (positive integer)
+
+      --scope <SCOPE>
+          Scope for `memory-search`
+
   -h, --help
           Print help
 

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_subcommand_all.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_subcommand_all.snap
@@ -532,6 +532,24 @@ Options:
       --json
           Output as JSON
 
+      --context <CONTEXT>
+          Free-form context for `memory-capture`
+
+      --file <FILE>
+          File path for `memory-capture` (repeatable)
+
+      --folder <FOLDER>
+          Folder path for `memory-capture` (repeatable)
+
+      --query <QUERY>
+          Search/query input for `memory-search` and `memory-query`
+
+      --limit <LIMIT>
+          Limit for `memory-search` (positive integer)
+
+      --scope <SCOPE>
+          Scope for `memory-search`
+
   -h, --help
           Print help
 

--- a/ito-rs/crates/ito-config/src/config/memory_tests.rs
+++ b/ito-rs/crates/ito-config/src/config/memory_tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+use serde_json::json;
+
+#[test]
+fn memory_default_is_absent_on_ito_config() {
+    let config = ItoConfig::default();
+    assert!(config.memory.is_none());
+}
+
+#[test]
+fn memory_section_round_trips_when_absent() {
+    let json = "{}";
+    let parsed: ItoConfig = serde_json::from_str(json).unwrap();
+    assert!(parsed.memory.is_none());
+
+    let serialized = serde_json::to_string(&parsed).unwrap();
+    assert!(!serialized.contains("memory"));
+}
+
+#[test]
+fn memory_section_accepts_capture_only() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "command", "command": "brv curate \"{context}\"" }
+        }
+    });
+    let parsed: ItoConfig = serde_json::from_value(json).unwrap();
+    let memory = parsed.memory.expect("memory section present");
+
+    assert!(matches!(
+        memory.capture,
+        Some(MemoryOpConfig::Command { ref command }) if command == "brv curate \"{context}\""
+    ));
+    assert!(memory.search.is_none());
+    assert!(memory.query.is_none());
+}
+
+#[test]
+fn memory_section_accepts_skill_with_options() {
+    let json = json!({
+        "memory": {
+            "capture": {
+                "kind": "skill",
+                "skill": "ito-memory-markdown",
+                "options": { "root": ".ito/memories" }
+            }
+        }
+    });
+    let parsed: ItoConfig = serde_json::from_value(json).unwrap();
+    let capture = parsed
+        .memory
+        .expect("memory section present")
+        .capture
+        .expect("capture present");
+
+    match capture {
+        MemoryOpConfig::Skill {
+            skill,
+            options: Some(options),
+        } => {
+            assert_eq!(skill, "ito-memory-markdown");
+            assert_eq!(options.get("root").and_then(|v| v.as_str()), Some(".ito/memories"));
+        }
+        other => panic!("expected Skill variant with options, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_section_skill_options_are_optional() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "skill", "skill": "byterover-explore" }
+        }
+    });
+    let parsed: ItoConfig = serde_json::from_value(json).unwrap();
+    let capture = parsed
+        .memory
+        .expect("memory section present")
+        .capture
+        .expect("capture present");
+
+    match capture {
+        MemoryOpConfig::Skill { skill, options } => {
+            assert_eq!(skill, "byterover-explore");
+            assert!(options.is_none());
+        }
+        other => panic!("expected Skill variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn memory_section_supports_mixed_per_op_shapes() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "skill", "skill": "ito-memory-markdown" },
+            "search":  { "kind": "command", "command": "rg \"{query}\" .ito/memories" },
+            "query":   { "kind": "command", "command": "brv query \"{query}\"" }
+        }
+    });
+    let parsed: ItoConfig = serde_json::from_value(json).unwrap();
+    let memory = parsed.memory.expect("memory section present");
+
+    assert!(matches!(memory.capture, Some(MemoryOpConfig::Skill { .. })));
+    assert!(matches!(memory.search, Some(MemoryOpConfig::Command { .. })));
+    assert!(matches!(memory.query, Some(MemoryOpConfig::Command { .. })));
+}
+
+#[test]
+fn memory_section_round_trips_full_config() {
+    let original = MemoryConfig {
+        capture: Some(MemoryOpConfig::Skill {
+            skill: "ito-memory-markdown".to_string(),
+            options: Some(json!({ "root": ".ito/memories" })),
+        }),
+        search: Some(MemoryOpConfig::Command {
+            command: "brv search \"{query}\" --limit {limit}".to_string(),
+        }),
+        query: Some(MemoryOpConfig::Command {
+            command: "brv query \"{query}\"".to_string(),
+        }),
+    };
+
+    let serialized = serde_json::to_value(&original).unwrap();
+    let roundtripped: MemoryConfig = serde_json::from_value(serialized).unwrap();
+
+    assert!(matches!(
+        roundtripped.capture,
+        Some(MemoryOpConfig::Skill { ref skill, options: Some(_) }) if skill == "ito-memory-markdown"
+    ));
+    assert!(matches!(
+        roundtripped.search,
+        Some(MemoryOpConfig::Command { ref command }) if command.contains("{query}")
+    ));
+    assert!(matches!(roundtripped.query, Some(MemoryOpConfig::Command { .. })));
+}
+
+#[test]
+fn memory_section_omits_absent_ops_when_serialized() {
+    let memory = MemoryConfig {
+        capture: Some(MemoryOpConfig::Command {
+            command: "brv curate \"{context}\"".to_string(),
+        }),
+        search: None,
+        query: None,
+    };
+    let json = serde_json::to_string(&memory).unwrap();
+    assert!(json.contains("\"capture\""));
+    assert!(!json.contains("\"search\""));
+    assert!(!json.contains("\"query\""));
+}
+
+#[test]
+fn memory_op_config_unknown_kind_is_rejected() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "magic", "command": "noop" }
+        }
+    });
+    let result: Result<ItoConfig, _> = serde_json::from_value(json);
+    assert!(result.is_err(), "expected error for unknown kind");
+}
+
+#[test]
+fn memory_op_config_skill_variant_requires_skill_field() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "skill" }
+        }
+    });
+    let result: Result<ItoConfig, _> = serde_json::from_value(json);
+    assert!(result.is_err(), "expected error when skill field missing");
+}
+
+#[test]
+fn memory_op_config_command_variant_requires_command_field() {
+    let json = json!({
+        "memory": {
+            "capture": { "kind": "command" }
+        }
+    });
+    let result: Result<ItoConfig, _> = serde_json::from_value(json);
+    assert!(result.is_err(), "expected error when command field missing");
+}
+
+#[test]
+fn memory_section_unknown_op_key_is_rejected() {
+    let json = json!({
+        "memory": {
+            "curate": { "kind": "command", "command": "noop" }
+        }
+    });
+    let result: Result<ItoConfig, _> = serde_json::from_value(json);
+    assert!(
+        result.is_err(),
+        "expected error for unknown operation key 'curate'"
+    );
+}

--- a/ito-rs/crates/ito-config/src/config/types.rs
+++ b/ito-rs/crates/ito-config/src/config/types.rs
@@ -83,6 +83,76 @@ pub struct ItoConfig {
     #[schemars(default, description = "Backend server configuration (multi-tenant)")]
     /// Backend server configuration for hosting the multi-tenant API.
     pub backend_server: BackendServerConfig,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Agent memory provider configuration (per-operation)")]
+    /// Agent memory provider configuration.
+    ///
+    /// Optional and additive. When absent, all `memory-*` instructions render
+    /// the not-configured branch. Each operation (`capture`, `search`, `query`)
+    /// is configured independently and can pick either a skill delegation or an
+    /// inline command template — see [`MemoryOpConfig`].
+    pub memory: Option<MemoryConfig>,
+}
+
+/// Agent memory configuration — per-operation provider selection.
+///
+/// Memory exposes three operations: `capture` (store / curate), `search`
+/// (structured ranked lookup), and `query` (synthesized natural-language
+/// answer). Each operation is independently optional and chooses its own
+/// shape via [`MemoryOpConfig`].
+///
+/// Unknown operation keys under `memory` are rejected at deserialization
+/// time (`deny_unknown_fields`), so typos like `curate` (instead of
+/// `capture`) surface as validation errors rather than silently disabling
+/// the operation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[schemars(description = "Agent memory provider configuration")]
+pub struct MemoryConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Provider for the `capture` (store / curate) operation")]
+    /// Provider for the `capture` (store / curate) operation.
+    pub capture: Option<MemoryOpConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Provider for the `search` (ranked lookup) operation")]
+    /// Provider for the `search` (ranked lookup) operation.
+    pub search: Option<MemoryOpConfig>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(description = "Provider for the `query` (synthesized answer) operation")]
+    /// Provider for the `query` (synthesized answer) operation.
+    pub query: Option<MemoryOpConfig>,
+}
+
+/// Per-operation memory provider shape.
+///
+/// Each variant is selected by the `kind` discriminator:
+///
+/// - `kind: "skill"` — delegate the operation to an installed skill.
+///   `options` is an opaque JSON value passed through verbatim to the skill;
+///   Ito does not interpret its contents.
+/// - `kind: "command"` — render an inline shell command line by substituting
+///   the operation's input placeholders at instruction-emission time. See
+///   the `agent-memory-abstraction` spec for the placeholder rendering rules.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
+#[schemars(description = "Per-operation memory provider shape")]
+pub enum MemoryOpConfig {
+    /// Delegate the operation to an installed skill.
+    Skill {
+        /// Identifier of an installed skill (resolvable under any known skills directory).
+        skill: String,
+        /// Opaque JSON options passed through verbatim to the skill.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        options: Option<Value>,
+    },
+    /// Render an inline shell command line with placeholder substitution.
+    Command {
+        /// Shell command template with `{placeholder}` substitution markers.
+        command: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1295,3 +1365,7 @@ mod coordination_storage_tests;
 #[cfg(test)]
 #[path = "worktree_init_tests.rs"]
 mod worktree_init_tests;
+
+#[cfg(test)]
+#[path = "memory_tests.rs"]
+mod memory_tests;

--- a/ito-rs/crates/ito-core/src/config.rs
+++ b/ito-rs/crates/ito-core/src/config.rs
@@ -3,13 +3,14 @@
 //! This module provides low-level functions for reading, writing, and
 //! manipulating JSON configuration files with dot-delimited path navigation.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::errors::{CoreError, CoreResult};
 use ito_config::ConfigContext;
 use ito_config::load_cascading_project_config;
 use ito_config::types::{
-    ArchiveMainIntegrationMode, IntegrationMode, RepositoryPersistenceMode, WorktreeStrategy,
+    ArchiveMainIntegrationMode, IntegrationMode, MemoryConfig, MemoryOpConfig,
+    RepositoryPersistenceMode, WorktreeStrategy,
 };
 
 /// Read a JSON config file, returning an empty object if the file doesn't exist.
@@ -267,11 +268,252 @@ pub fn validate_config_value(parts: &[&str], value: &serde_json::Value) -> CoreR
                 )));
             }
         }
+        path
+            if matches!(
+                parts,
+                ["memory", op, "kind"]
+                    if matches!(*op, "capture" | "search" | "query")
+            ) =>
+        {
+            let Some(s) = value.as_str() else {
+                return Err(CoreError::validation(format!(
+                    "Key '{}' requires a string value. Valid values: skill, command",
+                    path,
+                )));
+            };
+            if !matches!(s, "skill" | "command") {
+                return Err(CoreError::validation(format!(
+                    "Invalid value '{}' for key '{}'. Valid values: skill, command",
+                    s, path,
+                )));
+            }
+        }
+        path
+            if matches!(
+                parts,
+                ["memory", op, "skill"]
+                    if matches!(*op, "capture" | "search" | "query")
+            ) =>
+        {
+            let Some(s) = value.as_str() else {
+                return Err(CoreError::validation(format!(
+                    "Key '{}' requires a non-empty string skill id.",
+                    path,
+                )));
+            };
+            if s.trim().is_empty() {
+                return Err(CoreError::validation(format!(
+                    "Invalid value for key '{}'. Provide a non-empty skill id.",
+                    path,
+                )));
+            }
+        }
+        path
+            if matches!(
+                parts,
+                ["memory", op, "command"]
+                    if matches!(*op, "capture" | "search" | "query")
+            ) =>
+        {
+            let Some(s) = value.as_str() else {
+                return Err(CoreError::validation(format!(
+                    "Key '{}' requires a non-empty string command template.",
+                    path,
+                )));
+            };
+            if s.trim().is_empty() {
+                return Err(CoreError::validation(format!(
+                    "Invalid value for key '{}'. Provide a non-empty command template.",
+                    path,
+                )));
+            }
+        }
+        path
+            if matches!(parts, ["memory", op] if matches!(*op, "capture" | "search" | "query")) =>
+        {
+            let op_name = parts[1];
+            return validate_memory_op_value(op_name, value);
+        }
+        path if parts == ["memory"] => {
+            return validate_memory_section_value(value);
+        }
         // Wildcard: config keys are open-ended strings; only enum-constrained
         // keys are validated above. New constrained keys should be added here.
         _ => {}
     }
     Ok(())
+}
+
+/// Validate a structurally-set `memory` section value.
+///
+/// Accepts the leaf values for each operation (`capture`, `search`, `query`).
+/// Unknown operation keys are rejected here so that `ito config set memory <json>`
+/// surfaces typos like `curate` (instead of `capture`) with a clear message.
+fn validate_memory_section_value(value: &serde_json::Value) -> CoreResult<()> {
+    let Some(obj) = value.as_object() else {
+        return Err(CoreError::validation(
+            "Key 'memory' requires an object whose keys are operation names (capture, search, query).",
+        ));
+    };
+    for (key, child) in obj {
+        match key.as_str() {
+            "capture" | "search" | "query" => validate_memory_op_value(key, child)?,
+            other => {
+                return Err(CoreError::validation(format!(
+                    "Unknown memory operation '{}'. Valid keys: capture, search, query.",
+                    other
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a structurally-set `memory.<op>` value.
+///
+/// `op_name` is `capture`, `search`, or `query`.
+fn validate_memory_op_value(op_name: &str, value: &serde_json::Value) -> CoreResult<()> {
+    let Some(obj) = value.as_object() else {
+        return Err(CoreError::validation(format!(
+            "Key 'memory.{}' requires an object describing the provider shape.",
+            op_name
+        )));
+    };
+
+    let Some(kind) = obj.get("kind").and_then(|v| v.as_str()) else {
+        return Err(CoreError::validation(format!(
+            "Key 'memory.{}' must include a string 'kind' field. Valid values: skill, command.",
+            op_name
+        )));
+    };
+
+    match kind {
+        "skill" => match obj.get("skill").and_then(|v| v.as_str()) {
+            Some(s) if !s.trim().is_empty() => Ok(()),
+            _ => Err(CoreError::validation(format!(
+                "Key 'memory.{}.skill' is required and must be a non-empty string when kind is 'skill'.",
+                op_name
+            ))),
+        },
+        "command" => match obj.get("command").and_then(|v| v.as_str()) {
+            Some(s) if !s.trim().is_empty() => Ok(()),
+            _ => Err(CoreError::validation(format!(
+                "Key 'memory.{}.command' is required and must be a non-empty string when kind is 'command'.",
+                op_name
+            ))),
+        },
+        other => Err(CoreError::validation(format!(
+            "Invalid 'kind' value '{}' for 'memory.{}'. Valid values: skill, command.",
+            other, op_name
+        ))),
+    }
+}
+
+/// Validate a deserialized [`MemoryConfig`].
+///
+/// Performs structural checks that serde alone cannot enforce — most notably
+/// that any operation configured with `kind: "skill"` references a skill id
+/// discoverable under one of the supplied search paths.
+///
+/// `search_paths` SHOULD be the list of skills directories returned by
+/// [`known_skills_search_paths`] for the active project.
+///
+/// # Errors
+///
+/// Returns [`CoreError::Validation`] for any operation whose skill id does
+/// not resolve to a directory containing `SKILL.md` under one of the
+/// supplied search paths. Lists the searched paths in the error message.
+pub fn validate_memory_config(
+    config: &MemoryConfig,
+    search_paths: &[PathBuf],
+) -> CoreResult<()> {
+    for (op_name, op) in [
+        ("capture", &config.capture),
+        ("search", &config.search),
+        ("query", &config.query),
+    ] {
+        let Some(MemoryOpConfig::Skill { skill, .. }) = op else {
+            continue;
+        };
+
+        if skill.trim().is_empty() {
+            return Err(CoreError::validation(format!(
+                "Key 'memory.{}.skill' must be a non-empty string when kind is 'skill'.",
+                op_name
+            )));
+        }
+
+        if !skill_id_resolves(skill, search_paths) {
+            let searched = search_paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CoreError::validation(format!(
+                "memory.{op}: skill id '{skill}' was not found under any of the searched skills directories: [{searched}]. Install the skill or correct the id.",
+                op = op_name,
+                skill = skill,
+                searched = if searched.is_empty() { "(none configured)".to_string() } else { searched },
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Return the conventional skills directories Ito searches when resolving a
+/// skill id under [`MemoryOpConfig::Skill`].
+///
+/// Order is deterministic for stable error messages but does not imply any
+/// preference — a skill id matches as soon as any directory contains
+/// `<dir>/<skill-id>/SKILL.md` (or the skill id directly under
+/// `.agents/skills/<group>/<skill-id>/SKILL.md` for the shared layout used
+/// by ByteRover).
+pub fn known_skills_search_paths(project_root: &Path) -> Vec<PathBuf> {
+    [
+        ".agents/skills",
+        ".claude/skills",
+        ".codex/skills",
+        ".opencode/skills",
+        ".pi/skills",
+        ".github/skills",
+    ]
+    .into_iter()
+    .map(|p| project_root.join(p))
+    .collect()
+}
+
+/// Returns `true` if `skill_id` resolves to a directory containing
+/// `SKILL.md` under any of the supplied search paths.
+///
+/// Resolution accepts two layouts:
+/// - **Flat**: `<search-path>/<skill-id>/SKILL.md` (used by `.claude/skills/`,
+///   `.opencode/skills/`, etc.).
+/// - **Grouped**: `<search-path>/<group>/<skill-id>/SKILL.md` (used by
+///   `.agents/skills/<group>/<skill-id>/SKILL.md` — e.g. the ByteRover hub
+///   skills mirrored under `.agents/skills/byterover/`).
+pub fn skill_id_resolves(skill_id: &str, search_paths: &[PathBuf]) -> bool {
+    for base in search_paths {
+        if !base.is_dir() {
+            continue;
+        }
+        // Flat layout.
+        if base.join(skill_id).join("SKILL.md").is_file() {
+            return true;
+        }
+        // Grouped layout — one level deeper.
+        let Ok(entries) = std::fs::read_dir(base) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            if entry.path().join(skill_id).join("SKILL.md").is_file() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn is_valid_branch_name(value: &str) -> bool {
@@ -670,5 +912,167 @@ mod tests {
                 default_branch: "develop".to_string(),
             }
         );
+    }
+
+    // ---- memory config validation ------------------------------------------------
+
+    #[test]
+    fn validate_config_value_rejects_unknown_memory_kind() {
+        let parts = ["memory", "capture", "kind"];
+        let value = json!("delegate");
+        let err = validate_config_value(&parts, &value).expect_err("expected error");
+        let msg = err.to_string();
+        assert!(msg.contains("memory.capture.kind"), "msg = {msg}");
+        assert!(msg.contains("skill") && msg.contains("command"));
+    }
+
+    #[test]
+    fn validate_config_value_accepts_valid_memory_kind() {
+        for op in ["capture", "search", "query"] {
+            let parts = ["memory", op, "kind"];
+            for kind in ["skill", "command"] {
+                assert!(
+                    validate_config_value(&parts, &json!(kind)).is_ok(),
+                    "expected memory.{op}.kind = {kind} to validate"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn validate_config_value_rejects_empty_memory_skill_id() {
+        let parts = ["memory", "search", "skill"];
+        let err = validate_config_value(&parts, &json!("   ")).expect_err("expected error");
+        assert!(
+            err.to_string().contains("memory.search.skill"),
+            "msg = {err}"
+        );
+    }
+
+    #[test]
+    fn validate_config_value_rejects_empty_memory_command_template() {
+        let parts = ["memory", "query", "command"];
+        let err = validate_config_value(&parts, &json!("")).expect_err("expected error");
+        assert!(
+            err.to_string().contains("memory.query.command"),
+            "msg = {err}"
+        );
+    }
+
+    #[test]
+    fn validate_config_value_rejects_unknown_memory_op_key() {
+        let parts = ["memory"];
+        let value = json!({
+            "curate": { "kind": "command", "command": "noop" }
+        });
+        let err = validate_config_value(&parts, &value).expect_err("expected error");
+        let msg = err.to_string();
+        assert!(msg.contains("Unknown memory operation"), "msg = {msg}");
+        assert!(msg.contains("curate"), "msg = {msg}");
+    }
+
+    #[test]
+    fn validate_config_value_rejects_memory_op_missing_required_field() {
+        let parts = ["memory", "capture"];
+
+        let err = validate_config_value(&parts, &json!({ "kind": "skill" }))
+            .expect_err("skill variant requires `skill`");
+        assert!(err.to_string().contains("memory.capture.skill"));
+
+        let err = validate_config_value(&parts, &json!({ "kind": "command" }))
+            .expect_err("command variant requires `command`");
+        assert!(err.to_string().contains("memory.capture.command"));
+    }
+
+    #[test]
+    fn validate_config_value_rejects_memory_op_unknown_kind() {
+        let parts = ["memory", "search"];
+        let err = validate_config_value(
+            &parts,
+            &json!({ "kind": "magic", "command": "noop" }),
+        )
+        .expect_err("expected error");
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid 'kind' value 'magic'"), "msg = {msg}");
+        assert!(msg.contains("memory.search"), "msg = {msg}");
+    }
+
+    #[test]
+    fn validate_memory_config_passes_when_no_skill_provider() {
+        let config = MemoryConfig {
+            capture: Some(MemoryOpConfig::Command {
+                command: "brv curate \"{context}\"".to_string(),
+            }),
+            search: None,
+            query: None,
+        };
+        validate_memory_config(&config, &[]).expect("command-only config should validate");
+    }
+
+    #[test]
+    fn validate_memory_config_passes_when_skill_resolves_in_flat_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let skill_dir = tmp.path().join(".claude/skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "stub").unwrap();
+
+        let config = MemoryConfig {
+            capture: Some(MemoryOpConfig::Skill {
+                skill: "my-skill".to_string(),
+                options: None,
+            }),
+            search: None,
+            query: None,
+        };
+        let paths = known_skills_search_paths(tmp.path());
+        validate_memory_config(&config, &paths).expect("flat skill should resolve");
+    }
+
+    #[test]
+    fn validate_memory_config_passes_when_skill_resolves_in_grouped_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let skill_dir = tmp.path().join(".agents/skills/byterover/byterover-explore");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "stub").unwrap();
+
+        let config = MemoryConfig {
+            capture: Some(MemoryOpConfig::Skill {
+                skill: "byterover-explore".to_string(),
+                options: None,
+            }),
+            search: None,
+            query: None,
+        };
+        let paths = known_skills_search_paths(tmp.path());
+        validate_memory_config(&config, &paths)
+            .expect("grouped skill (.agents/skills/<group>/<id>) should resolve");
+    }
+
+    #[test]
+    fn validate_memory_config_rejects_missing_skill() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = MemoryConfig {
+            capture: None,
+            search: Some(MemoryOpConfig::Skill {
+                skill: "nonexistent".to_string(),
+                options: None,
+            }),
+            query: None,
+        };
+        let paths = known_skills_search_paths(tmp.path());
+        let err = validate_memory_config(&config, &paths)
+            .expect_err("missing skill should fail validation");
+        let msg = err.to_string();
+        assert!(msg.contains("memory.search"), "msg = {msg}");
+        assert!(msg.contains("nonexistent"), "msg = {msg}");
+        // Searched-paths list should include at least one of the conventional dirs.
+        assert!(msg.contains(".agents/skills") || msg.contains(".claude/skills"));
+    }
+
+    #[test]
+    fn skill_id_resolves_returns_false_when_no_paths_exist() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let paths = known_skills_search_paths(tmp.path());
+        assert!(!skill_id_resolves("anything", &paths));
     }
 }

--- a/ito-rs/crates/ito-core/src/config.rs
+++ b/ito-rs/crates/ito-core/src/config.rs
@@ -328,13 +328,12 @@ pub fn validate_config_value(parts: &[&str], value: &serde_json::Value) -> CoreR
                 )));
             }
         }
-        path
-            if matches!(parts, ["memory", op] if matches!(*op, "capture" | "search" | "query")) =>
+        _ if matches!(parts, ["memory", op] if matches!(*op, "capture" | "search" | "query")) =>
         {
             let op_name = parts[1];
             return validate_memory_op_value(op_name, value);
         }
-        path if parts == ["memory"] => {
+        _ if parts == ["memory"] => {
             return validate_memory_section_value(value);
         }
         // Wildcard: config keys are open-ended strings; only enum-constrained

--- a/ito-rs/crates/ito-core/src/config.rs
+++ b/ito-rs/crates/ito-core/src/config.rs
@@ -503,11 +503,15 @@ pub fn skill_id_resolves(skill_id: &str, search_paths: &[PathBuf]) -> bool {
         let Ok(entries) = std::fs::read_dir(base) else {
             continue;
         };
-        for entry in entries.flatten() {
-            if !entry.path().is_dir() {
+        for entry in entries {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            let path = entry.path();
+            if !path.is_dir() {
                 continue;
             }
-            if entry.path().join(skill_id).join("SKILL.md").is_file() {
+            if path.join(skill_id).join("SKILL.md").is_file() {
                 return true;
             }
         }

--- a/ito-rs/crates/ito-core/src/lib.rs
+++ b/ito-rs/crates/ito-core/src/lib.rs
@@ -112,6 +112,9 @@ pub mod installers;
 /// List/query project entities (modules, changes, tasks).
 pub mod list;
 
+/// Agent memory provider resolution and instruction rendering.
+pub mod memory;
+
 /// Filesystem-backed module repository implementation.
 pub mod module_repository;
 

--- a/ito-rs/crates/ito-core/src/memory/mod.rs
+++ b/ito-rs/crates/ito-core/src/memory/mod.rs
@@ -1,0 +1,189 @@
+//! Agent memory provider resolution and instruction rendering.
+//!
+//! Memory in Ito is intentionally provider-agnostic. The user configures one
+//! of three operations (`capture`, `search`, `query`) under
+//! `ItoConfig.memory`; each operation independently picks either an inline
+//! command template or a delegated skill. This module turns those
+//! configurations plus runtime inputs into a [`RenderedInstruction`] that
+//! the agent-facing CLI can print verbatim.
+//!
+//! See `.ito/specs/agent-memory-abstraction/` for the authoritative spec.
+
+use std::collections::BTreeMap;
+
+use ito_config::types::{MemoryConfig, MemoryOpConfig};
+use serde_json::Value;
+
+mod rendering;
+#[cfg(test)]
+mod rendering_tests;
+
+pub use rendering::shell_quote;
+
+/// Default value applied to `memory-search`'s `--limit` flag when the caller
+/// does not supply one.
+pub const DEFAULT_SEARCH_LIMIT: u64 = 10;
+
+/// Inputs accepted by `ito agent instruction memory-capture`.
+#[derive(Debug, Clone, Default)]
+pub struct CaptureInputs {
+    /// Free-form context describing what to remember.
+    pub context: Option<String>,
+    /// Files to include when the configured provider supports file context.
+    pub files: Vec<String>,
+    /// Folders to include when the configured provider supports folder packs.
+    pub folders: Vec<String>,
+}
+
+/// Inputs accepted by `ito agent instruction memory-search`.
+#[derive(Debug, Clone)]
+pub struct SearchInputs {
+    /// Search query (required).
+    pub query: String,
+    /// Maximum results. `None` falls back to [`DEFAULT_SEARCH_LIMIT`].
+    pub limit: Option<u64>,
+    /// Optional path-prefix scope (e.g. `auth/`).
+    pub scope: Option<String>,
+}
+
+/// Inputs accepted by `ito agent instruction memory-query`.
+#[derive(Debug, Clone)]
+pub struct QueryInputs {
+    /// Natural-language question (required).
+    pub query: String,
+}
+
+/// Identifies a memory operation for diagnostics and template rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// `capture` — store / curate a memory.
+    Capture,
+    /// `search` — structured BM25-style ranked lookup.
+    Search,
+    /// `query` — synthesized natural-language answer over stored memory.
+    Query,
+}
+
+impl Operation {
+    /// Lower-case, brv-compatible key for this operation.
+    #[must_use]
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::Capture => "capture",
+            Self::Search => "search",
+            Self::Query => "query",
+        }
+    }
+}
+
+/// Output of resolving and rendering a memory operation.
+///
+/// Three render branches mirror the three states a single operation can be
+/// in (configured-as-command / configured-as-skill / not-configured); see
+/// the `agent-memory-abstraction` spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenderedInstruction {
+    /// Operation is configured with `kind: "command"` — the rendered shell
+    /// command line is ready for the agent to execute.
+    Command {
+        /// Final command line with placeholders substituted.
+        line: String,
+    },
+    /// Operation is configured with `kind: "skill"` — the agent should
+    /// invoke the named skill with the listed inputs and opaque options.
+    Skill {
+        /// Skill identifier as configured.
+        skill_id: String,
+        /// Structured inputs for this operation, named by the operation's
+        /// schema (`context`, `files`, `folders`, `query`, `limit`,
+        /// `scope`).
+        inputs: BTreeMap<String, Value>,
+        /// Opaque per-skill options from configuration.
+        ///
+        /// `None` when no `options` field was supplied; the skill receives
+        /// nothing for it and decides on its own defaults.
+        options: Option<Value>,
+    },
+    /// Operation is not configured — the artifact should print provider
+    /// setup guidance (the caller embeds [`Operation`] context to build a
+    /// useful hint).
+    NotConfigured {
+        /// Which operation is missing.
+        operation: Operation,
+    },
+}
+
+/// Render the `memory-capture` instruction for the given config and inputs.
+///
+/// Returns [`RenderedInstruction::NotConfigured`] when `memory.capture` is
+/// absent, regardless of how `search` and `query` are configured.
+#[must_use]
+pub fn render_capture(
+    config: Option<&MemoryConfig>,
+    inputs: &CaptureInputs,
+) -> RenderedInstruction {
+    let op_cfg = config.and_then(|c| c.capture.as_ref());
+    let Some(op_cfg) = op_cfg else {
+        return RenderedInstruction::NotConfigured {
+            operation: Operation::Capture,
+        };
+    };
+    match op_cfg {
+        MemoryOpConfig::Command { command } => RenderedInstruction::Command {
+            line: rendering::render_capture_command(command, inputs),
+        },
+        MemoryOpConfig::Skill { skill, options } => RenderedInstruction::Skill {
+            skill_id: skill.clone(),
+            inputs: rendering::capture_inputs_as_structured(inputs),
+            options: options.clone(),
+        },
+    }
+}
+
+/// Render the `memory-search` instruction for the given config and inputs.
+#[must_use]
+pub fn render_search(
+    config: Option<&MemoryConfig>,
+    inputs: &SearchInputs,
+) -> RenderedInstruction {
+    let op_cfg = config.and_then(|c| c.search.as_ref());
+    let Some(op_cfg) = op_cfg else {
+        return RenderedInstruction::NotConfigured {
+            operation: Operation::Search,
+        };
+    };
+    match op_cfg {
+        MemoryOpConfig::Command { command } => RenderedInstruction::Command {
+            line: rendering::render_search_command(command, inputs),
+        },
+        MemoryOpConfig::Skill { skill, options } => RenderedInstruction::Skill {
+            skill_id: skill.clone(),
+            inputs: rendering::search_inputs_as_structured(inputs),
+            options: options.clone(),
+        },
+    }
+}
+
+/// Render the `memory-query` instruction for the given config and inputs.
+#[must_use]
+pub fn render_query(
+    config: Option<&MemoryConfig>,
+    inputs: &QueryInputs,
+) -> RenderedInstruction {
+    let op_cfg = config.and_then(|c| c.query.as_ref());
+    let Some(op_cfg) = op_cfg else {
+        return RenderedInstruction::NotConfigured {
+            operation: Operation::Query,
+        };
+    };
+    match op_cfg {
+        MemoryOpConfig::Command { command } => RenderedInstruction::Command {
+            line: rendering::render_query_command(command, inputs),
+        },
+        MemoryOpConfig::Skill { skill, options } => RenderedInstruction::Skill {
+            skill_id: skill.clone(),
+            inputs: rendering::query_inputs_as_structured(inputs),
+            options: options.clone(),
+        },
+    }
+}

--- a/ito-rs/crates/ito-core/src/memory/rendering.rs
+++ b/ito-rs/crates/ito-core/src/memory/rendering.rs
@@ -1,0 +1,192 @@
+//! Placeholder rendering for the `command` shape of memory operations.
+//!
+//! Rules (from the `agent-memory-abstraction` spec):
+//!
+//! - **Scalar string** (`{context}`, `{query}`, `{scope}`) — replaced with
+//!   a single shell-quoted token. Missing values render as the empty
+//!   string.
+//! - **Scalar integer** (`{limit}`) — replaced with the decimal literal,
+//!   or empty when unset and no operation default applies.
+//! - **List** (`{files}`, `{folders}`) — expanded as repeated flags. The
+//!   flag name is fixed by the placeholder name (`{files}` → `--file`,
+//!   `{folders}` → `--folder`). Empty lists render as empty strings.
+//! - **Unknown placeholder** (e.g. `{foo}`) — preserved literally.
+
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use super::{CaptureInputs, DEFAULT_SEARCH_LIMIT, QueryInputs, SearchInputs};
+
+/// POSIX single-quote shell quoting.
+///
+/// Wraps `value` in single quotes and escapes any embedded single quote with
+/// the canonical `'\''` sequence. The empty string renders as `''`. Pasting
+/// the output into a POSIX shell preserves the original byte sequence.
+#[must_use]
+pub fn shell_quote(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('\'');
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Render the `memory-capture` command template with placeholder
+/// substitution.
+pub(super) fn render_capture_command(template: &str, inputs: &CaptureInputs) -> String {
+    let context_quoted = shell_quote(inputs.context.as_deref().unwrap_or(""));
+    let files = render_repeated_flag("--file", &inputs.files);
+    let folders = render_repeated_flag("--folder", &inputs.folders);
+    substitute(template, |name| match name {
+        "context" => Some(context_quoted.clone()),
+        "files" => Some(files.clone()),
+        "folders" => Some(folders.clone()),
+        _ => None,
+    })
+}
+
+/// Render the `memory-search` command template with placeholder
+/// substitution.
+pub(super) fn render_search_command(template: &str, inputs: &SearchInputs) -> String {
+    let query_quoted = shell_quote(&inputs.query);
+    let limit_value = inputs
+        .limit
+        .unwrap_or(DEFAULT_SEARCH_LIMIT)
+        .to_string();
+    let scope_quoted = inputs
+        .scope
+        .as_ref()
+        .map(|s| shell_quote(s))
+        .unwrap_or_default();
+    substitute(template, |name| match name {
+        "query" => Some(query_quoted.clone()),
+        "limit" => Some(limit_value.clone()),
+        "scope" => Some(scope_quoted.clone()),
+        _ => None,
+    })
+}
+
+/// Render the `memory-query` command template with placeholder substitution.
+pub(super) fn render_query_command(template: &str, inputs: &QueryInputs) -> String {
+    let query_quoted = shell_quote(&inputs.query);
+    substitute(template, |name| match name {
+        "query" => Some(query_quoted.clone()),
+        _ => None,
+    })
+}
+
+/// Convert capture inputs to the structured map passed to a delegated skill.
+pub(super) fn capture_inputs_as_structured(inputs: &CaptureInputs) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    out.insert(
+        "context".to_string(),
+        inputs
+            .context
+            .as_ref()
+            .map_or(Value::Null, |s| Value::String(s.clone())),
+    );
+    out.insert("files".to_string(), json!(inputs.files));
+    out.insert("folders".to_string(), json!(inputs.folders));
+    out
+}
+
+/// Convert search inputs to the structured map passed to a delegated skill.
+pub(super) fn search_inputs_as_structured(inputs: &SearchInputs) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    out.insert("query".to_string(), Value::String(inputs.query.clone()));
+    out.insert(
+        "limit".to_string(),
+        Value::Number(inputs.limit.unwrap_or(DEFAULT_SEARCH_LIMIT).into()),
+    );
+    out.insert(
+        "scope".to_string(),
+        inputs
+            .scope
+            .as_ref()
+            .map_or(Value::Null, |s| Value::String(s.clone())),
+    );
+    out
+}
+
+/// Convert query inputs to the structured map passed to a delegated skill.
+pub(super) fn query_inputs_as_structured(inputs: &QueryInputs) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    out.insert("query".to_string(), Value::String(inputs.query.clone()));
+    out
+}
+
+/// Render `--<flag> 'value'` pairs for each value, joined by single spaces.
+/// Empty `values` returns an empty string.
+fn render_repeated_flag(flag: &str, values: &[String]) -> String {
+    let mut out = String::new();
+    for (idx, value) in values.iter().enumerate() {
+        if idx > 0 {
+            out.push(' ');
+        }
+        out.push_str(flag);
+        out.push(' ');
+        out.push_str(&shell_quote(value));
+    }
+    out
+}
+
+/// Walk `template` and replace `{name}` placeholders using `lookup`.
+///
+/// When `lookup(name)` returns `Some(value)`, the entire `{name}` token is
+/// replaced with `value`. When `lookup` returns `None`, the placeholder is
+/// preserved literally (including its braces) — this matches the spec's
+/// "unknown placeholders pass through" rule.
+fn substitute<F>(template: &str, lookup: F) -> String
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let bytes = template.as_bytes();
+    let mut out = String::with_capacity(template.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'{' {
+            // Find a matching closing brace within the same input. We don't
+            // support nested braces — they're not part of the spec.
+            let rest = &template[i + 1..];
+            if let Some(end) = rest.find('}') {
+                let name = &rest[..end];
+                if is_placeholder_name(name) {
+                    if let Some(replacement) = lookup(name) {
+                        out.push_str(&replacement);
+                    } else {
+                        // Unknown placeholder: preserve literally.
+                        out.push('{');
+                        out.push_str(name);
+                        out.push('}');
+                    }
+                    i += 1 + end + 1; // consume "{name}"
+                    continue;
+                }
+            }
+        }
+        // Default: copy this character literally. Use char_indices to handle
+        // multi-byte UTF-8 correctly.
+        let ch = template[i..].chars().next().expect("non-empty by loop guard");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// A valid placeholder name is non-empty and consists only of ASCII
+/// alphanumerics and underscores. This lets the substituter tell the
+/// difference between `{files}` (a placeholder) and `{}` or `{foo bar}`
+/// (literal text).
+fn is_placeholder_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}

--- a/ito-rs/crates/ito-core/src/memory/rendering.rs
+++ b/ito-rs/crates/ito-core/src/memory/rendering.rs
@@ -60,11 +60,10 @@ pub(super) fn render_search_command(template: &str, inputs: &SearchInputs) -> St
         .limit
         .unwrap_or(DEFAULT_SEARCH_LIMIT)
         .to_string();
-    let scope_quoted = inputs
-        .scope
-        .as_ref()
-        .map(|s| shell_quote(s))
-        .unwrap_or_default();
+    // Always shell-quote, even when unset, so flag-prefixed templates like
+    // `--scope {scope}` produce a valid shell token (`--scope ''`) rather
+    // than a dangling flag with no argument. Matches `{context}` semantics.
+    let scope_quoted = shell_quote(inputs.scope.as_deref().unwrap_or(""));
     substitute(template, |name| match name {
         "query" => Some(query_quoted.clone()),
         "limit" => Some(limit_value.clone()),

--- a/ito-rs/crates/ito-core/src/memory/rendering_tests.rs
+++ b/ito-rs/crates/ito-core/src/memory/rendering_tests.rs
@@ -183,14 +183,21 @@ fn search_command_uses_supplied_limit_when_present() {
 }
 
 #[test]
-fn search_command_omits_scope_when_absent() {
-    let cfg = search_command_cfg("brv search {query}{scope}");
+fn search_command_renders_scope_as_empty_quoted_token_when_absent() {
+    // {scope} always shell-quotes — even when unset — so that flag-prefixed
+    // templates like `--scope {scope}` produce a valid shell argument
+    // (`--scope ''`) instead of a dangling flag with no value. This matches
+    // the {context} placeholder's behavior for capture.
+    let cfg = search_command_cfg("brv search {query} --scope {scope}");
     let inputs = SearchInputs {
         query: "x".to_string(),
         limit: None,
         scope: None,
     };
-    assert_command(&render_search(Some(&cfg), &inputs), "brv search 'x'");
+    assert_command(
+        &render_search(Some(&cfg), &inputs),
+        "brv search 'x' --scope ''",
+    );
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/src/memory/rendering_tests.rs
+++ b/ito-rs/crates/ito-core/src/memory/rendering_tests.rs
@@ -1,0 +1,379 @@
+use super::rendering::shell_quote;
+use super::*;
+use ito_config::types::{MemoryConfig, MemoryOpConfig};
+use serde_json::{Value, json};
+
+fn capture_command_cfg(template: &str) -> MemoryConfig {
+    MemoryConfig {
+        capture: Some(MemoryOpConfig::Command {
+            command: template.to_string(),
+        }),
+        search: None,
+        query: None,
+    }
+}
+
+fn search_command_cfg(template: &str) -> MemoryConfig {
+    MemoryConfig {
+        capture: None,
+        search: Some(MemoryOpConfig::Command {
+            command: template.to_string(),
+        }),
+        query: None,
+    }
+}
+
+fn query_command_cfg(template: &str) -> MemoryConfig {
+    MemoryConfig {
+        capture: None,
+        search: None,
+        query: Some(MemoryOpConfig::Command {
+            command: template.to_string(),
+        }),
+    }
+}
+
+#[track_caller]
+fn assert_command(rendered: &RenderedInstruction, expected: &str) {
+    match rendered {
+        RenderedInstruction::Command { line } => assert_eq!(line, expected),
+        other => panic!("expected Command branch, got {other:?}"),
+    }
+}
+
+// ---- Shell quoting ----------------------------------------------------------
+
+#[test]
+fn shell_quote_handles_empty_string() {
+    assert_eq!(shell_quote(""), "''");
+}
+
+#[test]
+fn shell_quote_wraps_simple_strings_in_single_quotes() {
+    assert_eq!(shell_quote("foo"), "'foo'");
+    assert_eq!(shell_quote("foo bar"), "'foo bar'");
+}
+
+#[test]
+fn shell_quote_escapes_embedded_single_quotes() {
+    assert_eq!(shell_quote("it's"), "'it'\\''s'");
+    assert_eq!(shell_quote("'"), "''\\'''");
+}
+
+#[test]
+fn shell_quote_preserves_unicode_bytes() {
+    assert_eq!(shell_quote("naïve résumé"), "'naïve résumé'");
+}
+
+// ---- Placeholder substitution: capture --------------------------------------
+
+#[test]
+fn capture_command_substitutes_context_with_quoting() {
+    let cfg = capture_command_cfg("brv curate {context}");
+    let inputs = CaptureInputs {
+        context: Some("decision X".to_string()),
+        ..Default::default()
+    };
+    assert_command(
+        &render_capture(Some(&cfg), &inputs),
+        "brv curate 'decision X'",
+    );
+}
+
+#[test]
+fn capture_command_substitutes_missing_context_with_empty_quoted_string() {
+    let cfg = capture_command_cfg("brv curate {context}");
+    let inputs = CaptureInputs::default();
+    assert_command(&render_capture(Some(&cfg), &inputs), "brv curate ''");
+}
+
+#[test]
+fn capture_command_expands_files_as_repeated_flags() {
+    let cfg = capture_command_cfg("brv curate {context} {files}");
+    let inputs = CaptureInputs {
+        context: Some("notes".to_string()),
+        files: vec!["a.md".to_string(), "b.md".to_string()],
+        folders: vec![],
+    };
+    assert_command(
+        &render_capture(Some(&cfg), &inputs),
+        "brv curate 'notes' --file 'a.md' --file 'b.md'",
+    );
+}
+
+#[test]
+fn capture_command_expands_folders_with_explicit_flag_name() {
+    let cfg = capture_command_cfg("brv curate {context} {folders}");
+    let inputs = CaptureInputs {
+        context: Some("dir notes".to_string()),
+        folders: vec!["docs/".to_string()],
+        files: vec![],
+    };
+    assert_command(
+        &render_capture(Some(&cfg), &inputs),
+        "brv curate 'dir notes' --folder 'docs/'",
+    );
+}
+
+#[test]
+fn capture_command_empty_lists_render_as_empty_strings() {
+    let cfg = capture_command_cfg("brv curate {context} {files} {folders}");
+    let inputs = CaptureInputs {
+        context: Some("ctx".to_string()),
+        files: vec![],
+        folders: vec![],
+    };
+    assert_command(&render_capture(Some(&cfg), &inputs), "brv curate 'ctx'  ");
+}
+
+#[test]
+fn capture_command_preserves_unknown_placeholders_literally() {
+    let cfg = capture_command_cfg("brv curate {foo} --note {context}");
+    let inputs = CaptureInputs {
+        context: Some("hi".to_string()),
+        ..Default::default()
+    };
+    assert_command(
+        &render_capture(Some(&cfg), &inputs),
+        "brv curate {foo} --note 'hi'",
+    );
+}
+
+#[test]
+fn capture_command_quotes_shell_metacharacters() {
+    let cfg = capture_command_cfg("brv curate {context}");
+    let inputs = CaptureInputs {
+        context: Some("foo $(rm -rf /); echo 'gotcha'".to_string()),
+        ..Default::default()
+    };
+    assert_command(
+        &render_capture(Some(&cfg), &inputs),
+        "brv curate 'foo $(rm -rf /); echo '\\''gotcha'\\'''",
+    );
+}
+
+// ---- Placeholder substitution: search ---------------------------------------
+
+#[test]
+fn search_command_substitutes_query_and_default_limit() {
+    let cfg = search_command_cfg("brv search {query} --limit {limit}");
+    let inputs = SearchInputs {
+        query: "coordination".to_string(),
+        limit: None,
+        scope: None,
+    };
+    assert_command(
+        &render_search(Some(&cfg), &inputs),
+        "brv search 'coordination' --limit 10",
+    );
+}
+
+#[test]
+fn search_command_uses_supplied_limit_when_present() {
+    let cfg = search_command_cfg("brv search {query} --limit {limit}");
+    let inputs = SearchInputs {
+        query: "x".to_string(),
+        limit: Some(3),
+        scope: None,
+    };
+    assert_command(
+        &render_search(Some(&cfg), &inputs),
+        "brv search 'x' --limit 3",
+    );
+}
+
+#[test]
+fn search_command_omits_scope_when_absent() {
+    let cfg = search_command_cfg("brv search {query}{scope}");
+    let inputs = SearchInputs {
+        query: "x".to_string(),
+        limit: None,
+        scope: None,
+    };
+    assert_command(&render_search(Some(&cfg), &inputs), "brv search 'x'");
+}
+
+#[test]
+fn search_command_renders_scope_as_quoted_value() {
+    let cfg = search_command_cfg("brv search {query} --scope {scope}");
+    let inputs = SearchInputs {
+        query: "x".to_string(),
+        limit: None,
+        scope: Some("auth/".to_string()),
+    };
+    assert_command(
+        &render_search(Some(&cfg), &inputs),
+        "brv search 'x' --scope 'auth/'",
+    );
+}
+
+// ---- Placeholder substitution: query ----------------------------------------
+
+#[test]
+fn query_command_substitutes_query() {
+    let cfg = query_command_cfg("brv query {query}");
+    let inputs = QueryInputs {
+        query: "How does coordination work?".to_string(),
+    };
+    assert_command(
+        &render_query(Some(&cfg), &inputs),
+        "brv query 'How does coordination work?'",
+    );
+}
+
+// ---- Skill branch -----------------------------------------------------------
+
+#[test]
+fn capture_skill_emits_structured_inputs_and_options() {
+    let cfg = MemoryConfig {
+        capture: Some(MemoryOpConfig::Skill {
+            skill: "ito-memory-markdown".to_string(),
+            options: Some(json!({ "root": ".ito/memories" })),
+        }),
+        ..Default::default()
+    };
+    let inputs = CaptureInputs {
+        context: Some("decision X".to_string()),
+        files: vec!["a.md".to_string()],
+        folders: vec![],
+    };
+    let rendered = render_capture(Some(&cfg), &inputs);
+    let RenderedInstruction::Skill {
+        skill_id,
+        inputs,
+        options,
+    } = rendered
+    else {
+        panic!("expected Skill branch, got {rendered:?}");
+    };
+    assert_eq!(skill_id, "ito-memory-markdown");
+    assert_eq!(
+        inputs.get("context"),
+        Some(&Value::String("decision X".to_string()))
+    );
+    assert_eq!(inputs.get("files"), Some(&json!(["a.md"])));
+    assert_eq!(inputs.get("folders"), Some(&json!(Vec::<String>::new())));
+    assert_eq!(
+        options,
+        Some(json!({ "root": ".ito/memories" })),
+    );
+}
+
+#[test]
+fn search_skill_includes_default_limit_in_structured_inputs() {
+    let cfg = MemoryConfig {
+        search: Some(MemoryOpConfig::Skill {
+            skill: "byterover-explore".to_string(),
+            options: None,
+        }),
+        ..Default::default()
+    };
+    let inputs = SearchInputs {
+        query: "coordination".to_string(),
+        limit: None,
+        scope: None,
+    };
+    let rendered = render_search(Some(&cfg), &inputs);
+    let RenderedInstruction::Skill {
+        skill_id,
+        inputs,
+        options,
+    } = rendered
+    else {
+        panic!("expected Skill branch, got {rendered:?}");
+    };
+    assert_eq!(skill_id, "byterover-explore");
+    assert_eq!(
+        inputs.get("query"),
+        Some(&Value::String("coordination".to_string()))
+    );
+    assert_eq!(inputs.get("limit"), Some(&json!(10)));
+    assert_eq!(inputs.get("scope"), Some(&Value::Null));
+    assert!(options.is_none());
+}
+
+// ---- Not-configured branch --------------------------------------------------
+
+#[test]
+fn capture_not_configured_when_memory_section_absent() {
+    let rendered = render_capture(None, &CaptureInputs::default());
+    assert_eq!(
+        rendered,
+        RenderedInstruction::NotConfigured {
+            operation: Operation::Capture
+        }
+    );
+}
+
+#[test]
+fn capture_not_configured_when_only_search_is_set() {
+    let cfg = search_command_cfg("brv search {query}");
+    let rendered = render_capture(Some(&cfg), &CaptureInputs::default());
+    assert_eq!(
+        rendered,
+        RenderedInstruction::NotConfigured {
+            operation: Operation::Capture
+        }
+    );
+}
+
+#[test]
+fn search_not_configured_when_only_capture_is_set() {
+    let cfg = capture_command_cfg("brv curate {context}");
+    let rendered = render_search(
+        Some(&cfg),
+        &SearchInputs {
+            query: "x".to_string(),
+            limit: None,
+            scope: None,
+        },
+    );
+    assert_eq!(
+        rendered,
+        RenderedInstruction::NotConfigured {
+            operation: Operation::Search
+        }
+    );
+}
+
+// ---- Mixed shapes -----------------------------------------------------------
+
+#[test]
+fn mixed_shapes_render_independently() {
+    let cfg = MemoryConfig {
+        capture: Some(MemoryOpConfig::Skill {
+            skill: "ito-memory-markdown".to_string(),
+            options: None,
+        }),
+        search: Some(MemoryOpConfig::Command {
+            command: "rg {query} .ito/memories".to_string(),
+        }),
+        query: None,
+    };
+    assert!(matches!(
+        render_capture(Some(&cfg), &CaptureInputs::default()),
+        RenderedInstruction::Skill { .. }
+    ));
+    assert!(matches!(
+        render_search(
+            Some(&cfg),
+            &SearchInputs {
+                query: "auth".to_string(),
+                limit: None,
+                scope: None
+            }
+        ),
+        RenderedInstruction::Command { .. }
+    ));
+    assert!(matches!(
+        render_query(
+            Some(&cfg),
+            &QueryInputs {
+                query: "anything".to_string()
+            }
+        ),
+        RenderedInstruction::NotConfigured {
+            operation: Operation::Query
+        }
+    ));
+}

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -208,6 +208,27 @@ CHANGE_NAME='{{ instructions.changeName | replace("'", "'\"'\"'") }}'
 ito agent instruction finish --change "$CHANGE_NAME"
 ```
 {% endif %}
+{% if memory.capture.configured %}
+
+### Capture memories
+
+Before reporting completion, review what you learned during this change and
+capture anything worth remembering across sessions: design decisions and the
+reasons behind them, non-obvious gotchas, recurring patterns, and architectural
+rationale that the next agent (or you next time) would want to find.
+
+For each item, run the configured memory provider via:
+
+```bash
+ito agent instruction memory-capture \
+  --context "<one-paragraph summary of what to remember>" \
+  --file <path>            # repeatable; include reference files
+  --folder <path>          # repeatable; include reference folders
+```
+
+Ito will render the configured `command` template (or skill delegation) with
+the inputs you provide.
+{% endif %}
 
 {% if user_guidance %}
 ### User Guidance

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/finish.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/finish.md.j2
@@ -112,3 +112,31 @@ git -C "$PROJECT_ROOT" branch -d "$CHANGE_NAME"
 # git -C "$PROJECT_ROOT" push origin --delete "$CHANGE_NAME"
 ```
 {% endif %}
+{% if memory.capture.configured %}
+
+### Capture memories
+
+Before closing this change out, review what you learned and capture anything
+worth remembering across sessions: design decisions and rationale, non-obvious
+gotchas, recurring patterns, and architectural notes the next agent will want
+to surface.
+
+For each item, run the configured memory provider via:
+
+```bash
+ito agent instruction memory-capture \
+  --context "<one-paragraph summary of what to remember>" \
+  --file <path>            # repeatable
+  --folder <path>          # repeatable
+```
+{% endif %}
+
+### Refresh archive and specs
+
+Before declaring the change finished, walk the wrap-up checklist:
+
+{% if not archive_prompt_rendered %}
+- **Archive**: confirm `ito archive {% if change and change|trim != "" %}{{ change }}{% else %}<change-name>{% endif %} --yes` has run; if not, run it now.
+{% endif %}
+- **Specs**: open `.ito/specs/` and confirm the canonical specs reflect this change. Spec deltas under `.ito/changes/<change-id>/specs/` should already have been merged in by `ito archive`; if anything still looks out of date, fix it before reporting completion.
+- **Docs**: confirm agent-facing docs (`AGENTS.md`, `.ito/AGENTS.md`, harness-specific files) are up to date with whatever capability or behavior this change introduced.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -391,6 +391,22 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
     }
 
     #[derive(Serialize)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+    impl Default for MemoryOpState {
+        fn default() -> Self {
+            Self { configured: false }
+        }
+    }
+
+    #[derive(Serialize)]
     struct Ctx {
         instructions: InstructionsCtx,
         context_files: Vec<&'static str>,
@@ -399,6 +415,7 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
         tracking_warnings: Vec<&'static str>,
         testing_policy: TestingPolicyCtx,
         user_guidance: &'static str,
+        memory: MemoryCtx,
     }
 
     let ctx = Ctx {
@@ -435,6 +452,7 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
             coverage_target_percent: 80,
         },
         user_guidance: "",
+        memory: MemoryCtx::default(),
     };
 
     let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
@@ -584,11 +602,24 @@ fn finish_template_prompts_for_archive() {
         coordination_storage: &'static str,
     }
 
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+
     #[derive(Serialize)]
     struct Ctx {
         worktree: Worktree,
         archive: ArchiveCfg,
+        memory: MemoryCtx,
         change: Option<String>,
+        archive_prompt_rendered: bool,
     }
 
     let out = render_instruction_template(
@@ -604,7 +635,9 @@ fn finish_template_prompts_for_archive() {
                 main_integration_mode: "pull_request",
                 coordination_storage: "worktree",
             },
+            memory: MemoryCtx::default(),
             change: Some("025-09_add-worktree-sync-command".to_string()),
+            archive_prompt_rendered: true,
         },
     )
     .unwrap();
@@ -616,4 +649,359 @@ fn finish_template_prompts_for_archive() {
         out.contains("ito agent instruction archive --change '025-09_add-worktree-sync-command'")
     );
     assert!(out.contains("`changes.archive.main_integration_mode`: `pull_request`"));
+    // Wrap-up reminder always renders specs/docs checks; archive is suppressed
+    // because the existing archive prompt covers it.
+    assert!(out.contains("### Refresh archive and specs"));
+    assert!(out.contains("**Specs**:"));
+    assert!(out.contains("**Docs**:"));
+    assert!(
+        !out.contains("**Archive**:"),
+        "archive item must be suppressed when prompt is rendered"
+    );
+    // Memory capture reminder is keyed on memory.capture.configured.
+    assert!(
+        !out.contains("### Capture memories"),
+        "capture reminder must be absent when memory.capture is unconfigured"
+    );
+}
+
+#[test]
+fn finish_template_includes_capture_reminder_when_memory_capture_configured() {
+    #[derive(Serialize)]
+    struct Worktree {
+        enabled: bool,
+        strategy: &'static str,
+        layout_dir_name: &'static str,
+        default_branch: &'static str,
+    }
+    #[derive(Serialize)]
+    struct ArchiveCfg {
+        main_integration_mode: &'static str,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        worktree: Worktree,
+        archive: ArchiveCfg,
+        memory: MemoryCtx,
+        change: Option<String>,
+        archive_prompt_rendered: bool,
+    }
+
+    let out = render_instruction_template(
+        "agent/finish.md.j2",
+        &Ctx {
+            worktree: Worktree {
+                enabled: true,
+                strategy: "bare_control_siblings",
+                layout_dir_name: "ito-worktrees",
+                default_branch: "main",
+            },
+            archive: ArchiveCfg {
+                main_integration_mode: "pull_request",
+            },
+            memory: MemoryCtx {
+                capture: MemoryOpState { configured: true },
+                ..Default::default()
+            },
+            change: Some("000-01_test-change".to_string()),
+            archive_prompt_rendered: true,
+        },
+    )
+    .unwrap();
+
+    assert!(out.contains("### Capture memories"));
+    assert!(out.contains("ito agent instruction memory-capture"));
+    assert!(out.contains("### Refresh archive and specs"));
+}
+
+#[test]
+fn finish_template_includes_archive_check_when_prompt_suppressed() {
+    #[derive(Serialize)]
+    struct Worktree {
+        enabled: bool,
+        strategy: &'static str,
+        layout_dir_name: &'static str,
+        default_branch: &'static str,
+    }
+    #[derive(Serialize)]
+    struct ArchiveCfg {
+        main_integration_mode: &'static str,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        worktree: Worktree,
+        archive: ArchiveCfg,
+        memory: MemoryCtx,
+        change: Option<String>,
+        archive_prompt_rendered: bool,
+    }
+
+    let out = render_instruction_template(
+        "agent/finish.md.j2",
+        &Ctx {
+            worktree: Worktree {
+                enabled: true,
+                strategy: "bare_control_siblings",
+                layout_dir_name: "ito-worktrees",
+                default_branch: "main",
+            },
+            archive: ArchiveCfg {
+                main_integration_mode: "pull_request",
+            },
+            memory: MemoryCtx::default(),
+            change: Some("000-01_test-change".to_string()),
+            archive_prompt_rendered: false,
+        },
+    )
+    .unwrap();
+
+    assert!(out.contains("**Archive**:"));
+    assert!(out.contains("**Specs**:"));
+    assert!(out.contains("**Docs**:"));
+}
+
+#[test]
+fn apply_template_renders_capture_reminder_when_configured() {
+    use std::collections::BTreeMap;
+
+    #[derive(Serialize)]
+    struct ProgressCtx {
+        total: u64,
+        complete: u64,
+    }
+    #[derive(Serialize)]
+    struct InstructionsCtx {
+        #[serde(rename = "changeName")]
+        change_name: &'static str,
+        #[serde(rename = "schemaName")]
+        schema_name: &'static str,
+        state: &'static str,
+        #[serde(rename = "missingArtifacts")]
+        missing_artifacts: Vec<&'static str>,
+        instruction: &'static str,
+        #[serde(rename = "tracksFile")]
+        tracks_file: bool,
+        #[serde(rename = "tracksPath")]
+        tracks_path: &'static str,
+        #[serde(rename = "tracksFormat")]
+        tracks_format: &'static str,
+        progress: ProgressCtx,
+        tasks: Vec<&'static str>,
+    }
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+        apply_enabled: bool,
+        strategy: &'static str,
+        default_branch: &'static str,
+        layout_dir_name: &'static str,
+        integration_mode: &'static str,
+        copy_from_main: Vec<&'static str>,
+        setup_commands: Vec<&'static str>,
+    }
+    #[derive(Serialize)]
+    struct TestingPolicyCtx {
+        tdd_workflow: &'static str,
+        coverage_target_percent: u64,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+    #[derive(Serialize)]
+    struct Ctx {
+        instructions: InstructionsCtx,
+        context_files: Vec<&'static str>,
+        worktree: WorktreeCtx,
+        tracking_errors: Vec<&'static str>,
+        tracking_warnings: Vec<&'static str>,
+        testing_policy: TestingPolicyCtx,
+        user_guidance: &'static str,
+        memory: MemoryCtx,
+    }
+
+    let _ = BTreeMap::<String, String>::new();
+
+    let ctx = Ctx {
+        instructions: InstructionsCtx {
+            change_name: "029-02_agent-memory-abstraction",
+            schema_name: "spec-driven",
+            state: "ready",
+            missing_artifacts: Vec::new(),
+            instruction: "Implement.",
+            tracks_file: false,
+            tracks_path: "",
+            tracks_format: "",
+            progress: ProgressCtx {
+                total: 0,
+                complete: 0,
+            },
+            tasks: Vec::new(),
+        },
+        context_files: Vec::new(),
+        worktree: WorktreeCtx {
+            enabled: true,
+            apply_enabled: true,
+            strategy: "bare_control_siblings",
+            default_branch: "main",
+            layout_dir_name: "ito-worktrees",
+            integration_mode: "commit_pr",
+            copy_from_main: Vec::new(),
+            setup_commands: Vec::new(),
+        },
+        tracking_errors: Vec::new(),
+        tracking_warnings: Vec::new(),
+        testing_policy: TestingPolicyCtx {
+            tdd_workflow: "red-green-refactor",
+            coverage_target_percent: 80,
+        },
+        user_guidance: "",
+        memory: MemoryCtx {
+            capture: MemoryOpState { configured: true },
+            ..Default::default()
+        },
+    };
+
+    let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert!(out.contains("### Capture memories"));
+    assert!(out.contains("ito agent instruction memory-capture"));
+}
+
+#[test]
+fn apply_template_omits_capture_reminder_when_search_only_configured() {
+    #[derive(Serialize)]
+    struct ProgressCtx {
+        total: u64,
+        complete: u64,
+    }
+    #[derive(Serialize)]
+    struct InstructionsCtx {
+        #[serde(rename = "changeName")]
+        change_name: &'static str,
+        #[serde(rename = "schemaName")]
+        schema_name: &'static str,
+        state: &'static str,
+        #[serde(rename = "missingArtifacts")]
+        missing_artifacts: Vec<&'static str>,
+        instruction: &'static str,
+        #[serde(rename = "tracksFile")]
+        tracks_file: bool,
+        #[serde(rename = "tracksPath")]
+        tracks_path: &'static str,
+        #[serde(rename = "tracksFormat")]
+        tracks_format: &'static str,
+        progress: ProgressCtx,
+        tasks: Vec<&'static str>,
+    }
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+        apply_enabled: bool,
+        strategy: &'static str,
+        default_branch: &'static str,
+        layout_dir_name: &'static str,
+        integration_mode: &'static str,
+        copy_from_main: Vec<&'static str>,
+        setup_commands: Vec<&'static str>,
+    }
+    #[derive(Serialize)]
+    struct TestingPolicyCtx {
+        tdd_workflow: &'static str,
+        coverage_target_percent: u64,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+    #[derive(Serialize)]
+    struct Ctx {
+        instructions: InstructionsCtx,
+        context_files: Vec<&'static str>,
+        worktree: WorktreeCtx,
+        tracking_errors: Vec<&'static str>,
+        tracking_warnings: Vec<&'static str>,
+        testing_policy: TestingPolicyCtx,
+        user_guidance: &'static str,
+        memory: MemoryCtx,
+    }
+
+    let ctx = Ctx {
+        instructions: InstructionsCtx {
+            change_name: "test",
+            schema_name: "spec-driven",
+            state: "ready",
+            missing_artifacts: Vec::new(),
+            instruction: "Implement.",
+            tracks_file: false,
+            tracks_path: "",
+            tracks_format: "",
+            progress: ProgressCtx {
+                total: 0,
+                complete: 0,
+            },
+            tasks: Vec::new(),
+        },
+        context_files: Vec::new(),
+        worktree: WorktreeCtx {
+            enabled: true,
+            apply_enabled: true,
+            strategy: "bare_control_siblings",
+            default_branch: "main",
+            layout_dir_name: "ito-worktrees",
+            integration_mode: "commit_pr",
+            copy_from_main: Vec::new(),
+            setup_commands: Vec::new(),
+        },
+        tracking_errors: Vec::new(),
+        tracking_warnings: Vec::new(),
+        testing_policy: TestingPolicyCtx {
+            tdd_workflow: "red-green-refactor",
+            coverage_target_percent: 80,
+        },
+        user_guidance: "",
+        memory: MemoryCtx {
+            search: MemoryOpState { configured: true },
+            ..Default::default()
+        },
+    };
+
+    let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert!(
+        !out.contains("### Capture memories"),
+        "capture reminder must be absent when only search is configured"
+    );
 }

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -677,6 +677,7 @@ fn finish_template_includes_capture_reminder_when_memory_capture_configured() {
     #[derive(Serialize)]
     struct ArchiveCfg {
         main_integration_mode: &'static str,
+        coordination_storage: &'static str,
     }
     #[derive(Serialize, Default)]
     struct MemoryOpState {
@@ -709,6 +710,7 @@ fn finish_template_includes_capture_reminder_when_memory_capture_configured() {
             },
             archive: ArchiveCfg {
                 main_integration_mode: "pull_request",
+                coordination_storage: "worktree",
             },
             memory: MemoryCtx {
                 capture: MemoryOpState { configured: true },
@@ -737,6 +739,7 @@ fn finish_template_includes_archive_check_when_prompt_suppressed() {
     #[derive(Serialize)]
     struct ArchiveCfg {
         main_integration_mode: &'static str,
+        coordination_storage: &'static str,
     }
     #[derive(Serialize, Default)]
     struct MemoryOpState {
@@ -769,6 +772,7 @@ fn finish_template_includes_archive_check_when_prompt_suppressed() {
             },
             archive: ArchiveCfg {
                 main_integration_mode: "pull_request",
+                coordination_storage: "worktree",
             },
             memory: MemoryCtx::default(),
             change: Some("000-01_test-change".to_string()),

--- a/schemas/ito-config.schema.json
+++ b/schemas/ito-config.schema.json
@@ -918,6 +918,96 @@
       },
       "type": "object"
     },
+    "MemoryConfig": {
+      "additionalProperties": false,
+      "description": "Agent memory provider configuration",
+      "properties": {
+        "capture": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MemoryOpConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Provider for the `capture` (store / curate) operation"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MemoryOpConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Provider for the `query` (synthesized answer) operation"
+        },
+        "search": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MemoryOpConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Provider for the `search` (ranked lookup) operation"
+        }
+      },
+      "type": "object"
+    },
+    "MemoryOpConfig": {
+      "description": "Per-operation memory provider shape",
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "description": "Delegate the operation to an installed skill.",
+          "properties": {
+            "kind": {
+              "enum": [
+                "skill"
+              ],
+              "type": "string"
+            },
+            "options": {
+              "description": "Opaque JSON options passed through verbatim to the skill."
+            },
+            "skill": {
+              "description": "Identifier of an installed skill (resolvable under any known skills directory).",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "skill"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "description": "Render an inline shell command line with placeholder substitution.",
+          "properties": {
+            "command": {
+              "description": "Shell command template with `{placeholder}` substitution markers.",
+              "type": "string"
+            },
+            "kind": {
+              "enum": [
+                "command"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "command",
+            "kind"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "OpenCodeHarnessConfig": {
       "description": "OpenCode harness configuration",
       "properties": {
@@ -1585,6 +1675,17 @@
         }
       },
       "description": "Logging configuration"
+    },
+    "memory": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/MemoryConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Agent memory provider configuration (per-operation)"
     },
     "projectPath": {
       "default": null,


### PR DESCRIPTION
## Summary

Makes agent memory a first-class, provider-agnostic concept in Ito. Adds a per-operation `memory` config section, three new `ito agent instruction memory-*` artifacts, and apply/finish reminders that surface memory operations to agents. **No default provider** — projects opt in by configuring `memory.capture`, `memory.search`, or `memory.query` independently.

## What landed

### Wave 1 — Config & validation
- New `memory` section under `ItoConfig`, optional and additive.
- `MemoryConfig { capture, search, query: Option<MemoryOpConfig> }` with `deny_unknown_fields` so typos like `curate` (instead of `capture`) are rejected.
- `MemoryOpConfig` is a tagged enum with two variants:
  - `{ kind: "skill", skill, options? }` — delegate to an installed skill.
  - `{ kind: "command", command }` — render an inline shell template.
- Path-keyed branches in `validate_config_value` for friendly errors when setting memory leaves via `ito config set`.
- `validate_memory_config` for structural skill discoverability checks (flat `<dir>/<id>/SKILL.md` and grouped `<dir>/<group>/<id>/SKILL.md` layouts; covers `.agents`, `.claude`, `.codex`, `.opencode`, `.pi`, `.github`).

### Wave 2 — Resolver + CLI artifacts
- `ito_core::memory` module: `render_capture` / `render_search` / `render_query` produce `RenderedInstruction` (Command / Skill / NotConfigured) keyed only on each operation's own config.
- Placeholder rendering rules:
  - `{context}`, `{query}`, `{scope}` — POSIX shell-quoted.
  - `{limit}` — decimal int (default 10 for memory-search).
  - `{files}` / `{folders}` — repeated-flag expansion (`--file 'a' --file 'b'` / `--folder 'x'`).
  - Unknown placeholders preserved literally.
- Three new artifacts:
  - `ito agent instruction memory-capture --context ... --file ... --folder ...`
  - `ito agent instruction memory-search --query ... --limit N --scope ...`
  - `ito agent instruction memory-query --query ...`
- 22 unit tests for the resolver + 13 CLI integration tests covering the full 3×3 (operation × branch) grid.

### Wave 3 — Apply / finish reminders
- `apply.md.j2` appends a *Capture memories* section guarded by `{% if memory.capture.configured %}`.
- `finish.md.j2` appends:
  - The same *Capture memories* reminder.
  - A *Refresh archive and specs* wrap-up reminder. The Archive item is gated on `archive_prompt_rendered` so finish never double-prompts; Specs and Docs items always render.
- Render contexts plumb `memory: MemoryTemplateConfig { capture/search/query.configured }` through both apply and finish.
- 4 new template render tests covering capture-configured / not-configured branches and the archive-prompt-suppressed case.

### Wave 4 — Docs
- New *Agent memory* subsection in `docs/config.md` covering operations, shapes, placeholder rendering rules, worked examples (command + skill, including a mixed-shape one), and how apply/finish reminders behave. Examples avoid hard-coding any specific backend in normative prose; `brv` appears only as a cross-reference.

### Refactor
- Moved `MemoryTemplateConfig` helpers out of `instructions.rs` into `memory_instructions.rs` to keep `instructions.rs` under the workspace 1200-line hard limit (enforced by `tests/source_file_size.rs`).

## Verification

- `ito validate 029-02_agent-memory-abstraction --strict` — passes.
- `make config-schema-check` — passes.
- `cargo test --workspace --exclude ito-web` — 1898 pass.
- `cargo clippy -p ito-core --tests` — clean for new code (pre-existing hits in unrelated `orchestrate/` modules unchanged).

## Module 029 — agent-memory

This is the second of two changes under `029_agent-memory`:

- `029-01_add-byterover-integration` (merged in #206).
- `029-02_agent-memory-abstraction` (this PR).

A fresh project still has no memory configured. Projects that already ran 029-01 can opt in by adding e.g.:

```jsonc
{
  "memory": {
    "capture": { "kind": "command", "command": "brv curate \"{context}\" {files} {folders}" },
    "search":  { "kind": "command", "command": "brv search \"{query}\" --limit {limit}" },
    "query":   { "kind": "command", "command": "brv query \"{query}\"" }
  }
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent memory configuration system supporting three operations: capture, search, and query
  * Introduced CLI commands `memory-capture`, `memory-search`, and `memory-query` with configurable inputs (context, files, folders, query, limit, scope)
  * Support for two provider types: inline command templates and skill delegation
  * Enhanced agent instructions to prompt for memory capture during workflow

* **Documentation**
  * Added comprehensive memory configuration guide with placeholder rendering rules and provider setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->