### PR TITLE
fix(templates): enforce worktree write isolation

### DIFF
--- a/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
@@ -44,7 +44,8 @@ Use `ito path ...` to get absolute paths at runtime (do not hardcode absolute pa
 
 Worktree rules:
 
-- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no Ito change ID exists yet, create a temporary proposal worktree first, run change creation there, then move into the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse one worktree for two changes.
 - If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -30,7 +30,8 @@ Strategy: `{{ worktree.strategy }}` | Default branch: `{{ worktree.default_branc
 
 Worktree rules for this change:
 
-- Keep the main/control checkout clean; do not implement change work there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Before any write operation, create the dedicated worktree for this change or move into it.
 - Use the full change ID as the branch and primary worktree directory name: `{{ instructions.changeName }}`.
 - Do not reuse one worktree for two changes.
 - Additional worktrees for this same change must start with `{{ instructions.changeName }}` and add a suffix, for example `{{ instructions.changeName }}-review`.
@@ -123,7 +124,7 @@ cd "$CHANGE_DIR"
 {% elif worktree.enabled and not worktree.apply_enabled %}
 ### Worktree Mode
 
-Worktrees are enabled but apply-time setup is disabled. Work in your current directory.
+Worktrees are enabled but apply-time setup is disabled. Do not write from the main/control checkout. Move into the dedicated change worktree before any write operation, or create it manually using `ito agent instruction worktrees`.
 
 {% endif %}
 {% if instructions.tracksFile and instructions.tracksPath %}
@@ -189,15 +190,13 @@ git push -u origin "$CHANGE_NAME"
 gh pr create --title "feat($CHANGE_ID): <short summary>" --body "Implements change $CHANGE_NAME"
 ```
 {% elif worktree.integration_mode == "merge_parent" %}
-Mode: **Merge into Parent** — commit on the change branch, then merge into `{{ worktree.default_branch }}`.
+Mode: **Merge into Parent** — commit on the change branch, then merge using a separate integration worktree or PR flow. Do not merge from the main/control checkout.
 
 ```bash
 CHANGE_NAME='{{ instructions.changeName | replace("'", "'\"'\"'") }}'
 CHANGE_DIR="$(ito path worktree --change "$CHANGE_NAME")"
 cd "$CHANGE_DIR"
 git add -A && git commit -m "feat: $CHANGE_NAME"
-cd "$(ito path worktree --main)"
-git merge "$CHANGE_NAME"
 ```
 {% else %}
 Mode: `{{ worktree.integration_mode }}` (unrecognized). Set to `commit_pr` or `merge_parent`:

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -119,15 +119,22 @@ Sub-modules group related changes within a module. Sub-module IDs use the format
 Only proceed here after the user has confirmed their module (or sub-module) choice.
 
 {% if worktree is defined and worktree.enabled %}
-Create the change ID first, then create and use a **new** worktree before editing proposal artifacts:
+Before running any command that writes proposal artifacts, create and use a **new** worktree. If the final Ito change ID is not allocated yet, start in a temporary proposal worktree, create the change there, then move into the final change worktree before editing generated artifacts:
 
-- Keep the main/control checkout clean; do not edit proposal, spec, design, or task files there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Do not run `ito create change` from the main/control checkout. Run it from the temporary proposal worktree or from the final change worktree.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse a worktree from another change.
 - If you need more than one worktree for the same change, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
 {% endif %}
 
 ```bash
+{% if worktree is defined and worktree.enabled %}
+# If the final change ID is not known yet, create a temporary proposal worktree first.
+git worktree add "../{{ worktree.layout_dir_name | default(value="ito-worktrees") }}/proposal-<short-name>" -b "proposal-<short-name>" {{ worktree.default_branch | default(value="main") }}
+cd "../{{ worktree.layout_dir_name | default(value="ito-worktrees") }}/proposal-<short-name>"
+
+{% endif %}
 # For a regular module:
 ito create change "<change-name>" --module <module-id> --schema <schema>
 

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
@@ -15,7 +15,8 @@ Run the following to create and initialize the dedicated change worktree (idempo
 
 Worktree rules:
 
-- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no Ito change ID exists yet, create a temporary proposal worktree first, run change creation there, then move into the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name.
 - Do not reuse one worktree for two changes.
 - Extra worktrees for the same change must start with the full change ID and add a suffix.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
@@ -49,7 +49,8 @@ Use the commands below for the configured strategy.
 
 Change worktree rules:
 
-- Keep the main/control checkout clean; do not create proposals or implement changes there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no Ito change ID exists yet, create a temporary proposal worktree first, run change creation there, then move into the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse one worktree for two changes.
 - If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
@@ -132,7 +133,7 @@ git -C "$PROJECT_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANC
 {% if worktree.integration_mode == "commit_pr" %}
 Commit on the worktree branch, push, and open a PR into `{{ worktree.default_branch }}`.
 {% elif worktree.integration_mode == "merge_parent" %}
-Commit on the worktree branch, then merge into `{{ worktree.default_branch }}`.
+Commit on the worktree branch, then merge using a separate integration worktree or PR flow. Do not merge from the main/control checkout.
 {% endif %}
 
 #### Cleanup

--- a/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
@@ -19,7 +19,8 @@ Git worktrees create isolated workspaces that share the same repository, allowin
 
 ## Change Worktree Rules
 
-- Keep the main/control checkout clean; do not create proposal artifacts or implement change work there.
+- Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
+- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no Ito change ID exists yet, create a temporary proposal worktree first, run change creation there, then move into the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse one worktree for two changes.
 - If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -2,6 +2,24 @@ use super::*;
 
 use serde::Serialize;
 
+const READ_ONLY_MAIN_RULE: &str = "Treat the main/control checkout";
+const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create a dedicated change worktree or move into the existing worktree for that change";
+const BEFORE_WRITE_THIS_CHANGE_RULE: &str =
+    "Before any write operation, create the dedicated worktree for this change or move into it";
+const NO_MAIN_WRITE_RULE: &str = "Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work";
+
+fn assert_main_worktree_guardrails(text: &str) {
+    assert!(text.contains(READ_ONLY_MAIN_RULE));
+    assert!(text.contains(BEFORE_WRITE_WORKTREE_RULE));
+    assert!(text.contains(NO_MAIN_WRITE_RULE));
+}
+
+fn assert_change_worktree_guardrails(text: &str) {
+    assert!(text.contains(READ_ONLY_MAIN_RULE));
+    assert!(text.contains(BEFORE_WRITE_THIS_CHANGE_RULE));
+    assert!(text.contains(NO_MAIN_WRITE_RULE));
+}
+
 #[test]
 fn render_template_str_renders_from_serialize_ctx() {
     #[derive(Serialize)]
@@ -358,7 +376,7 @@ fn worktrees_template_bare_control_siblings_branches_from_default_branch() {
     };
 
     let out = render_instruction_template("agent/worktrees.md.j2", &ctx).unwrap();
-    assert!(out.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&out);
     assert!(
         out.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -520,6 +538,7 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
     };
 
     let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert_change_worktree_guardrails(&out);
     assert!(out.contains("Use the full change ID as the branch and primary worktree directory name: `000-01_test-change`"));
     assert!(out.contains("Do not reuse one worktree for two changes"));
     assert!(out.contains(
@@ -647,10 +666,127 @@ fn apply_template_checkout_subdir_branches_from_default_branch() {
     };
 
     let out = render_instruction_template("agent/apply.md.j2", &ctx).unwrap();
+    assert_change_worktree_guardrails(&out);
     assert!(out.contains("Default branch: `develop`"));
     assert!(out.contains(
         "git -C \"$WORKTREE_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
     ));
+}
+
+#[test]
+fn apply_template_requires_change_worktree_when_apply_setup_disabled() {
+    #[derive(Serialize)]
+    struct InstructionsCtx {
+        #[serde(rename = "changeName")]
+        change_name: &'static str,
+        #[serde(rename = "schemaName")]
+        schema_name: &'static str,
+        state: &'static str,
+        #[serde(rename = "missingArtifacts")]
+        missing_artifacts: Vec<&'static str>,
+        instruction: &'static str,
+        #[serde(rename = "tracksFile")]
+        tracks_file: bool,
+        #[serde(rename = "tracksPath")]
+        tracks_path: &'static str,
+        #[serde(rename = "tracksFormat")]
+        tracks_format: &'static str,
+        progress: ProgressCtx,
+        tasks: Vec<&'static str>,
+    }
+
+    #[derive(Serialize)]
+    struct ProgressCtx {
+        total: usize,
+        complete: usize,
+    }
+
+    #[derive(Serialize)]
+    struct WorktreeCtx {
+        enabled: bool,
+        apply_enabled: bool,
+        strategy: &'static str,
+        default_branch: &'static str,
+        layout_dir_name: &'static str,
+        integration_mode: &'static str,
+        copy_from_main: Vec<&'static str>,
+        setup_commands: Vec<&'static str>,
+    }
+
+    #[derive(Serialize)]
+    struct TestingPolicyCtx {
+        tdd_workflow: &'static str,
+        coverage_target_percent: u64,
+    }
+
+    #[derive(Serialize, Default)]
+    struct MemoryOpState {
+        configured: bool,
+    }
+
+    #[derive(Serialize, Default)]
+    struct MemoryCtx {
+        capture: MemoryOpState,
+        search: MemoryOpState,
+        query: MemoryOpState,
+    }
+
+    #[derive(Serialize)]
+    struct Ctx {
+        instructions: InstructionsCtx,
+        context_files: Vec<&'static str>,
+        worktree: WorktreeCtx,
+        tracking_errors: Vec<&'static str>,
+        tracking_warnings: Vec<&'static str>,
+        testing_policy: TestingPolicyCtx,
+        user_guidance: &'static str,
+        memory: MemoryCtx,
+    }
+
+    let out = render_instruction_template(
+        "agent/apply.md.j2",
+        &Ctx {
+            instructions: InstructionsCtx {
+                change_name: "000-01_test-change",
+                schema_name: "spec-driven",
+                state: "ready",
+                missing_artifacts: Vec::new(),
+                instruction: "Implement the change.",
+                tracks_file: false,
+                tracks_path: "",
+                tracks_format: "",
+                progress: ProgressCtx {
+                    total: 0,
+                    complete: 0,
+                },
+                tasks: Vec::new(),
+            },
+            context_files: Vec::new(),
+            worktree: WorktreeCtx {
+                enabled: true,
+                apply_enabled: false,
+                strategy: "bare_control_siblings",
+                default_branch: "main",
+                layout_dir_name: "ito-worktrees",
+                integration_mode: "commit_pr",
+                copy_from_main: Vec::new(),
+                setup_commands: Vec::new(),
+            },
+            tracking_errors: Vec::new(),
+            tracking_warnings: Vec::new(),
+            testing_policy: TestingPolicyCtx {
+                tdd_workflow: "red-green-refactor",
+                coverage_target_percent: 80,
+            },
+            user_guidance: "",
+            memory: MemoryCtx::default(),
+        },
+    )
+    .unwrap();
+
+    assert!(out.contains("Do not write from the main/control checkout"));
+    assert!(out.contains("Move into the dedicated change worktree before any write operation"));
+    assert!(!out.contains("Work in your current directory"));
 }
 
 #[test]
@@ -664,6 +800,8 @@ fn new_proposal_template_moves_to_worktree_after_create() {
     #[derive(Serialize)]
     struct WorktreeCtx {
         enabled: bool,
+        layout_dir_name: &'static str,
+        default_branch: &'static str,
     }
 
     #[derive(Serialize)]
@@ -679,12 +817,20 @@ fn new_proposal_template_moves_to_worktree_after_create() {
                 id: "012",
                 name: "git-worktrees",
             }],
-            worktree: WorktreeCtx { enabled: true },
+            worktree: WorktreeCtx {
+                enabled: true,
+                layout_dir_name: "ito-worktrees",
+                default_branch: "main",
+            },
         },
     )
     .unwrap();
 
-    assert!(out.contains("Create the change ID first"));
+    assert!(out.contains("Before running any command that writes proposal artifacts"));
+    assert!(out.contains(READ_ONLY_MAIN_RULE));
+    assert!(out.contains("Do not run `ito create change` from the main/control checkout"));
+    assert!(out.contains(NO_MAIN_WRITE_RULE));
+    assert!(out.contains("proposal-<short-name>"));
     assert!(out.contains("CHANGE_DIR=$(ito worktree ensure --change \"<change-id>\")"));
     assert!(out.contains("cd \"$CHANGE_DIR\""));
     assert!(out.contains("Run all subsequent file operations from `$CHANGE_DIR`"));
@@ -719,6 +865,7 @@ fn worktree_init_template_includes_fresh_worktree_rules() {
     .unwrap();
 
     assert!(out.contains("Worktree rules:"));
+    assert_main_worktree_guardrails(&out);
     assert!(
         out.contains("Use the full change ID as the branch and primary worktree directory name")
     );

--- a/ito-rs/crates/ito-templates/src/project_templates.rs
+++ b/ito-rs/crates/ito-templates/src/project_templates.rs
@@ -99,6 +99,16 @@ fn contains_jinja2_syntax(text: &str) -> bool {
 mod tests {
     use super::*;
 
+    const READ_ONLY_MAIN_RULE: &str = "Treat the main/control checkout";
+    const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create a dedicated change worktree or move into the existing worktree for that change";
+    const NO_MAIN_WRITE_RULE: &str = "Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work";
+
+    fn assert_main_worktree_guardrails(text: &str) {
+        assert!(text.contains(READ_ONLY_MAIN_RULE));
+        assert!(text.contains(BEFORE_WRITE_WORKTREE_RULE));
+        assert!(text.contains(NO_MAIN_WRITE_RULE));
+    }
+
     #[test]
     fn render_project_template_passes_plain_text_through() {
         let bytes = b"Hello, this is plain text.";
@@ -185,7 +195,7 @@ mod tests {
 
         assert!(text.contains("## Worktree Workflow"));
         assert!(text.contains("**Strategy:** `checkout_subdir`"));
-        assert!(text.contains("Keep the main/control checkout clean"));
+        assert_main_worktree_guardrails(&text);
         assert!(
             text.contains(
                 "Use the full change ID as the branch and primary worktree directory name"
@@ -224,7 +234,7 @@ mod tests {
         let text = String::from_utf8(rendered).unwrap();
 
         assert!(text.contains("**Strategy:** `checkout_siblings`"));
-        assert!(text.contains("Keep the main/control checkout clean"));
+        assert_main_worktree_guardrails(&text);
         assert!(
             text.contains(
                 "Use the full change ID as the branch and primary worktree directory name"
@@ -263,7 +273,7 @@ mod tests {
         let text = String::from_utf8(rendered).unwrap();
 
         assert!(text.contains("**Strategy:** `bare_control_siblings`"));
-        assert!(text.contains("Keep the main/control checkout clean"));
+        assert_main_worktree_guardrails(&text);
         assert!(
             text.contains(
                 "Use the full change ID as the branch and primary worktree directory name"

--- a/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
+++ b/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
@@ -6,6 +6,10 @@
 
 use ito_templates::project_templates::{WorktreeTemplateContext, render_project_template};
 
+const READ_ONLY_MAIN_RULE: &str = "Treat the main/control checkout";
+const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create a dedicated change worktree or move into the existing worktree for that change";
+const NO_MAIN_WRITE_RULE: &str = "Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work";
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -40,6 +44,12 @@ fn skill_md_bytes() -> &'static [u8] {
 fn render_text(template: &[u8], ctx: &WorktreeTemplateContext) -> String {
     let bytes = render_project_template(template, ctx).expect("template should render");
     String::from_utf8(bytes).expect("rendered output should be UTF-8")
+}
+
+fn assert_main_worktree_guardrails(text: &str) {
+    assert!(text.contains(READ_ONLY_MAIN_RULE));
+    assert!(text.contains(BEFORE_WRITE_WORKTREE_RULE));
+    assert!(text.contains(NO_MAIN_WRITE_RULE));
 }
 
 /// Strings that indicate vague directory-discovery heuristics. None of these
@@ -227,7 +237,7 @@ fn agents_md_checkout_subdir() {
             "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
         )
     );
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -247,7 +257,7 @@ fn agents_md_checkout_siblings() {
     let text = render_text(agents_md_bytes(), &ctx);
 
     assert!(text.contains("**Strategy:** `checkout_siblings`"));
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -284,7 +294,7 @@ fn agents_md_bare_control_siblings() {
     let text = render_text(agents_md_bytes(), &ctx);
 
     assert!(text.contains("**Strategy:** `bare_control_siblings`"));
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -333,7 +343,7 @@ fn skill_checkout_subdir() {
             "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
         )
     );
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -349,7 +359,7 @@ fn skill_checkout_siblings() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `checkout_siblings`"));
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
@@ -384,7 +394,7 @@ fn skill_bare_control_siblings() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `bare_control_siblings`"));
-    assert!(text.contains("Keep the main/control checkout clean"));
+    assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );


### PR DESCRIPTION
## Summary
- Strengthen generated worktree instructions so main/control is read-only for writes.
- Require dedicated change/proposal worktrees before write operations across AGENTS, worktree skill, and agent instruction templates.
- Add tests for AGENTS, worktree skill, apply, worktrees, worktree-init, and new-proposal rendering.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p ito-templates -- --nocapture`
- `ito validate 011-04_ito-init-update --strict`
- Final blocking review: no blocking findings

## Known Gate Status
- `make check` is blocked by pre-existing repo-wide issues outside this diff: ByteRover markdownlint copies, rustdoc broken intra-doc links, missing llvm coverage tools, max-line limits, and cargo-deny duplicate `wit-bindgen`.