### PR TITLE
feat(011-06): audit/repository/backend validation rules

### DIFF
--- a/.ito/architecture.md
+++ b/.ito/architecture.md
@@ -162,16 +162,15 @@ See [`specs/cli-archive`](specs/cli-archive/spec.md) and [`specs/cli-validate`](
 
 Beyond per-artifact validation (`ito validate <change-id>`), Ito ships a **config-aware repository validation engine** at `ito-core::validate_repo` exposed as `ito validate repo`. The engine iterates a registry of small, gated rules and merges their findings into the standard `ValidationReport` envelope.
 
-Built-in rule namespaces (this change):
+Built-in rule namespaces (13 rules in five namespaces, each gated on a
+specific `ItoConfig` predicate so the rule is silently skipped when the
+feature is off):
 
-- `coordination/*` — gates on `changes.coordination_branch.storage == worktree`. Checks symlink wiring, canonical `.gitignore` lines, and that staged paths do not live under coordination directories.
-- `worktrees/*` — gates on `worktrees.enabled == true`. Catches commits made on the control / default-branch worktree and layout drift.
-
-Added by change `011-06` (extends the same registry):
-
-- `audit/*` — mirror branch invariants.
-- `repository/*` — sqlite path / commit policy when `repository.mode == sqlite`.
-- `backend/*` — token-not-committed, URL scheme, and project org/repo presence.
+- `coordination/*` (4 rules) — gates on `changes.coordination_branch.storage == worktree`. Checks symlink wiring, canonical `.gitignore` lines, and that staged paths do not live under coordination directories. The `coordination/branch-name-set` rule is always active.
+- `worktrees/*` (2 rules) — gates on `worktrees.enabled == true`. Catches commits made on the control / default-branch worktree and worktree layout drift.
+- `audit/*` (2 rules) — gates on `audit.mirror.enabled == true`. Enforces a non-empty mirror branch following the `ito/internal/*` convention; the distinct-from-coordination rule additionally requires `coordination_branch.storage == worktree` to fire.
+- `repository/*` (2 rules) — gates on `repository.mode == sqlite`. The `db_path` must resolve inside the project root, have an existing parent directory, and the database file must be untracked AND covered by `.gitignore`.
+- `backend/*` (3 rules) — gates on `backend.enabled == true`. The security-critical `backend/token-not-committed` inspects the cascading config layer-by-layer and emits an `ERROR` (regardless of `--strict`) if a token is set in any tracked-by-git layer.
 
 The `pre-commit` git hook installed by `ito-update-repo` runs `ito validate repo --staged --strict`, so every commit gets a fast, configuration-aware sanity check. The heavier `cargo` quality gates remain at `pre-push`.
 

--- a/ito-rs/crates/ito-cli/tests/validate_repo_cli.rs
+++ b/ito-rs/crates/ito-cli/tests/validate_repo_cli.rs
@@ -20,6 +20,26 @@ fn write(path: impl AsRef<Path>, contents: &str) {
     std::fs::write(path, contents).unwrap();
 }
 
+/// Run a `git` command in the given directory and panic with a useful
+/// message on either spawn failure (e.g. git missing from PATH) or
+/// non-zero exit. Used by tests that need a real git repository for
+/// `git ls-files --error-unmatch` / `git check-ignore` to behave
+/// correctly.
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `git {}`: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` exited non-zero (code: {:?})\nstderr: {}",
+        args.join(" "),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 /// Minimal initialised project: `.ito/` directory with an empty config file.
 /// Sufficient for `ito validate repo --list-rules` and similar non-rule paths.
 fn make_minimal_project() -> tempfile::TempDir {
@@ -299,30 +319,15 @@ fn validate_repo_backend_token_not_committed_fails_when_token_in_config() {
     );
     // Initialise a real git repo so `git ls-files --error-unmatch` can
     // actually classify the config file as tracked.
-    let _ = std::process::Command::new("git")
-        .args(["init", "--initial-branch=main"])
-        .current_dir(project.path())
-        .output();
-    let _ = std::process::Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(project.path())
-        .output();
-    let _ = std::process::Command::new("git")
-        .args(["config", "user.name", "test"])
-        .current_dir(project.path())
-        .output();
-    let _ = std::process::Command::new("git")
-        .args(["config", "commit.gpgsign", "false"])
-        .current_dir(project.path())
-        .output();
-    let _ = std::process::Command::new("git")
-        .args(["add", ".ito/config.json"])
-        .current_dir(project.path())
-        .output();
-    let _ = std::process::Command::new("git")
-        .args(["commit", "--no-verify", "-m", "init"])
-        .current_dir(project.path())
-        .output();
+    run_git(project.path(), &["init", "--initial-branch=main"]);
+    run_git(
+        project.path(),
+        &["config", "user.email", "test@example.com"],
+    );
+    run_git(project.path(), &["config", "user.name", "test"]);
+    run_git(project.path(), &["config", "commit.gpgsign", "false"]);
+    run_git(project.path(), &["add", ".ito/config.json"]);
+    run_git(project.path(), &["commit", "--no-verify", "-m", "init"]);
 
     let home = tempfile::tempdir().expect("home");
     let rust_path = assert_cmd::cargo::cargo_bin!("ito");

--- a/ito-rs/crates/ito-cli/tests/validate_repo_cli.rs
+++ b/ito-rs/crates/ito-cli/tests/validate_repo_cli.rs
@@ -93,12 +93,21 @@ fn validate_repo_list_rules_enumerates_built_in_rules() {
     );
     assert_eq!(out.code, 0, "--list-rules must exit 0");
     for id in &[
+        // 011-05
         "coordination/branch-name-set",
         "coordination/gitignore-entries",
         "coordination/staged-symlinked-paths",
         "coordination/symlinks-wired",
         "worktrees/layout-consistent",
         "worktrees/no-write-on-control",
+        // 011-06
+        "audit/mirror-branch-distinct-from-coordination",
+        "audit/mirror-branch-set",
+        "backend/project-org-repo-set",
+        "backend/token-not-committed",
+        "backend/url-scheme-valid",
+        "repository/sqlite-db-not-committed",
+        "repository/sqlite-db-path-set",
     ] {
         assert!(
             out.stdout.contains(id),
@@ -126,11 +135,15 @@ fn validate_repo_list_rules_json_returns_array() {
         .get("rules")
         .and_then(|r| r.as_array())
         .expect("rules array");
-    // Exact count is intentional: when change 011-06 adds the
-    // `audit/*`, `repository/*`, and `backend/*` rules, this assertion
-    // fails loudly so the test (and any docs that quote the rule count)
-    // get updated together.
-    assert_eq!(rules.len(), 6, "expected 6 built-in rules, got {rules:#?}");
+    // Exact count is intentional: when more rules are added, this
+    // assertion fails loudly so the test (and any docs that quote the
+    // rule count) get updated together. Currently 13 rules ship: 6 from
+    // 011-05 + 7 from 011-06.
+    assert_eq!(
+        rules.len(),
+        13,
+        "expected 13 built-in rules, got {rules:#?}"
+    );
 }
 
 #[test]
@@ -237,6 +250,155 @@ fn validate_repo_json_emits_validation_report_envelope() {
     assert_eq!(summary.get("errors"), Some(&serde_json::json!(0)));
     assert_eq!(summary.get("warnings"), Some(&serde_json::json!(0)));
     assert_eq!(summary.get("info"), Some(&serde_json::json!(0)));
+}
+
+#[test]
+fn validate_repo_explain_audit_mirror_distinct_rule() {
+    // 011-06: explain output for one of the new rules, demonstrating
+    // that the registry surfaces description and gate metadata.
+    let project = make_minimal_project();
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "validate",
+            "repo",
+            "--explain",
+            "audit/mirror-branch-distinct-from-coordination",
+        ],
+        project.path(),
+        home.path(),
+    );
+    assert_eq!(out.code, 0);
+    assert!(out.stdout.contains("severity: ERROR"));
+    assert!(out.stdout.contains("audit.mirror.enabled"));
+    assert!(out.stdout.contains("coordination_branch.storage"));
+}
+
+#[test]
+fn validate_repo_backend_token_not_committed_fails_when_token_in_config() {
+    // 011-06 security check: write a project that has backend.enabled =
+    // true and a backend.token set in `.ito/config.json`. The CLI
+    // command should exit 1 with the token-not-committed rule firing.
+    let project = tempfile::tempdir().expect("project");
+    write(
+        project.path().join(".ito/config.json"),
+        r#"{
+  "changes": { "coordination_branch": { "storage": "embedded" } },
+  "worktrees": { "enabled": false },
+  "backend": {
+    "enabled": true,
+    "url": "https://api.example.com",
+    "token": "leaked-secret",
+    "project": { "org": "withakay", "repo": "ito" }
+  }
+}
+"#,
+    );
+    // Initialise a real git repo so `git ls-files --error-unmatch` can
+    // actually classify the config file as tracked.
+    let _ = std::process::Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(project.path())
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(project.path())
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["config", "user.name", "test"])
+        .current_dir(project.path())
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(project.path())
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["add", ".ito/config.json"])
+        .current_dir(project.path())
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["commit", "--no-verify", "-m", "init"])
+        .current_dir(project.path())
+        .output();
+
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["validate", "repo", "--json"],
+        project.path(),
+        home.path(),
+    );
+    assert_eq!(
+        out.code, 1,
+        "expected exit 1 (validation failure); stdout: {}",
+        out.stdout,
+    );
+
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("--json output");
+    let issues = v
+        .get("issues")
+        .and_then(|i| i.as_array())
+        .expect("issues array");
+    let token_issues: Vec<_> = issues
+        .iter()
+        .filter(|i| {
+            i.get("rule_id").and_then(|r| r.as_str()) == Some("backend/token-not-committed")
+        })
+        .collect();
+    assert_eq!(
+        token_issues.len(),
+        1,
+        "expected one token-not-committed issue; got: {issues:#?}",
+    );
+    assert_eq!(
+        token_issues[0].get("level").and_then(|l| l.as_str()),
+        Some("ERROR"),
+    );
+}
+
+#[test]
+fn validate_repo_url_scheme_valid_fails_for_non_http_scheme() {
+    // 011-06: enabling the backend with an ftp URL should fail with the
+    // url-scheme-valid rule.
+    let project = tempfile::tempdir().expect("project");
+    write(
+        project.path().join(".ito/config.json"),
+        r#"{
+  "changes": { "coordination_branch": { "storage": "embedded" } },
+  "worktrees": { "enabled": false },
+  "backend": {
+    "enabled": true,
+    "url": "ftp://files.example.com",
+    "project": { "org": "withakay", "repo": "ito" }
+  }
+}
+"#,
+    );
+
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["validate", "repo"],
+        project.path(),
+        home.path(),
+    );
+    assert_eq!(
+        out.code, 1,
+        "expected exit 1 for ftp scheme; stdout: {}",
+        out.stdout,
+    );
+    assert!(
+        out.stdout.contains("backend/url-scheme-valid"),
+        "stdout should mention the failing rule; got:\n{}",
+        out.stdout,
+    );
 }
 
 #[test]

--- a/ito-rs/crates/ito-config/src/config/mod.rs
+++ b/ito-rs/crates/ito-config/src/config/mod.rs
@@ -264,6 +264,23 @@ pub struct CascadingProjectConfig {
     pub merged: Value,
     /// Paths that were successfully loaded and merged.
     pub loaded_from: Vec<PathBuf>,
+    /// Per-layer breakdown, in precedence order (low → high).
+    ///
+    /// Each entry carries the source path and the parsed JSON value of
+    /// that single layer (before merging). Validation rules that need to
+    /// distinguish "value came from a committed file" from "value came
+    /// from a gitignored override" inspect this list rather than the
+    /// merged view.
+    pub layers: Vec<ResolvedConfigLayer>,
+}
+
+#[derive(Debug, Clone)]
+/// A single configuration layer that contributed to the merged view.
+pub struct ResolvedConfigLayer {
+    /// Absolute path of the layer's source file.
+    pub path: PathBuf,
+    /// Parsed JSON of this layer, before merging.
+    pub value: Value,
 }
 
 /// Alias used by consumers who only care about the resolved config output.
@@ -352,6 +369,7 @@ pub fn load_cascading_project_config_fs<F: FileSystem>(
 ) -> CascadingProjectConfig {
     let mut merged = defaults::default_config_json();
     let mut loaded_from: Vec<PathBuf> = Vec::new();
+    let mut layers: Vec<ResolvedConfigLayer> = Vec::new();
 
     let paths = project_config_paths(project_root, ito_path, ctx);
     for path in paths {
@@ -362,6 +380,10 @@ pub fn load_cascading_project_config_fs<F: FileSystem>(
         // the new key names participate in the normal merge process and
         // override defaults correctly.
         migrate_legacy_worktree_keys(&mut v);
+        layers.push(ResolvedConfigLayer {
+            path: path.clone(),
+            value: v.clone(),
+        });
         merge_json(&mut merged, v);
         loaded_from.push(path);
     }
@@ -369,6 +391,7 @@ pub fn load_cascading_project_config_fs<F: FileSystem>(
     CascadingProjectConfig {
         merged,
         loaded_from,
+        layers,
     }
 }
 
@@ -526,6 +549,30 @@ mod tests {
                 ito_path.join("config.json"),
                 project_dir.path().join("config.json"),
             ]
+        );
+
+        // The new `layers` field is precedence-ordered (low → high) and
+        // each entry carries the un-merged value of that layer alone.
+        let layer_paths: Vec<_> = r.layers.iter().map(|l| &l.path).collect();
+        assert_eq!(
+            layer_paths,
+            vec![
+                &repo.path().join("ito.json"),
+                &repo.path().join(".ito.json"),
+                &ito_path.join("config.json"),
+                &project_dir.path().join("config.json"),
+            ]
+        );
+
+        // The first layer (`ito.json`) only set `obj.a = 1`, `arr = [1]`,
+        // and `x = "repo"` — its raw value must NOT include the
+        // higher-precedence overrides applied later.
+        let first = &r.layers[0].value;
+        assert_eq!(first.get("x").unwrap(), &serde_json::json!("repo"));
+        assert_eq!(first.get("obj").unwrap(), &serde_json::json!({"a": 1}));
+        assert!(
+            first.get("z").is_none(),
+            "layer 0 must not see ito_dir keys"
         );
     }
 

--- a/ito-rs/crates/ito-core/src/validate_repo/audit_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/audit_rules.rs
@@ -62,7 +62,12 @@ impl Rule for MirrorBranchSetRule {
         let mut issues = Vec::new();
 
         if branch.is_empty() {
-            let issue = warning(".ito/config.json", "`audit.mirror.branch` is empty.");
+            let issue = warning(
+                ".ito/config.json",
+                "`audit.mirror.branch` is empty. \
+                 Without a branch name the audit subsystem cannot push mirror \
+                 commits and the mirror feature is effectively disabled.",
+            );
             let issue = with_rule_id(issue, MIRROR_BRANCH_SET_ID.as_str());
             issues.push(with_metadata(
                 issue,

--- a/ito-rs/crates/ito-core/src/validate_repo/audit_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/audit_rules.rs
@@ -1,0 +1,390 @@
+//! Rules under the `audit/*` namespace.
+//!
+//! Two rules live here:
+//!
+//! - `audit/mirror-branch-set` — when audit mirroring is enabled, the
+//!   configured mirror branch must be non-empty and SHOULD live under
+//!   `ito/internal/`.
+//! - `audit/mirror-branch-distinct-from-coordination` — the mirror branch
+//!   must not collide with the coordination branch when both worktree-based
+//!   features are enabled.
+
+use ito_config::types::{CoordinationStorage, ItoConfig};
+
+use crate::errors::CoreError;
+use crate::validate::{ValidationIssue, error, warning, with_metadata, with_rule_id};
+
+use super::rule::{Rule, RuleContext, RuleId, RuleSeverity};
+
+const MIRROR_BRANCH_SET_ID: RuleId = RuleId::new("audit/mirror-branch-set");
+const MIRROR_BRANCH_DISTINCT_ID: RuleId =
+    RuleId::new("audit/mirror-branch-distinct-from-coordination");
+
+const ITO_INTERNAL_PREFIX: &str = "ito/internal/";
+
+/// True when coordination storage is `worktree`.
+fn coordination_is_worktree(config: &ItoConfig) -> bool {
+    match config.changes.coordination_branch.storage {
+        CoordinationStorage::Worktree => true,
+        CoordinationStorage::Embedded => false,
+    }
+}
+
+// ── audit/mirror-branch-set ──────────────────────────────────────────────
+
+/// `audit/mirror-branch-set` — mirror branch must be non-empty and follow
+/// the `ito/internal/` convention.
+pub(crate) struct MirrorBranchSetRule;
+
+impl Rule for MirrorBranchSetRule {
+    fn id(&self) -> RuleId {
+        MIRROR_BRANCH_SET_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Warning
+    }
+
+    fn description(&self) -> &'static str {
+        "Audit mirror branch is non-empty and follows the `ito/internal/` convention."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("audit.mirror.enabled == true")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        config.audit.mirror.enabled
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let branch = ctx.config.audit.mirror.branch.trim();
+        let mut issues = Vec::new();
+
+        if branch.is_empty() {
+            let issue = warning(".ito/config.json", "`audit.mirror.branch` is empty.");
+            let issue = with_rule_id(issue, MIRROR_BRANCH_SET_ID.as_str());
+            issues.push(with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!(
+                        "Set `audit.mirror.branch` to a value under `{ITO_INTERNAL_PREFIX}` (for example `{ITO_INTERNAL_PREFIX}audit`)."
+                    ),
+                    "config_key": "audit.mirror.branch",
+                }),
+            ));
+            return Ok(issues);
+        }
+
+        if !branch.starts_with(ITO_INTERNAL_PREFIX) {
+            let issue = warning(
+                ".ito/config.json",
+                format!(
+                    "`audit.mirror.branch = \"{branch}\"` does not follow the \
+                     `{ITO_INTERNAL_PREFIX}*` convention.",
+                ),
+            );
+            let issue = with_rule_id(issue, MIRROR_BRANCH_SET_ID.as_str());
+            issues.push(with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!(
+                        "Rename the branch under `{ITO_INTERNAL_PREFIX}` (for example \
+                         `{ITO_INTERNAL_PREFIX}audit`) to keep audit mirrors in the \
+                         workspace's internal namespace."
+                    ),
+                    "current": branch,
+                }),
+            ));
+        }
+
+        Ok(issues)
+    }
+}
+
+// ── audit/mirror-branch-distinct-from-coordination ───────────────────────
+
+/// `audit/mirror-branch-distinct-from-coordination` — the audit mirror
+/// branch must not be the same as the coordination branch.
+pub(crate) struct MirrorBranchDistinctRule;
+
+impl Rule for MirrorBranchDistinctRule {
+    fn id(&self) -> RuleId {
+        MIRROR_BRANCH_DISTINCT_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "Audit mirror branch is distinct from the coordination branch."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("audit.mirror.enabled == true && changes.coordination_branch.storage == worktree")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        config.audit.mirror.enabled && coordination_is_worktree(config)
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let mirror = ctx.config.audit.mirror.branch.trim();
+        let coord = ctx.config.changes.coordination_branch.name.trim();
+
+        if mirror.is_empty() || coord.is_empty() || mirror != coord {
+            return Ok(Vec::new());
+        }
+
+        let issue = error(
+            ".ito/config.json",
+            format!(
+                "`audit.mirror.branch` and `changes.coordination_branch.name` are both \
+                 set to `{mirror}`. A single git branch cannot store both audit events \
+                 and coordination state — pushes from each subsystem would clobber the \
+                 other.",
+            ),
+        );
+        let issue = with_rule_id(issue, MIRROR_BRANCH_DISTINCT_ID.as_str());
+        let issue = with_metadata(
+            issue,
+            serde_json::json!({
+                "fix": format!(
+                    "Use distinct branch names — for example `{ITO_INTERNAL_PREFIX}changes` \
+                     for coordination and `{ITO_INTERNAL_PREFIX}audit` for the mirror."
+                ),
+                "shared_branch": mirror,
+            }),
+        );
+        Ok(vec![issue])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::{ProcessExecutionError, ProcessOutput, ProcessRequest, ProcessRunner};
+    use crate::validate_repo::staged::StagedFiles;
+    use ito_config::types::{
+        AuditConfig, AuditMirrorConfig, ChangesConfig, CoordinationBranchConfig,
+        CoordinationStorage, ItoConfig,
+    };
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    struct NoopRunner;
+
+    impl ProcessRunner for NoopRunner {
+        fn run(&self, _request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
+            Ok(ProcessOutput {
+                exit_code: 0,
+                success: true,
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+            })
+        }
+        fn run_with_timeout(
+            &self,
+            request: &ProcessRequest,
+            _timeout: Duration,
+        ) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.run(request)
+        }
+    }
+
+    fn config(
+        mirror_enabled: bool,
+        mirror_branch: &str,
+        storage: CoordinationStorage,
+        coord_branch: &str,
+    ) -> ItoConfig {
+        ItoConfig {
+            audit: AuditConfig {
+                mirror: AuditMirrorConfig {
+                    enabled: mirror_enabled,
+                    branch: mirror_branch.to_string(),
+                },
+            },
+            changes: ChangesConfig {
+                coordination_branch: CoordinationBranchConfig {
+                    storage,
+                    name: coord_branch.to_string(),
+                    ..CoordinationBranchConfig::default()
+                },
+                ..ChangesConfig::default()
+            },
+            ..ItoConfig::default()
+        }
+    }
+
+    // ── activation tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn mirror_branch_set_inactive_when_mirror_disabled() {
+        let cfg = config(
+            false,
+            "ito/internal/audit",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        assert!(!MirrorBranchSetRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn mirror_branch_set_active_when_mirror_enabled() {
+        let cfg = config(
+            true,
+            "ito/internal/audit",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        assert!(MirrorBranchSetRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn mirror_branch_distinct_inactive_when_mirror_disabled() {
+        let cfg = config(false, "x", CoordinationStorage::Worktree, "y");
+        assert!(!MirrorBranchDistinctRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn mirror_branch_distinct_inactive_when_storage_embedded() {
+        let cfg = config(true, "x", CoordinationStorage::Embedded, "y");
+        assert!(!MirrorBranchDistinctRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn mirror_branch_distinct_active_when_both_enabled() {
+        let cfg = config(true, "x", CoordinationStorage::Worktree, "y");
+        assert!(MirrorBranchDistinctRule.is_active(&cfg));
+    }
+
+    // ── audit/mirror-branch-set ──────────────────────────────────────────
+
+    fn ctx_for<'a>(
+        cfg: &'a ItoConfig,
+        tmp: &'a TempDir,
+        runner: &'a NoopRunner,
+        staged: &'a StagedFiles,
+    ) -> RuleContext<'a> {
+        RuleContext::new(cfg, tmp.path(), staged, runner)
+    }
+
+    #[test]
+    fn mirror_branch_set_passes_for_canonical_name() {
+        let cfg = config(
+            true,
+            "ito/internal/audit",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchSetRule.check(&ctx).unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn mirror_branch_set_warns_on_empty_branch() {
+        let cfg = config(
+            true,
+            "",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchSetRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "WARNING");
+        assert!(issues[0].message.contains("empty"));
+    }
+
+    #[test]
+    fn mirror_branch_set_warns_on_non_conventional_name() {
+        let cfg = config(
+            true,
+            "mirror/audit",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchSetRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("ito/internal/"));
+    }
+
+    // ── audit/mirror-branch-distinct ─────────────────────────────────────
+
+    #[test]
+    fn mirror_branch_distinct_passes_when_branches_differ() {
+        let cfg = config(
+            true,
+            "ito/internal/audit",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchDistinctRule.check(&ctx).unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn mirror_branch_distinct_fails_when_branches_match() {
+        let shared = "ito/internal/changes";
+        let cfg = config(true, shared, CoordinationStorage::Worktree, shared);
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchDistinctRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "ERROR");
+        assert_eq!(
+            issues[0].rule_id.as_deref(),
+            Some(MIRROR_BRANCH_DISTINCT_ID.as_str()),
+        );
+        assert!(
+            issues[0].message.contains(shared),
+            "error should name the shared branch; got: {}",
+            issues[0].message,
+        );
+    }
+
+    #[test]
+    fn mirror_branch_distinct_passes_when_either_branch_empty() {
+        // Empty branches are flagged separately by `mirror-branch-set` /
+        // `coordination/branch-name-set`; the distinct rule should not
+        // double-report.
+        let cfg = config(
+            true,
+            "",
+            CoordinationStorage::Worktree,
+            "ito/internal/changes",
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = NoopRunner;
+        let staged = StagedFiles::empty();
+        let ctx = ctx_for(&cfg, &tmp, &runner, &staged);
+
+        let issues = MirrorBranchDistinctRule.check(&ctx).unwrap();
+        assert!(issues.is_empty());
+    }
+}

--- a/ito-rs/crates/ito-core/src/validate_repo/backend_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/backend_rules.rs
@@ -1,0 +1,604 @@
+//! Rules under the `backend/*` namespace.
+//!
+//! All three rules gate on `backend.enabled == true`.
+//!
+//! - `backend/token-not-committed` — a security-critical check: the
+//!   `backend.token` MUST NOT be committed to a tracked configuration
+//!   file. Severity is **`ERROR` regardless** of the engine's `--strict`
+//!   flag.
+//! - `backend/url-scheme-valid` — `backend.url` must be a parseable
+//!   `http`/`https` URL.
+//! - `backend/project-org-repo-set` — multi-tenant routing requires both
+//!   `backend.project.org` and `backend.project.repo`.
+
+use std::path::Path;
+
+use ito_config::ConfigContext;
+use ito_config::load_cascading_project_config;
+use ito_config::types::ItoConfig;
+
+use crate::errors::CoreError;
+use crate::process::{ProcessRequest, ProcessRunner};
+use crate::validate::{ValidationIssue, error, with_metadata, with_rule_id};
+
+use super::rule::{Rule, RuleContext, RuleId, RuleSeverity};
+
+const TOKEN_NOT_COMMITTED_ID: RuleId = RuleId::new("backend/token-not-committed");
+const URL_SCHEME_VALID_ID: RuleId = RuleId::new("backend/url-scheme-valid");
+const PROJECT_ORG_REPO_SET_ID: RuleId = RuleId::new("backend/project-org-repo-set");
+
+// ── backend/token-not-committed ──────────────────────────────────────────
+
+/// `backend/token-not-committed` — flag a `backend.token` set in any
+/// tracked-by-git configuration layer.
+pub(crate) struct TokenNotCommittedRule;
+
+impl Rule for TokenNotCommittedRule {
+    fn id(&self) -> RuleId {
+        TOKEN_NOT_COMMITTED_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "`backend.token` is not committed to a tracked configuration file."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("backend.enabled == true")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        config.backend.enabled
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        // Reload the cascading config with per-layer breakdown. The
+        // engine's merged `ItoConfig` does not carry layer provenance.
+        let cfg_ctx = ConfigContext::from_process_env();
+        let ito_path = ctx.project_root.join(".ito");
+        let cascading = load_cascading_project_config(ctx.project_root, &ito_path, &cfg_ctx);
+
+        let mut issues = Vec::new();
+        for layer in &cascading.layers {
+            let Some(token) = layer
+                .value
+                .get("backend")
+                .and_then(|b| b.get("token"))
+                .and_then(|t| t.as_str())
+            else {
+                continue;
+            };
+            if token.trim().is_empty() {
+                continue;
+            }
+
+            // Each layer is potentially a leak. Classify by path so the
+            // operator can immediately tell whether to rotate or to
+            // change the source.
+            let path_str = layer.path.to_string_lossy();
+            if !is_layer_tracked_in_git(ctx.runner, ctx.project_root, &layer.path)? {
+                continue;
+            }
+
+            let issue = error(
+                &path_str,
+                format!(
+                    "`backend.token` is set in `{path_str}`, which is tracked by git. \
+                     Committing the token to history is a security incident; rotate it \
+                     immediately and move the value to an environment variable, a \
+                     gitignored config layer, or a system keychain.",
+                ),
+            );
+            let issue = with_rule_id(issue, TOKEN_NOT_COMMITTED_ID.as_str());
+            issues.push(with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!(
+                        "1) Rotate the token at the backend. \
+                         2) Remove `backend.token` from `{path_str}`. \
+                         3) Set the new token via the `ITO_BACKEND_TOKEN` env var, or \
+                         add it to `.ito/config.local.json` (gitignored)."
+                    ),
+                    "tracked_path": path_str,
+                }),
+            ));
+        }
+
+        Ok(issues)
+    }
+}
+
+/// True when `path` is currently tracked by git.
+///
+/// Mirrors `repository::sqlite-db-not-committed`'s helper but scoped to a
+/// config layer path. Returns `false` on any git failure so the rule errs
+/// on the side of NOT emitting a false positive (a false negative here is
+/// less harmful than blocking commits with a phantom error).
+fn is_layer_tracked_in_git(
+    runner: &dyn ProcessRunner,
+    project_root: &Path,
+    path: &Path,
+) -> Result<bool, CoreError> {
+    let rel = match path.strip_prefix(project_root) {
+        Ok(rel) => rel.to_path_buf(),
+        // Layer is outside the project (e.g. ~/.config/ito/config.json) —
+        // by definition not tracked in this repo.
+        Err(_) => return Ok(false),
+    };
+    let rel_str = rel.to_string_lossy().into_owned();
+
+    let request = ProcessRequest::new("git")
+        .args(["ls-files", "--error-unmatch", "--", &rel_str])
+        .current_dir(project_root);
+
+    let output = runner.run(&request).map_err(|err| {
+        CoreError::process(format!(
+            "Cannot check whether `{rel_str}` is tracked by git.\n\
+             Why: {err}\n\
+             Fix: ensure git is installed and `{root}` is a git repository.",
+            root = project_root.display(),
+        ))
+    })?;
+    Ok(output.success)
+}
+
+// ── backend/url-scheme-valid ─────────────────────────────────────────────
+
+/// `backend/url-scheme-valid` — `backend.url` must be a non-empty,
+/// parseable URL with an `http` or `https` scheme.
+pub(crate) struct UrlSchemeValidRule;
+
+impl Rule for UrlSchemeValidRule {
+    fn id(&self) -> RuleId {
+        URL_SCHEME_VALID_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "`backend.url` is a parseable http(s) URL."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("backend.enabled == true")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        config.backend.enabled
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let url = ctx.config.backend.url.trim();
+        if url.is_empty() {
+            return Ok(vec![issue_for_url_problem(
+                "`backend.url` is empty while `backend.enabled = true`.",
+                "Set `backend.url` to the backend endpoint, for example `https://api.example.com`.",
+            )]);
+        }
+
+        // Lightweight scheme check: avoid a `url` crate dependency.
+        // Spec only requires accept http/https; reject everything else.
+        let Some((scheme, rest)) = url.split_once("://") else {
+            return Ok(vec![issue_for_url_problem(
+                format!("`backend.url = \"{url}\"` is not a parseable URL (missing scheme)."),
+                "Use a full URL with an `http://` or `https://` prefix.",
+            )]);
+        };
+
+        match scheme {
+            "http" | "https" => {}
+            other => {
+                return Ok(vec![issue_for_url_problem(
+                    format!(
+                        "`backend.url = \"{url}\"` uses unsupported scheme `{other}`. \
+                         Only `http` and `https` are accepted."
+                    ),
+                    "Switch the URL to `http://` or `https://`.",
+                )]);
+            }
+        }
+
+        if rest.trim().is_empty() {
+            return Ok(vec![issue_for_url_problem(
+                format!("`backend.url = \"{url}\"` has no host."),
+                "Use a full URL with a host, for example `https://api.example.com`.",
+            )]);
+        }
+
+        Ok(Vec::new())
+    }
+}
+
+fn issue_for_url_problem(message: impl Into<String>, fix: impl Into<String>) -> ValidationIssue {
+    let issue = error(".ito/config.json", message);
+    let issue = with_rule_id(issue, URL_SCHEME_VALID_ID.as_str());
+    with_metadata(
+        issue,
+        serde_json::json!({
+            "fix": fix.into(),
+            "config_key": "backend.url",
+        }),
+    )
+}
+
+// ── backend/project-org-repo-set ─────────────────────────────────────────
+
+/// `backend/project-org-repo-set` — both `backend.project.org` and
+/// `backend.project.repo` must be set when the backend is enabled.
+pub(crate) struct ProjectOrgRepoSetRule;
+
+impl Rule for ProjectOrgRepoSetRule {
+    fn id(&self) -> RuleId {
+        PROJECT_ORG_REPO_SET_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "`backend.project.org` and `backend.project.repo` are both set."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("backend.enabled == true")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        config.backend.enabled
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let mut issues = Vec::new();
+        let project = &ctx.config.backend.project;
+        let org_set = project
+            .org
+            .as_ref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+        let repo_set = project
+            .repo
+            .as_ref()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false);
+
+        if !org_set {
+            issues.push(missing_identifier_issue("backend.project.org"));
+        }
+        if !repo_set {
+            issues.push(missing_identifier_issue("backend.project.repo"));
+        }
+        Ok(issues)
+    }
+}
+
+fn missing_identifier_issue(key: &'static str) -> ValidationIssue {
+    let issue = error(
+        ".ito/config.json",
+        format!(
+            "`{key}` is empty or unset. Multi-tenant backend routing requires both \
+             `backend.project.org` and `backend.project.repo`."
+        ),
+    );
+    let issue = with_rule_id(issue, PROJECT_ORG_REPO_SET_ID.as_str());
+    with_metadata(
+        issue,
+        serde_json::json!({
+            "fix": format!("Set `{key}` in `.ito/config.json`."),
+            "config_key": key,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::{ProcessExecutionError, ProcessOutput, ProcessRequest, ProcessRunner};
+    use crate::validate_repo::staged::StagedFiles;
+    use ito_config::types::{BackendApiConfig, BackendProjectConfig, ItoConfig};
+    use std::cell::RefCell;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    struct ScriptedRunner {
+        rules: Vec<(Vec<&'static str>, ProcessOutput)>,
+        default: ProcessOutput,
+        seen: RefCell<Vec<ProcessRequest>>,
+    }
+
+    fn ok_output(success: bool, exit_code: i32) -> ProcessOutput {
+        ProcessOutput {
+            exit_code,
+            success,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+        }
+    }
+
+    impl ScriptedRunner {
+        fn new(default: ProcessOutput) -> Self {
+            Self {
+                rules: Vec::new(),
+                default,
+                seen: RefCell::new(Vec::new()),
+            }
+        }
+        fn with_rule(mut self, args_prefix: &[&'static str], output: ProcessOutput) -> Self {
+            self.rules.push((args_prefix.to_vec(), output));
+            self
+        }
+    }
+
+    impl ProcessRunner for ScriptedRunner {
+        fn run(&self, request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.seen.borrow_mut().push(request.clone());
+            for (prefix, output) in &self.rules {
+                if request.args.len() >= prefix.len()
+                    && request.args.iter().zip(prefix.iter()).all(|(a, b)| a == b)
+                {
+                    return Ok(output.clone());
+                }
+            }
+            Ok(self.default.clone())
+        }
+        fn run_with_timeout(
+            &self,
+            request: &ProcessRequest,
+            _timeout: Duration,
+        ) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.run(request)
+        }
+    }
+
+    fn config(enabled: bool, url: &str, org: Option<&str>, repo: Option<&str>) -> ItoConfig {
+        ItoConfig {
+            backend: BackendApiConfig {
+                enabled,
+                url: url.to_string(),
+                project: BackendProjectConfig {
+                    org: org.map(str::to_string),
+                    repo: repo.map(str::to_string),
+                },
+                ..BackendApiConfig::default()
+            },
+            ..ItoConfig::default()
+        }
+    }
+
+    fn ctx_for<'a>(
+        cfg: &'a ItoConfig,
+        tmp: &'a TempDir,
+        runner: &'a dyn ProcessRunner,
+        staged: &'a StagedFiles,
+    ) -> RuleContext<'a> {
+        RuleContext::new(cfg, tmp.path(), staged, runner)
+    }
+
+    // ── activation ───────────────────────────────────────────────────────
+
+    #[test]
+    fn rules_inactive_when_backend_disabled() {
+        let cfg = config(false, "https://example.com", Some("a"), Some("b"));
+        assert!(!TokenNotCommittedRule.is_active(&cfg));
+        assert!(!UrlSchemeValidRule.is_active(&cfg));
+        assert!(!ProjectOrgRepoSetRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn rules_active_when_backend_enabled() {
+        let cfg = config(true, "https://example.com", Some("a"), Some("b"));
+        assert!(TokenNotCommittedRule.is_active(&cfg));
+        assert!(UrlSchemeValidRule.is_active(&cfg));
+        assert!(ProjectOrgRepoSetRule.is_active(&cfg));
+    }
+
+    // ── backend/url-scheme-valid ─────────────────────────────────────────
+
+    #[test]
+    fn url_scheme_passes_for_https() {
+        let cfg = config(true, "https://api.example.com", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn url_scheme_passes_for_http() {
+        let cfg = config(true, "http://localhost:9010", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn url_scheme_fails_for_ftp() {
+        let cfg = config(true, "ftp://files.example.com", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "ERROR");
+        assert!(issues[0].message.contains("ftp"));
+    }
+
+    #[test]
+    fn url_scheme_fails_for_unparseable() {
+        let cfg = config(true, "not a url", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("not a parseable URL"));
+    }
+
+    #[test]
+    fn url_scheme_fails_for_empty() {
+        let cfg = config(true, "", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("empty"));
+    }
+
+    // ── backend/project-org-repo-set ─────────────────────────────────────
+
+    #[test]
+    fn project_org_repo_passes_when_both_set() {
+        let cfg = config(true, "https://x", Some("withakay"), Some("ito"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = ProjectOrgRepoSetRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn project_org_repo_fails_when_org_missing() {
+        let cfg = config(true, "https://x", None, Some("ito"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = ProjectOrgRepoSetRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("backend.project.org"));
+    }
+
+    #[test]
+    fn project_org_repo_fails_when_repo_missing() {
+        let cfg = config(true, "https://x", Some("withakay"), None);
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = ProjectOrgRepoSetRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("backend.project.repo"));
+    }
+
+    #[test]
+    fn project_org_repo_reports_both_when_both_missing() {
+        let cfg = config(true, "https://x", None, None);
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = ProjectOrgRepoSetRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 2);
+    }
+
+    // ── backend/token-not-committed ──────────────────────────────────────
+
+    #[test]
+    fn token_not_committed_passes_when_no_layer_sets_token() {
+        // A fresh tempdir has no config files, so `cascading.layers` is
+        // empty and the rule is silent.
+        let cfg = config(true, "https://x", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = TokenNotCommittedRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn token_not_committed_fails_when_token_in_tracked_config() {
+        // Fixture: `.ito/config.json` (tracked) sets backend.token.
+        // ScriptedRunner returns success for `git ls-files --error-unmatch`,
+        // simulating a tracked file.
+        let cfg = config(true, "https://x", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ito")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ito/config.json"),
+            r#"{"backend": {"token": "secret-leak"}}"#,
+        )
+        .unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1))
+            .with_rule(&["ls-files", "--error-unmatch"], ok_output(true, 0));
+        let staged = StagedFiles::empty();
+        let issues = TokenNotCommittedRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1, "expected one error, got {issues:?}");
+        assert_eq!(issues[0].level, "ERROR");
+        assert!(issues[0].message.contains("tracked by git"));
+    }
+
+    #[test]
+    fn token_not_committed_passes_when_token_in_local_config() {
+        // Fixture: `.ito/config.local.json` sets the token but is NOT
+        // tracked (git ls-files --error-unmatch returns failure).
+        let cfg = config(true, "https://x", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ito")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ito/config.local.json"),
+            r#"{"backend": {"token": "secret-but-local"}}"#,
+        )
+        .unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = TokenNotCommittedRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn token_not_committed_severity_unaffected_by_strict_mode() {
+        // The rule emits ERROR severity directly; strict mode is applied
+        // by the engine at report-build time but cannot weaken an
+        // already-ERROR issue. This test pins the severity contract so a
+        // future refactor that changes it is caught.
+        let cfg = config(true, "https://x", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ito")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ito/config.json"),
+            r#"{"backend": {"token": "leak"}}"#,
+        )
+        .unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1))
+            .with_rule(&["ls-files", "--error-unmatch"], ok_output(true, 0));
+        let staged = StagedFiles::empty();
+        let issues = TokenNotCommittedRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "ERROR");
+        // Rule's nominal severity is ERROR.
+        assert_eq!(TokenNotCommittedRule.severity(), RuleSeverity::Error);
+    }
+}

--- a/ito-rs/crates/ito-core/src/validate_repo/backend_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/backend_rules.rs
@@ -53,10 +53,17 @@ impl Rule for TokenNotCommittedRule {
     fn is_active(&self, config: &ItoConfig) -> bool {
         config.backend.enabled
     }
-
     fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
-        // Reload the cascading config with per-layer breakdown. The
-        // engine's merged `ItoConfig` does not carry layer provenance.
+        // We reload the cascading config here rather than receiving it via
+        // `RuleContext` because the engine's merged `ItoConfig` discards
+        // per-layer provenance and we need to know which layer set the
+        // token. The extra disk I/O is acceptable for an infrequent
+        // validation pass; the TOCTOU window between engine init and rule
+        // execution is negligible in practice.
+        //
+        // `ConfigContext::from_process_env()` matches the CLI's view of
+        // the layer set (XDG / HOME / PROJECT_DIR), so the rule reports
+        // what an operator running `ito validate repo` actually sees.
         let cfg_ctx = ConfigContext::from_process_env();
         let ito_path = ctx.project_root.join(".ito");
         let cascading = load_cascading_project_config(ctx.project_root, &ito_path, &cfg_ctx);
@@ -176,7 +183,8 @@ impl Rule for UrlSchemeValidRule {
         let url = ctx.config.backend.url.trim();
         if url.is_empty() {
             return Ok(vec![issue_for_url_problem(
-                "`backend.url` is empty while `backend.enabled = true`.",
+                "`backend.url` is empty while `backend.enabled = true`. \
+                 The backend client requires an addressable endpoint to connect to.",
                 "Set `backend.url` to the backend endpoint, for example `https://api.example.com`.",
             )]);
         }
@@ -192,6 +200,10 @@ impl Rule for UrlSchemeValidRule {
 
         match scheme {
             "http" | "https" => {}
+            // `scheme` is a free-form string from `split_once`; we cannot
+            // exhaustively enumerate every possible value, so a catch-all
+            // arm is the only option here. (See `.agents/skills/rust-style`
+            // — wildcards are allowed when the matched type is open.)
             other => {
                 return Ok(vec![issue_for_url_problem(
                     format!(
@@ -452,6 +464,24 @@ mod tests {
     }
 
     #[test]
+    fn url_scheme_fails_for_scheme_only_no_host() {
+        // Edge case: scheme is valid but `://` is followed by nothing.
+        let cfg = config(true, "https://", Some("a"), Some("b"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let issues = UrlSchemeValidRule
+            .check(&ctx_for(&cfg, &tmp, &runner, &staged))
+            .unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(
+            issues[0].message.contains("no host"),
+            "expected 'no host' message; got: {}",
+            issues[0].message,
+        );
+    }
+
+    #[test]
     fn url_scheme_fails_for_empty() {
         let cfg = config(true, "", Some("a"), Some("b"));
         let tmp = TempDir::new().unwrap();
@@ -577,11 +607,11 @@ mod tests {
     }
 
     #[test]
-    fn token_not_committed_severity_unaffected_by_strict_mode() {
-        // The rule emits ERROR severity directly; strict mode is applied
-        // by the engine at report-build time but cannot weaken an
-        // already-ERROR issue. This test pins the severity contract so a
-        // future refactor that changes it is caught.
+    fn token_not_committed_emits_error_severity_directly() {
+        // The rule constructs ERROR-level issues via `error()` rather than
+        // returning WARNINGs that strict mode would promote. This test
+        // pins the severity contract so a future refactor can't silently
+        // demote the rule to WARNING.
         let cfg = config(true, "https://x", Some("a"), Some("b"));
         let tmp = TempDir::new().unwrap();
         std::fs::create_dir_all(tmp.path().join(".ito")).unwrap();
@@ -598,7 +628,51 @@ mod tests {
             .unwrap();
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].level, "ERROR");
-        // Rule's nominal severity is ERROR.
         assert_eq!(TokenNotCommittedRule.severity(), RuleSeverity::Error);
+    }
+
+    #[test]
+    fn token_not_committed_strict_flag_does_not_weaken_severity() {
+        // End-to-end check: run the rule through the engine path with
+        // both `strict = false` and `strict = true` and confirm the
+        // emitted issue has level "ERROR" in both cases. The engine's
+        // strict flag promotes WARNINGs to errors but never demotes an
+        // existing ERROR.
+        use crate::validate_repo::run_repo_validation;
+
+        let mut cfg = config(true, "https://x", Some("a"), Some("b"));
+        // Disable every other gated rule so only `backend/*` rules fire
+        // under this fixture.
+        cfg.changes.coordination_branch.storage = ito_config::types::CoordinationStorage::Embedded;
+        cfg.worktrees.enabled = false;
+
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ito")).unwrap();
+        std::fs::write(
+            tmp.path().join(".ito/config.json"),
+            r#"{"backend": {"token": "leak"}}"#,
+        )
+        .unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1))
+            .with_rule(&["ls-files", "--error-unmatch"], ok_output(true, 0));
+        let staged = StagedFiles::empty();
+
+        for strict in [false, true] {
+            let report = run_repo_validation(&cfg, tmp.path(), &staged, &runner, strict);
+            let token_issues: Vec<_> = report
+                .issues
+                .iter()
+                .filter(|i| i.rule_id.as_deref() == Some(TOKEN_NOT_COMMITTED_ID.as_str()))
+                .collect();
+            assert_eq!(
+                token_issues.len(),
+                1,
+                "expected one token issue (strict={strict}); got {token_issues:?}",
+            );
+            assert_eq!(
+                token_issues[0].level, "ERROR",
+                "token-not-committed must always emit ERROR (strict={strict})",
+            );
+        }
     }
 }

--- a/ito-rs/crates/ito-core/src/validate_repo/mod.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/mod.rs
@@ -35,9 +35,12 @@ use ito_config::types::ItoConfig;
 use crate::process::ProcessRunner;
 use crate::validate::{ValidationReport, report, with_rule_id};
 
+pub mod audit_rules;
+pub mod backend_rules;
 pub mod coordination_rules;
 pub mod pre_commit_detect;
 pub mod registry;
+pub mod repository_rules;
 pub mod rule;
 pub mod staged;
 pub mod worktrees_rules;

--- a/ito-rs/crates/ito-core/src/validate_repo/registry.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/registry.rs
@@ -333,6 +333,193 @@ mod tests {
         );
     }
 
+    /// Activation matrix for the full built-in rule set.
+    ///
+    /// Each row is a config permutation and the rule ids that should be
+    /// `active = true` for it. Rules not listed are expected to be
+    /// inactive. This test catches accidental gate changes by enforcing
+    /// the entire matrix at once rather than one rule at a time.
+    #[test]
+    fn list_active_rules_matrix_matches_specification() {
+        use ito_config::types::{
+            AuditConfig, AuditMirrorConfig, BackendApiConfig, BackendProjectConfig, ChangesConfig,
+            CoordinationBranchConfig, CoordinationStorage, RepositoryPersistenceMode,
+            RepositoryRuntimeConfig, RepositorySqliteConfig, WorktreesConfig,
+        };
+
+        struct Case {
+            label: &'static str,
+            mutate: fn(&mut ItoConfig),
+            expected_active: &'static [&'static str],
+        }
+
+        // Always-active rule applies to every row.
+        const ALWAYS: &[&str] = &["coordination/branch-name-set"];
+
+        let cases = [
+            Case {
+                label: "minimal: embedded coord, worktrees off, fs repo, backend/audit off",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Embedded;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = false;
+                    c.backend.enabled = false;
+                },
+                expected_active: ALWAYS,
+            },
+            Case {
+                label: "coordination_worktree only",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Worktree;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = false;
+                    c.backend.enabled = false;
+                },
+                expected_active: &[
+                    "coordination/branch-name-set",
+                    "coordination/gitignore-entries",
+                    "coordination/staged-symlinked-paths",
+                    "coordination/symlinks-wired",
+                ],
+            },
+            Case {
+                label: "worktrees enabled only",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Embedded;
+                    c.worktrees.enabled = true;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = false;
+                    c.backend.enabled = false;
+                },
+                expected_active: &[
+                    "coordination/branch-name-set",
+                    "worktrees/layout-consistent",
+                    "worktrees/no-write-on-control",
+                ],
+            },
+            Case {
+                label: "audit mirror enabled, embedded coord (distinct rule still skipped)",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Embedded;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = true;
+                    c.backend.enabled = false;
+                },
+                expected_active: &["audit/mirror-branch-set", "coordination/branch-name-set"],
+            },
+            Case {
+                label: "audit mirror + worktree coord (both audit rules active)",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Worktree;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = true;
+                    c.backend.enabled = false;
+                },
+                expected_active: &[
+                    "audit/mirror-branch-distinct-from-coordination",
+                    "audit/mirror-branch-set",
+                    "coordination/branch-name-set",
+                    "coordination/gitignore-entries",
+                    "coordination/staged-symlinked-paths",
+                    "coordination/symlinks-wired",
+                ],
+            },
+            Case {
+                label: "sqlite repo only",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Embedded;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Sqlite;
+                    c.audit.mirror.enabled = false;
+                    c.backend.enabled = false;
+                },
+                expected_active: &[
+                    "coordination/branch-name-set",
+                    "repository/sqlite-db-not-committed",
+                    "repository/sqlite-db-path-set",
+                ],
+            },
+            Case {
+                label: "backend enabled only",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Embedded;
+                    c.worktrees.enabled = false;
+                    c.repository.mode = RepositoryPersistenceMode::Filesystem;
+                    c.audit.mirror.enabled = false;
+                    c.backend.enabled = true;
+                },
+                expected_active: &[
+                    "backend/project-org-repo-set",
+                    "backend/token-not-committed",
+                    "backend/url-scheme-valid",
+                    "coordination/branch-name-set",
+                ],
+            },
+            Case {
+                label: "everything on (all 13 rules active)",
+                mutate: |c| {
+                    c.changes.coordination_branch.storage = CoordinationStorage::Worktree;
+                    c.worktrees.enabled = true;
+                    c.repository.mode = RepositoryPersistenceMode::Sqlite;
+                    c.audit.mirror.enabled = true;
+                    c.backend.enabled = true;
+                },
+                expected_active: &[
+                    "audit/mirror-branch-distinct-from-coordination",
+                    "audit/mirror-branch-set",
+                    "backend/project-org-repo-set",
+                    "backend/token-not-committed",
+                    "backend/url-scheme-valid",
+                    "coordination/branch-name-set",
+                    "coordination/gitignore-entries",
+                    "coordination/staged-symlinked-paths",
+                    "coordination/symlinks-wired",
+                    "repository/sqlite-db-not-committed",
+                    "repository/sqlite-db-path-set",
+                    "worktrees/layout-consistent",
+                    "worktrees/no-write-on-control",
+                ],
+            },
+        ];
+
+        // Suppress unused warnings when the matrix references types that
+        // some compilation units may not exercise.
+        let _ = (
+            AuditConfig::default(),
+            AuditMirrorConfig::default(),
+            BackendApiConfig::default(),
+            BackendProjectConfig::default(),
+            ChangesConfig::default(),
+            CoordinationBranchConfig::default(),
+            RepositoryRuntimeConfig::default(),
+            RepositorySqliteConfig::default(),
+            WorktreesConfig::default(),
+        );
+
+        for case in &cases {
+            let mut cfg = ItoConfig::default();
+            (case.mutate)(&mut cfg);
+
+            let active_ids: Vec<_> = list_active_rules(&cfg)
+                .into_iter()
+                .filter(|r| r.active)
+                .map(|r| r.rule_id.as_str())
+                .collect();
+
+            let expected: Vec<&str> = case.expected_active.iter().copied().collect();
+            assert_eq!(
+                active_ids,
+                expected,
+                "case `{label}`: active set mismatch",
+                label = case.label,
+            );
+        }
+    }
+
     #[test]
     fn public_list_active_rules_delegates_to_built_in_registry() {
         let config = ItoConfig::default();

--- a/ito-rs/crates/ito-core/src/validate_repo/registry.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/registry.rs
@@ -510,7 +510,7 @@ mod tests {
                 .map(|r| r.rule_id.as_str())
                 .collect();
 
-            let expected: Vec<&str> = case.expected_active.iter().copied().collect();
+            let expected: Vec<&str> = case.expected_active.to_vec();
             assert_eq!(
                 active_ids,
                 expected,

--- a/ito-rs/crates/ito-core/src/validate_repo/registry.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/registry.rs
@@ -58,24 +58,41 @@ impl RuleRegistry {
 
     /// Construct a registry pre-populated with every built-in rule.
     ///
-    /// Wave 2 registers the `coordination/*` and `worktrees/*` rules.
-    /// Change `011-06` adds the `audit/*`, `repository/*`, and `backend/*`
-    /// rules. Order of registration does not matter —
-    /// [`list_active_rules`] sorts by `RuleId` for deterministic output.
+    /// Order of registration does not matter — [`list_active_rules`] sorts
+    /// by `RuleId` for deterministic output.
+    ///
+    /// Built-in rules:
+    ///
+    /// - `coordination/*` and `worktrees/*` — change 011-05.
+    /// - `audit/*`, `repository/*`, `backend/*` — change 011-06.
     #[must_use]
     pub fn built_in() -> Self {
+        use super::audit_rules::{MirrorBranchDistinctRule, MirrorBranchSetRule};
+        use super::backend_rules::{
+            ProjectOrgRepoSetRule, TokenNotCommittedRule, UrlSchemeValidRule,
+        };
         use super::coordination_rules::{
             BranchNameSetRule, GitignoreEntriesRule, StagedSymlinkedPathsRule, SymlinksWiredRule,
         };
+        use super::repository_rules::{SqliteDbNotCommittedRule, SqliteDbPathSetRule};
         use super::worktrees_rules::{LayoutConsistentRule, NoWriteOnControlRule};
 
         Self::empty()
+            // 011-05: coordination/*, worktrees/*
             .with_rule(Box::new(SymlinksWiredRule))
             .with_rule(Box::new(GitignoreEntriesRule))
             .with_rule(Box::new(StagedSymlinkedPathsRule))
             .with_rule(Box::new(BranchNameSetRule))
             .with_rule(Box::new(NoWriteOnControlRule))
             .with_rule(Box::new(LayoutConsistentRule))
+            // 011-06: audit/*, repository/*, backend/*
+            .with_rule(Box::new(MirrorBranchSetRule))
+            .with_rule(Box::new(MirrorBranchDistinctRule))
+            .with_rule(Box::new(SqliteDbPathSetRule))
+            .with_rule(Box::new(SqliteDbNotCommittedRule))
+            .with_rule(Box::new(TokenNotCommittedRule))
+            .with_rule(Box::new(UrlSchemeValidRule))
+            .with_rule(Box::new(ProjectOrgRepoSetRule))
     }
 
     /// Register a rule with this registry.
@@ -217,18 +234,31 @@ mod tests {
     }
 
     #[test]
-    fn built_in_registry_contains_all_wave2_rules() {
+    fn built_in_registry_contains_every_built_in_rule() {
         let registry = RuleRegistry::built_in();
-        // Six rules ship in Wave 2 of change 011-05:
-        // - coordination/{symlinks-wired,gitignore-entries,staged-symlinked-paths,branch-name-set}
-        // - worktrees/{no-write-on-control,layout-consistent}
+        // Thirteen rules ship after changes 011-05 + 011-06:
+        // - 011-05: coordination/{symlinks-wired,gitignore-entries,
+        //   staged-symlinked-paths,branch-name-set} + worktrees/{
+        //   no-write-on-control,layout-consistent} = 6.
+        // - 011-06: audit/{mirror-branch-set,
+        //   mirror-branch-distinct-from-coordination} +
+        //   repository/{sqlite-db-path-set,sqlite-db-not-committed} +
+        //   backend/{token-not-committed,url-scheme-valid,
+        //   project-org-repo-set} = 7.
         let ids: Vec<_> = registry.iter().map(|r| r.id().as_str()).collect();
-        assert_eq!(ids.len(), 6, "expected 6 built-in rules, got {ids:?}");
+        assert_eq!(ids.len(), 13, "expected 13 built-in rules, got {ids:?}");
         for expected in [
+            "audit/mirror-branch-distinct-from-coordination",
+            "audit/mirror-branch-set",
+            "backend/project-org-repo-set",
+            "backend/token-not-committed",
+            "backend/url-scheme-valid",
             "coordination/branch-name-set",
             "coordination/gitignore-entries",
             "coordination/staged-symlinked-paths",
             "coordination/symlinks-wired",
+            "repository/sqlite-db-not-committed",
+            "repository/sqlite-db-path-set",
             "worktrees/layout-consistent",
             "worktrees/no-write-on-control",
         ] {

--- a/ito-rs/crates/ito-core/src/validate_repo/repository_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/repository_rules.rs
@@ -46,15 +46,68 @@ fn resolve_db_path(config: &ItoConfig, project_root: &Path) -> Option<PathBuf> {
     }
 }
 
-/// True when `path` is inside `root` (after lexical normalization).
+/// True when `path` is inside `root` after both lexical normalization
+/// (collapsing `..` and `.` components) AND, when possible, OS-level
+/// canonicalization (resolving symlinks).
+///
+/// `Path::starts_with` is component-based and does NOT resolve `..`, so a
+/// fallback that uses it directly would let `<root>/.ito/state/../../etc/passwd`
+/// claim to be "inside the root". The lexical normalisation below
+/// closes that hole when the file does not yet exist (so
+/// `Path::canonicalize` is unavailable).
 fn path_inside_root(path: &Path, root: &Path) -> bool {
-    let Ok(canonical_root) = root.canonicalize() else {
-        return path.starts_with(root);
-    };
-    if let Ok(canonical_path) = path.canonicalize() {
-        return canonical_path.starts_with(&canonical_root);
+    let canonical_root = root.canonicalize().ok();
+
+    // Best case: canonicalize both. Resolves symlinks too.
+    if let Some(canonical_root) = canonical_root.as_ref()
+        && let Ok(canonical_path) = path.canonicalize()
+    {
+        return canonical_path.starts_with(canonical_root);
     }
-    path.starts_with(root)
+
+    // File doesn't exist yet (or root cannot be canonicalised). Lexically
+    // normalise `path`, then compare against the canonicalised root (when
+    // available) AND the original root — handles macOS where `/var` →
+    // `/private/var` so a path under `/var/...` would not literally
+    // start with `/private/var`.
+    let normalized = lexical_normalize(path);
+    if let Some(canonical_root) = canonical_root.as_ref()
+        && normalized.starts_with(canonical_root)
+    {
+        return true;
+    }
+    normalized.starts_with(root)
+}
+
+/// Collapse `.` and `..` components without touching the filesystem.
+///
+/// Unlike `Path::canonicalize`, this is purely lexical — `..` after a
+/// regular component pops the previous component; `..` after `..` or at
+/// the start is kept (we cannot know what the parent of an unknown root
+/// is).
+fn lexical_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out: Vec<Component<'_>> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                let pops_prior_normal = match out.last() {
+                    Some(Component::Normal(_)) => true,
+                    Some(_) | None => false,
+                };
+                if pops_prior_normal {
+                    out.pop();
+                } else {
+                    out.push(component);
+                }
+            }
+            Component::CurDir => {}
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                out.push(component);
+            }
+        }
+    }
+    out.iter().collect()
 }
 
 // ── repository/sqlite-db-path-set ────────────────────────────────────────
@@ -132,7 +185,9 @@ impl Rule for SqliteDbPathSetRule {
             let issue = warning(
                 ".ito/config.json",
                 format!(
-                    "`repository.sqlite.db_path` parent directory does not exist: `{parent}`.",
+                    "`repository.sqlite.db_path` parent directory does not exist: `{parent}`. \
+                     SQLite cannot create parent directories on its own; the database open \
+                     will fail at runtime if the directory is still missing.",
                     parent = parent.display(),
                 ),
             );
@@ -413,6 +468,34 @@ mod tests {
         let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
         assert_eq!(issues.len(), 1);
         assert!(issues[0].message.contains("outside the project root"));
+    }
+
+    #[test]
+    fn sqlite_db_path_set_errors_when_path_escapes_root_via_dotdot() {
+        // Regression test for a `..` traversal bypass in path_inside_root:
+        // `Path::starts_with` is component-based and does not resolve `..`,
+        // so a path of `.ito/state/../../../etc/passwd` could appear to
+        // "start with" the project root while actually escaping it.
+        let cfg = config(
+            RepositoryPersistenceMode::Sqlite,
+            Some(".ito/state/../../../etc/passwd"),
+        );
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
+        assert_eq!(
+            issues.len(),
+            1,
+            "expected one error for `..` traversal escape; got {issues:?}",
+        );
+        assert!(
+            issues[0].message.contains("outside the project root"),
+            "expected outside-root message; got: {}",
+            issues[0].message,
+        );
     }
 
     #[test]

--- a/ito-rs/crates/ito-core/src/validate_repo/repository_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate_repo/repository_rules.rs
@@ -1,0 +1,511 @@
+//! Rules under the `repository/*` namespace.
+//!
+//! Both rules gate on `repository.mode == sqlite`. When the project uses
+//! the filesystem-backed repository, neither rule fires.
+//!
+//! - `repository/sqlite-db-path-set` — the configured `db_path` must
+//!   resolve inside the project root and have an existing parent
+//!   directory.
+//! - `repository/sqlite-db-not-committed` — the database file MUST NOT
+//!   be tracked by git AND SHOULD be covered by a `.gitignore` entry.
+
+use std::path::{Path, PathBuf};
+
+use ito_config::types::{ItoConfig, RepositoryPersistenceMode};
+
+use crate::errors::CoreError;
+use crate::process::{ProcessRequest, ProcessRunner};
+use crate::validate::{ValidationIssue, error, warning, with_metadata, with_rule_id};
+
+use super::rule::{Rule, RuleContext, RuleId, RuleSeverity};
+
+const SQLITE_DB_PATH_SET_ID: RuleId = RuleId::new("repository/sqlite-db-path-set");
+const SQLITE_DB_NOT_COMMITTED_ID: RuleId = RuleId::new("repository/sqlite-db-not-committed");
+
+/// True when the repository persistence mode is sqlite.
+fn mode_is_sqlite(config: &ItoConfig) -> bool {
+    match config.repository.mode {
+        RepositoryPersistenceMode::Sqlite => true,
+        RepositoryPersistenceMode::Filesystem => false,
+    }
+}
+
+/// Return the configured sqlite db path resolved against `project_root`.
+///
+/// Returns `None` when the path is unset or empty.
+fn resolve_db_path(config: &ItoConfig, project_root: &Path) -> Option<PathBuf> {
+    let raw = config.repository.sqlite.db_path.as_ref()?.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        Some(project_root.join(path))
+    }
+}
+
+/// True when `path` is inside `root` (after lexical normalization).
+fn path_inside_root(path: &Path, root: &Path) -> bool {
+    let Ok(canonical_root) = root.canonicalize() else {
+        return path.starts_with(root);
+    };
+    if let Ok(canonical_path) = path.canonicalize() {
+        return canonical_path.starts_with(&canonical_root);
+    }
+    path.starts_with(root)
+}
+
+// ── repository/sqlite-db-path-set ────────────────────────────────────────
+
+/// `repository/sqlite-db-path-set` — sqlite db_path must be set and
+/// resolvable inside the project root.
+pub(crate) struct SqliteDbPathSetRule;
+
+impl Rule for SqliteDbPathSetRule {
+    fn id(&self) -> RuleId {
+        SQLITE_DB_PATH_SET_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "SQLite db_path is set, resolves inside the project root, and has an existing parent."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("repository.mode == sqlite")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        mode_is_sqlite(config)
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let Some(db_path) = resolve_db_path(ctx.config, ctx.project_root) else {
+            let issue = error(
+                ".ito/config.json",
+                "`repository.sqlite.db_path` is empty or unset while `repository.mode = \"sqlite\"`. \
+                 The runtime cannot open a database without a path.",
+            );
+            let issue = with_rule_id(issue, SQLITE_DB_PATH_SET_ID.as_str());
+            let issue = with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": "Set `repository.sqlite.db_path` to a project-relative path under \
+                            `.ito/state/`, e.g. `.ito/state/ito.db`.",
+                    "config_key": "repository.sqlite.db_path",
+                }),
+            );
+            return Ok(vec![issue]);
+        };
+
+        if !path_inside_root(&db_path, ctx.project_root) {
+            let issue = error(
+                ".ito/config.json",
+                format!(
+                    "`repository.sqlite.db_path = \"{path}\"` resolves outside the project root \
+                     (`{root}`). The repository runtime confines persistence to the project tree.",
+                    path = db_path.display(),
+                    root = ctx.project_root.display(),
+                ),
+            );
+            let issue = with_rule_id(issue, SQLITE_DB_PATH_SET_ID.as_str());
+            let issue = with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": "Use a project-relative path (e.g. `.ito/state/ito.db`).",
+                    "resolved": db_path.to_string_lossy(),
+                    "project_root": ctx.project_root.to_string_lossy(),
+                }),
+            );
+            return Ok(vec![issue]);
+        }
+
+        let mut issues = Vec::new();
+        if let Some(parent) = db_path.parent()
+            && !parent.exists()
+        {
+            let issue = warning(
+                ".ito/config.json",
+                format!(
+                    "`repository.sqlite.db_path` parent directory does not exist: `{parent}`.",
+                    parent = parent.display(),
+                ),
+            );
+            let issue = with_rule_id(issue, SQLITE_DB_PATH_SET_ID.as_str());
+            issues.push(with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!("Create the directory: `mkdir -p {}`", parent.display()),
+                    "missing_parent": parent.to_string_lossy(),
+                }),
+            ));
+        }
+
+        Ok(issues)
+    }
+}
+
+// ── repository/sqlite-db-not-committed ───────────────────────────────────
+
+/// `repository/sqlite-db-not-committed` — db file must not be tracked by
+/// git AND should be covered by `.gitignore`.
+pub(crate) struct SqliteDbNotCommittedRule;
+
+impl Rule for SqliteDbNotCommittedRule {
+    fn id(&self) -> RuleId {
+        SQLITE_DB_NOT_COMMITTED_ID
+    }
+
+    fn severity(&self) -> RuleSeverity {
+        RuleSeverity::Error
+    }
+
+    fn description(&self) -> &'static str {
+        "SQLite database file is not tracked by git and is covered by `.gitignore`."
+    }
+
+    fn gate(&self) -> Option<&'static str> {
+        Some("repository.mode == sqlite")
+    }
+
+    fn is_active(&self, config: &ItoConfig) -> bool {
+        mode_is_sqlite(config)
+    }
+
+    fn check(&self, ctx: &RuleContext<'_>) -> Result<Vec<ValidationIssue>, CoreError> {
+        let Some(db_path) = resolve_db_path(ctx.config, ctx.project_root) else {
+            // Companion rule `sqlite-db-path-set` reports the missing path.
+            return Ok(Vec::new());
+        };
+
+        let rel_str = match db_path.strip_prefix(ctx.project_root) {
+            Ok(rel) => rel.to_string_lossy().into_owned(),
+            Err(_) => db_path.to_string_lossy().into_owned(),
+        };
+
+        if git_tracks_path(ctx.runner, ctx.project_root, &rel_str)? {
+            let issue = error(
+                rel_str.clone(),
+                format!(
+                    "SQLite database `{rel_str}` is currently tracked by git. \
+                     Committing the live database leaks every entry through history \
+                     and corrupts the file across machine clones.",
+                ),
+            );
+            let issue = with_rule_id(issue, SQLITE_DB_NOT_COMMITTED_ID.as_str());
+            let issue = with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!(
+                        "Untrack: `git rm --cached {rel_str}`. \
+                         Then ensure `.gitignore` covers it (e.g. `{rel_str}` or \
+                         `{parent}/*.db`).",
+                        parent = std::path::Path::new(&rel_str)
+                            .parent()
+                            .map(std::path::Path::to_string_lossy)
+                            .unwrap_or_default(),
+                    ),
+                    "untrack_command": format!("git rm --cached {rel_str}"),
+                    "path": rel_str,
+                }),
+            );
+            return Ok(vec![issue]);
+        }
+
+        if !git_check_ignore(ctx.runner, ctx.project_root, &rel_str)? {
+            let issue = warning(
+                ".gitignore",
+                format!(
+                    "SQLite database `{rel_str}` is not currently tracked by git but is \
+                     also not covered by `.gitignore`. A future `git add .` would \
+                     accidentally commit it.",
+                ),
+            );
+            let issue = with_rule_id(issue, SQLITE_DB_NOT_COMMITTED_ID.as_str());
+            return Ok(vec![with_metadata(
+                issue,
+                serde_json::json!({
+                    "fix": format!("Append `{rel_str}` (or a glob like `*.db`) to `.gitignore`."),
+                    "path": rel_str,
+                }),
+            )]);
+        }
+
+        Ok(Vec::new())
+    }
+}
+
+/// Return `true` when `rel_path` is currently tracked by git.
+///
+/// Implementation: `git ls-files --error-unmatch <path>` exits 0 only when
+/// the path is in the index; non-zero means untracked or missing.
+fn git_tracks_path(
+    runner: &dyn ProcessRunner,
+    project_root: &Path,
+    rel_path: &str,
+) -> Result<bool, CoreError> {
+    let request = ProcessRequest::new("git")
+        .args(["ls-files", "--error-unmatch", "--", rel_path])
+        .current_dir(project_root);
+
+    let output = runner.run(&request).map_err(|err| {
+        CoreError::process(format!(
+            "Cannot run `git ls-files --error-unmatch {rel_path}`.\n\
+             Why: {err}\n\
+             Fix: ensure git is installed and `{root}` is a git repository.",
+            root = project_root.display(),
+        ))
+    })?;
+    Ok(output.success)
+}
+
+/// Return `true` when `rel_path` is matched by a `.gitignore` rule.
+///
+/// Implementation: `git check-ignore -q <path>` exits 0 when the path is
+/// ignored, 1 when it is not, and 128+ on error. We treat error exits as
+/// "unknown" and conservatively return `false` so the rule warns rather
+/// than silently passes.
+fn git_check_ignore(
+    runner: &dyn ProcessRunner,
+    project_root: &Path,
+    rel_path: &str,
+) -> Result<bool, CoreError> {
+    let request = ProcessRequest::new("git")
+        .args(["check-ignore", "-q", "--", rel_path])
+        .current_dir(project_root);
+
+    let output = runner.run(&request).map_err(|err| {
+        CoreError::process(format!(
+            "Cannot run `git check-ignore {rel_path}`.\n\
+             Why: {err}\n\
+             Fix: ensure git is installed and `{root}` is a git repository.",
+            root = project_root.display(),
+        ))
+    })?;
+    Ok(output.success)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::{ProcessExecutionError, ProcessOutput};
+    use crate::validate_repo::staged::StagedFiles;
+    use ito_config::types::{ItoConfig, RepositoryRuntimeConfig, RepositorySqliteConfig};
+    use std::cell::RefCell;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    /// Test runner that returns canned exit codes per `(program, args[0..N])` prefix.
+    ///
+    /// The first matching rule wins; falls back to a default if no rule matches.
+    struct ScriptedRunner {
+        rules: Vec<(Vec<&'static str>, ProcessOutput)>,
+        default: ProcessOutput,
+        seen: RefCell<Vec<ProcessRequest>>,
+    }
+
+    fn ok_output(success: bool, exit_code: i32) -> ProcessOutput {
+        ProcessOutput {
+            exit_code,
+            success,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+        }
+    }
+
+    impl ScriptedRunner {
+        fn new(default: ProcessOutput) -> Self {
+            Self {
+                rules: Vec::new(),
+                default,
+                seen: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_rule(mut self, args_prefix: &[&'static str], output: ProcessOutput) -> Self {
+            self.rules.push((args_prefix.to_vec(), output));
+            self
+        }
+    }
+
+    impl ProcessRunner for ScriptedRunner {
+        fn run(&self, request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.seen.borrow_mut().push(request.clone());
+            for (prefix, output) in &self.rules {
+                if request.args.len() >= prefix.len()
+                    && request.args.iter().zip(prefix.iter()).all(|(a, b)| a == b)
+                {
+                    return Ok(output.clone());
+                }
+            }
+            Ok(self.default.clone())
+        }
+        fn run_with_timeout(
+            &self,
+            request: &ProcessRequest,
+            _timeout: Duration,
+        ) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.run(request)
+        }
+    }
+
+    fn config(mode: RepositoryPersistenceMode, db_path: Option<&str>) -> ItoConfig {
+        ItoConfig {
+            repository: RepositoryRuntimeConfig {
+                mode,
+                sqlite: RepositorySqliteConfig {
+                    db_path: db_path.map(str::to_string),
+                },
+            },
+            ..ItoConfig::default()
+        }
+    }
+
+    // ── activation ───────────────────────────────────────────────────────
+
+    #[test]
+    fn rules_inactive_in_filesystem_mode() {
+        let cfg = config(
+            RepositoryPersistenceMode::Filesystem,
+            Some(".ito/state/ito.db"),
+        );
+        assert!(!SqliteDbPathSetRule.is_active(&cfg));
+        assert!(!SqliteDbNotCommittedRule.is_active(&cfg));
+    }
+
+    #[test]
+    fn rules_active_in_sqlite_mode() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        assert!(SqliteDbPathSetRule.is_active(&cfg));
+        assert!(SqliteDbNotCommittedRule.is_active(&cfg));
+    }
+
+    // ── repository/sqlite-db-path-set ────────────────────────────────────
+
+    #[test]
+    fn sqlite_db_path_set_errors_when_path_unset() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, None);
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "ERROR");
+        assert!(issues[0].message.contains("empty or unset"));
+    }
+
+    #[test]
+    fn sqlite_db_path_set_errors_when_path_outside_project_root() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some("/var/tmp/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("outside the project root"));
+    }
+
+    #[test]
+    fn sqlite_db_path_set_warns_when_parent_directory_missing() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        // Don't create `.ito/state/`.
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "WARNING");
+        assert!(issues[0].message.contains("parent directory"));
+    }
+
+    #[test]
+    fn sqlite_db_path_set_passes_when_parent_exists() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join(".ito/state")).unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbPathSetRule.check(&ctx).unwrap();
+        assert!(issues.is_empty(), "expected no issues; got {issues:?}");
+    }
+
+    // ── repository/sqlite-db-not-committed ───────────────────────────────
+
+    #[test]
+    fn sqlite_db_not_committed_errors_when_file_is_tracked() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        // ls-files --error-unmatch returns success → tracked.
+        let runner = ScriptedRunner::new(ok_output(false, 1))
+            .with_rule(&["ls-files", "--error-unmatch"], ok_output(true, 0));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbNotCommittedRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "ERROR");
+        assert!(issues[0].message.contains("tracked by git"));
+        let metadata = issues[0].metadata.as_ref().expect("metadata");
+        let untrack = metadata
+            .get("untrack_command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(untrack.starts_with("git rm --cached"));
+    }
+
+    #[test]
+    fn sqlite_db_not_committed_warns_when_untracked_and_not_ignored() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        // ls-files --error-unmatch fails (untracked); check-ignore fails (not ignored).
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbNotCommittedRule.check(&ctx).unwrap();
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].level, "WARNING");
+        assert!(issues[0].message.contains("not covered by `.gitignore`"));
+    }
+
+    #[test]
+    fn sqlite_db_not_committed_passes_when_untracked_and_ignored() {
+        let cfg = config(RepositoryPersistenceMode::Sqlite, Some(".ito/state/ito.db"));
+        let tmp = TempDir::new().unwrap();
+        // ls-files fails (untracked); check-ignore succeeds (ignored).
+        let runner = ScriptedRunner::new(ok_output(false, 1))
+            .with_rule(&["check-ignore"], ok_output(true, 0));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbNotCommittedRule.check(&ctx).unwrap();
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn sqlite_db_not_committed_silent_when_path_unset() {
+        // Companion rule `sqlite-db-path-set` reports the missing path.
+        let cfg = config(RepositoryPersistenceMode::Sqlite, None);
+        let tmp = TempDir::new().unwrap();
+        let runner = ScriptedRunner::new(ok_output(false, 1));
+        let staged = StagedFiles::empty();
+        let ctx = RuleContext::new(&cfg, tmp.path(), &staged, &runner);
+
+        let issues = SqliteDbNotCommittedRule.check(&ctx).unwrap();
+        assert!(issues.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements change `011-06_extend-ito-validate-repo-audit-repository-backend-rules`: extends the `ito validate repo` engine (introduced in #229) with **seven** new rules across three namespaces, including the security-critical `backend/token-not-committed`.

- 7/7 tasks complete across 3 waves
- 4 commits (Wave 1 feat, Wave 1 review fixes, Wave 2 tests, Wave 3 docs)
- ~50 new tests; 707 ito-core lib + 12 validate_repo_cli + 73 ito-cli bins all green

Builds on #229; that PR introduced the engine, registry, and CLI surface.

## Rules added

| Rule | Severity | Gate |
| --- | --- | --- |
| `audit/mirror-branch-set` | WARNING | `audit.mirror.enabled` |
| `audit/mirror-branch-distinct-from-coordination` | ERROR | `audit.mirror.enabled && coordination_branch.storage == worktree` |
| `repository/sqlite-db-path-set` | ERROR | `repository.mode == sqlite` |
| `repository/sqlite-db-not-committed` | ERROR / WARNING | `repository.mode == sqlite` |
| `backend/token-not-committed` | **ERROR** (regardless of `--strict`) | `backend.enabled` |
| `backend/url-scheme-valid` | ERROR | `backend.enabled` |
| `backend/project-org-repo-set` | ERROR | `backend.enabled` |

Total built-in rule count: **13** (6 from #229 + 7 from this PR).

## Highlights

### `ito-config` per-layer access

`CascadingProjectConfig` gains a `layers: Vec<ResolvedConfigLayer>` field carrying the un-merged value of each contributing config file in precedence order. Existing `merged` and `loaded_from` callers are unaffected. The new `backend/token-not-committed` rule consumes this so it can ask "did this token come from a tracked-by-git layer?" without merging away the provenance.

### Security-critical `backend/token-not-committed`

- Severity is **`ERROR` regardless of `--strict`** (committing a backend token to git is a security incident).
- Inspects each cascading config layer individually rather than the merged view.
- A token in `.ito/config.local.json` (gitignored) or `ITO_BACKEND_TOKEN` env var is acceptable; only tokens in tracked layers fire.
- End-to-end CLI integration test (`validate_repo_backend_token_not_committed_fails_when_token_in_config`) writes a fixture, initialises a real git repo, commits, and verifies the rule emits ERROR + exit code 1.

### `repository/sqlite-db-path-set` `..` traversal hardening

The Wave 1 review caught a `..` traversal bypass in `path_inside_root`: `Path::canonicalize` errors when the db file does not yet exist, and the fallback `path.starts_with(root)` is **component-based** and does not resolve `..`. So a configured path of `.ito/state/../../../etc/passwd` could appear to "start with" the project root while actually escaping it.

Fix: lexically normalise `path` (collapse `.` and `..`) before the fallback compare; also test against the canonicalised root to handle macOS `/var` → `/private/var` symlinks. Regression test `sqlite_db_path_set_errors_when_path_escapes_root_via_dotdot` pins this.

### Registry activation matrix test

`list_active_rules_matrix_matches_specification` exercises 8 `ItoConfig` permutations (minimal / coordination_worktree only / worktrees only / audit-mirror only / audit+worktree-coord / sqlite repo only / backend only / all-on) and asserts the active rule set matches the spec exactly. Catches accidental gate changes in any of the 13 rules.

## Reviews handled

`rust-code-reviewer` flagged 1 real bug (B-1) and 4 improvements; all applied:

- **B-1**: `path_inside_root` `..` traversal bypass — fixed and regression-tested
- **I-1**: `token-not-committed` strict-mode test strengthened to actually call `run_repo_validation` with `strict: true` and assert the issue level remains ERROR
- **I-2**: Three messages gained their missing **Why** clauses (audit/mirror-branch-set empty, backend/url-scheme-valid empty, repository/sqlite-db-path-set parent-missing)
- **I-3**: `other =>` wildcard arm in `backend/url-scheme-valid` got a justification comment (matched value is `&str` — open set, exhaustive enumeration impossible)
- **I-4**: New `url_scheme_fails_for_scheme_only_no_host` test for the `https://` (valid scheme, empty host) edge case

Also caught and fixed a regression I introduced when adding the Why clause: the convention-check branch in `audit/mirror-branch-set::check` was accidentally elided.

## Verification

| Check | Result |
| --- | --- |
| `cargo build --workspace` | PASS |
| `cargo clippy --workspace --all-targets -- -D warnings` | PASS |
| `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` | PASS |
| `cargo test -p ito-core --lib` (707 tests) | PASS |
| `cargo test -p ito-cli --bins` (73 tests) | PASS |
| `cargo test -p ito-cli --test validate_repo_cli` (12 tests) | PASS |
| `cargo test -p ito-config` (3 tests + doctests) | PASS |
| `make arch-guardrails` | PASS |
| `make check-max-lines` | PASS |
| `cargo deny check` | PASS |

## Self-test (this repo)

\`\`\`
$ ito validate repo --list-rules
Built-in repository validation rules:

  [ ] audit/mirror-branch-distinct-from-coordination   ERROR    audit.mirror.enabled == true && changes.coordination_branch.storage == worktree
  [ ] audit/mirror-branch-set                          WARNING  audit.mirror.enabled == true
  [ ] backend/project-org-repo-set                     ERROR    backend.enabled == true
  [ ] backend/token-not-committed                      ERROR    backend.enabled == true
  [ ] backend/url-scheme-valid                         ERROR    backend.enabled == true
  [x] coordination/branch-name-set                     WARNING  (always active)
  [x] coordination/gitignore-entries                   WARNING  changes.coordination_branch.storage == worktree
  [x] coordination/staged-symlinked-paths              ERROR    changes.coordination_branch.storage == worktree && staged context present
  [x] coordination/symlinks-wired                      ERROR    changes.coordination_branch.storage == worktree
  [ ] repository/sqlite-db-not-committed               ERROR    repository.mode == sqlite
  [ ] repository/sqlite-db-path-set                    ERROR    repository.mode == sqlite
  [x] worktrees/layout-consistent                      WARNING  worktrees.enabled == true
  [x] worktrees/no-write-on-control                    ERROR    worktrees.enabled == true

$ ito validate repo
Repository validation passed.
\`\`\`

The new rules are inactive on this repo because audit mirroring, sqlite mode, and backend mode are all disabled in this project's config — exactly the design intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend configuration validation rules: token security checks, URL scheme validation, and project organization/repository field enforcement.
  * Added audit mirror configuration rules with conflict detection between mirror and coordination branches.
  * Added repository SQLite database validation rules ensuring proper path containment and Git tracking compliance.
  * Expanded `ito validate repo` with 7 additional built-in validation rules (13 total).

* **Documentation**
  * Updated validation rules documentation with precise specifications and behavioral requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->