### PR TITLE
fix(init): refresh managed agent templates on update

### DIFF
--- a/ito-rs/crates/ito-cli/tests/init_more.rs
+++ b/ito-rs/crates/ito-cli/tests/init_more.rs
@@ -17,6 +17,16 @@ fn expected_release_tag() -> String {
     format!("v{version}")
 }
 
+fn expected_opencode_general_model() -> String {
+    use ito_templates::agents::{AgentTier, Harness, default_agent_configs};
+
+    default_agent_configs()
+        .get(&(Harness::OpenCode, AgentTier::General))
+        .expect("opencode general config")
+        .model
+        .clone()
+}
+
 #[test]
 fn init_requires_tools_when_non_interactive() {
     let repo = tempfile::tempdir().expect("work");
@@ -84,6 +94,185 @@ fn init_with_tools_opencode_installs_orchestrator_agent_template() {
     assert!(!contents.contains("{{model}}"));
     assert!(!contents.contains("{{variant}}"));
     assert!(contents.contains("model:"));
+}
+
+#[test]
+fn init_update_with_tools_all_installs_all_orchestrator_agent_templates() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+
+    let repo_path = repo.path().to_string_lossy();
+    let argv = ["init", repo_path.as_ref(), "--tools", "all", "--update"];
+    let out = run_rust_candidate(rust_path, &argv, repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let expected = [
+        ".opencode/agent/ito-orchestrator.md",
+        ".opencode/agent/ito-orchestrator-planner.md",
+        ".opencode/agent/ito-orchestrator-researcher.md",
+        ".opencode/agent/ito-orchestrator-worker.md",
+        ".opencode/agent/ito-orchestrator-reviewer.md",
+        ".claude/agents/ito-orchestrator.md",
+        ".claude/agents/ito-orchestrator-planner.md",
+        ".claude/agents/ito-orchestrator-researcher.md",
+        ".claude/agents/ito-orchestrator-worker.md",
+        ".claude/agents/ito-orchestrator-reviewer.md",
+        ".github/agents/ito-orchestrator.md",
+        ".github/agents/ito-orchestrator-planner.md",
+        ".github/agents/ito-orchestrator-researcher.md",
+        ".github/agents/ito-orchestrator-worker.md",
+        ".github/agents/ito-orchestrator-reviewer.md",
+        ".pi/agents/ito-orchestrator.md",
+        ".pi/agents/ito-orchestrator-planner.md",
+        ".pi/agents/ito-orchestrator-researcher.md",
+        ".pi/agents/ito-orchestrator-worker.md",
+        ".pi/agents/ito-orchestrator-reviewer.md",
+        ".agents/skills/ito-orchestrator/SKILL.md",
+        ".agents/skills/ito-orchestrator-planner/SKILL.md",
+        ".agents/skills/ito-orchestrator-researcher/SKILL.md",
+        ".agents/skills/ito-orchestrator-worker/SKILL.md",
+        ".agents/skills/ito-orchestrator-reviewer/SKILL.md",
+    ];
+
+    for rel in expected {
+        assert!(repo.path().join(rel).exists(), "expected {rel} to install");
+    }
+
+    let contents = std::fs::read_to_string(repo.path().join(".opencode/agent/ito-orchestrator.md"))
+        .expect("read opencode orchestrator");
+    assert!(!contents.contains("{{model}}"));
+    assert!(!contents.contains("{{variant}}"));
+}
+
+#[test]
+fn init_update_refreshes_existing_opencode_orchestrator_agent_template() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+
+    let agent_path = repo.path().join(".opencode/agent/ito-orchestrator.md");
+    fixtures::write(
+        &agent_path,
+        r#"---
+model: "old-model"
+---
+
+custom prefix
+
+<!-- ITO:START -->
+stale orchestrator body
+<!-- ITO:END -->
+
+custom suffix
+"#,
+    );
+
+    let repo_path = repo.path().to_string_lossy();
+    let argv = [
+        "init",
+        repo_path.as_ref(),
+        "--tools",
+        "opencode",
+        "--update",
+    ];
+    let out = run_rust_candidate(rust_path, &argv, repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let contents = std::fs::read_to_string(agent_path).expect("read agent");
+    assert!(contents.contains("custom prefix"));
+    assert!(contents.contains("custom suffix"));
+    assert!(contents.contains("You are an orchestrator."));
+    assert!(!contents.contains("stale orchestrator body"));
+    assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
+}
+
+#[test]
+fn init_update_preserves_existing_markerless_opencode_agent_template_body() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+
+    let agent_path = repo.path().join(".opencode/agent/ito-orchestrator.md");
+    fixtures::write(
+        &agent_path,
+        r#"---
+model: "old-model"
+---
+
+legacy custom orchestrator body
+"#,
+    );
+
+    let repo_path = repo.path().to_string_lossy();
+    let argv = [
+        "init",
+        repo_path.as_ref(),
+        "--tools",
+        "opencode",
+        "--update",
+    ];
+    let out = run_rust_candidate(rust_path, &argv, repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let contents = std::fs::read_to_string(agent_path).expect("read agent");
+    assert!(contents.contains("legacy custom orchestrator body"));
+    assert!(!contents.contains("You are an orchestrator."));
+    assert!(!contents.contains("old-model"));
+    assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
+}
+
+#[test]
+fn init_update_preserves_existing_partial_marker_opencode_agent_template_body() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+
+    let agent_path = repo.path().join(".opencode/agent/ito-orchestrator.md");
+    fixtures::write(
+        &agent_path,
+        r#"---
+model: "old-model"
+---
+
+legacy partial-marker orchestrator body
+<!-- ITO:START -->
+"#,
+    );
+
+    let repo_path = repo.path().to_string_lossy();
+    let argv = [
+        "init",
+        repo_path.as_ref(),
+        "--tools",
+        "opencode",
+        "--update",
+    ];
+    let out = run_rust_candidate(rust_path, &argv, repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(
+        out.stderr.contains("partial Ito marker pair"),
+        "expected partial marker warning, got {}",
+        out.stderr
+    );
+
+    let contents = std::fs::read_to_string(agent_path).expect("read agent");
+    assert!(contents.contains("legacy partial-marker orchestrator body"));
+    assert!(!contents.contains("You are an orchestrator."));
+    assert!(!contents.contains("old-model"));
+    assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/src/installers/mod.rs
+++ b/ito-rs/crates/ito-core/src/installers/mod.rs
@@ -457,26 +457,6 @@ fn render_and_stamp_agent(
     ito_templates::stamp_version(text, semver).into_bytes()
 }
 
-/// Refresh the `<!--ITO:VERSION:...-->` stamp inside an on-disk agent file.
-///
-/// Used after `update_agent_model_field` patches frontmatter so the file's
-/// stamp matches the CLI version even when only the model field changed. A
-/// no-op for files without managed markers.
-fn refresh_agent_version_stamp(target: &Path) -> CoreResult<()> {
-    let semver = option_env!("ITO_WORKSPACE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
-    let existing = ito_common::io::read_to_string_std(target)
-        .map_err(|e| CoreError::io(format!("reading {}", target.display()), e))?;
-    if !existing.contains(ito_templates::ITO_START_MARKER) {
-        return Ok(());
-    }
-    let stamped = ito_templates::stamp_version(&existing, semver);
-    if stamped == existing {
-        return Ok(());
-    }
-    ito_common::io::write_std(target, stamped.into_bytes())
-        .map_err(|e| CoreError::io(format!("stamping {}", target.display()), e))
-}
-
 /// Write a rendered managed-block markdown file with marker-scoped update
 /// semantics, suitable for installer paths that do not need the full
 /// `write_one` ownership/upgrade machinery (e.g. the harness manifest
@@ -945,57 +925,68 @@ fn install_agent_templates(
             match mode {
                 InstallMode::Init => {
                     if target.exists() {
-                        if opts.update {
-                            // --update: only update model field in existing agent files
-                            if let Some(cfg) = config {
-                                update_agent_model_field(&target, &cfg.model)?;
+                        if !opts.force {
+                            if opts.update {
+                                let rendered = render_and_stamp_agent(contents, config, &target);
+                                update_existing_agent_template(
+                                    &target, &rendered, mode, opts, config,
+                                )?;
                             }
                             continue;
                         }
-                        if !opts.force {
-                            // Default init: skip existing files
-                            continue;
-                        }
                     }
 
-                    // Render full template (and stamp managed-block markdown)
                     let rendered = render_and_stamp_agent(contents, config, &target);
-
-                    // Ensure parent directory exists
-                    if let Some(parent) = target.parent() {
-                        ito_common::io::create_dir_all_std(parent).map_err(|e| {
-                            CoreError::io(format!("creating directory {}", parent.display()), e)
-                        })?;
-                    }
-
-                    ito_common::io::write_std(&target, rendered)
-                        .map_err(|e| CoreError::io(format!("writing {}", target.display()), e))?;
+                    write_marker_aware_markdown(&target, &rendered, mode, opts)?;
                 }
                 InstallMode::Update => {
-                    // During update: only update model in existing ito agent files
-                    if !target.exists() {
-                        // File doesn't exist, create it
-                        let rendered = render_and_stamp_agent(contents, config, &target);
-
-                        if let Some(parent) = target.parent() {
-                            ito_common::io::create_dir_all_std(parent).map_err(|e| {
-                                CoreError::io(format!("creating directory {}", parent.display()), e)
-                            })?;
-                        }
-                        ito_common::io::write_std(&target, rendered).map_err(|e| {
-                            CoreError::io(format!("writing {}", target.display()), e)
-                        })?;
-                    } else if let Some(cfg) = config {
-                        // File exists, only update model field in frontmatter
-                        update_agent_model_field(&target, &cfg.model)?;
-                        // Refresh the managed-block stamp so the file's
-                        // ITO:VERSION reflects the current CLI even when
-                        // only the model field was patched.
-                        refresh_agent_version_stamp(&target)?;
+                    let rendered = render_and_stamp_agent(contents, config, &target);
+                    if target.exists() {
+                        update_existing_agent_template(&target, &rendered, mode, opts, config)?;
+                    } else {
+                        write_marker_aware_markdown(&target, &rendered, mode, opts)?;
                     }
                 }
             }
         }
+    }
+
+    Ok(())
+}
+
+/// Updates an existing agent template without clobbering user-owned bodies.
+///
+/// Files with complete Ito markers get their managed block refreshed. Legacy
+/// markerless files keep their body and only receive frontmatter model updates.
+/// Partial marker pairs are treated like damaged managed regions: preserve the
+/// body for compatibility, but warn so the user can repair the file.
+fn update_existing_agent_template(
+    target: &Path,
+    rendered: &[u8],
+    mode: InstallMode,
+    opts: &InitOptions,
+    config: Option<&ito_templates::agents::AgentConfig>,
+) -> CoreResult<()> {
+    let existing = ito_common::io::read_to_string_std(target)
+        .map_err(|e| CoreError::io(format!("reading {}", target.display()), e))?;
+    let has_start = existing.contains(ito_templates::ITO_START_MARKER);
+    let has_end = existing.contains(ito_templates::ITO_END_MARKER);
+
+    match (has_start, has_end) {
+        (true, true) => write_marker_aware_markdown(target, rendered, mode, opts)?,
+        (false, false) => {}
+        (true, false) | (false, true) => {
+            eprintln!(
+                "warning: skipping marker update for {}: file has a partial Ito marker pair \
+                (start={has_start}, end={has_end}). Restore both markers manually, or rerun \
+                with `--force` to overwrite the file wholesale.",
+                target.display()
+            );
+        }
+    }
+
+    if let Some(cfg) = config {
+        update_agent_model_field(target, &cfg.model)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Refresh managed Ito agent template blocks during `init --update` and `ito update`.
- Preserve markerless or partial-marker agent bodies while still updating model frontmatter.
- Add integration coverage for orchestrator agent installation and update behavior.

## Verification
- `cargo fmt --check`
- `cargo test -p ito-cli --test init_more`
- `cargo test -p ito-core`

Supersedes #218, which included an unrelated generated-asset commit.