### PR TITLE
fix(worktree): repair Ito coordination links in change worktrees

### DIFF
--- a/demos/001-37-fix-worktree-symlink-recovery/wave-1-2-worktree-recovery.md
+++ b/demos/001-37-fix-worktree-symlink-recovery/wave-1-2-worktree-recovery.md
@@ -6,7 +6,7 @@
 Implemented automatic coordination symlink wiring in worktree ensure, explicit repair support for init update on existing worktrees, and create-change recovery/error handling for missing worktree wiring.
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test worktree_ensure_e2e
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test worktree_ensure_e2e
 ```
 
 ```output
@@ -24,7 +24,7 @@ test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ```
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test create
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test create
 ```
 
 ```output
@@ -55,7 +55,7 @@ test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fin
 ```
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
 ```
 
 ```output

--- a/demos/001-37-fix-worktree-symlink-recovery/wave-1-2-worktree-recovery.md
+++ b/demos/001-37-fix-worktree-symlink-recovery/wave-1-2-worktree-recovery.md
@@ -1,0 +1,74 @@
+# Wave 1-2: Worktree Recovery
+
+*2026-04-30T10:46:31Z by Showboat 0.6.1*
+<!-- showboat-id: 435372cd-045c-4a46-a1b1-581b76fdf788 -->
+
+Implemented automatic coordination symlink wiring in worktree ensure, explicit repair support for init update on existing worktrees, and create-change recovery/error handling for missing worktree wiring.
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test worktree_ensure_e2e
+```
+
+```output
+    Finished `test` profile [optimized + debuginfo] target(s) in 0.33s
+     Running tests/worktree_ensure_e2e.rs (target/debug/deps/worktree_ensure_e2e-8e817f71bae0c07d)
+
+running 4 tests
+test ensure_worktree_disabled_returns_cwd ... ok
+test ensure_worktree_repairs_missing_coordination_links_in_existing_worktree ... ok
+test ensure_worktree_creates_and_initializes_with_include_files ... ok
+test ensure_worktree_with_setup_script ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s
+
+```
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-core --test create
+```
+
+```output
+    Finished `test` profile [optimized + debuginfo] target(s) in 0.17s
+     Running tests/create.rs (target/debug/deps/create-c5e723a8111a8f02)
+
+running 17 tests
+test create_change_rejects_uppercase_names ... ok
+test create_change_in_sub_module_rejects_missing_parent_module ... ok
+test create_change_reports_actionable_error_when_coordination_worktree_missing ... ok
+test create_module_creates_directory_and_module_md ... ok
+test create_module_returns_existing_module_when_name_matches ... ok
+test create_change_in_sub_module_rejects_missing_sub_module_dir ... ok
+test create_module_writes_description_to_purpose_section ... ok
+test create_change_rewrites_module_changes_in_ascending_change_id_order ... ok
+test create_change_allocates_next_number_from_existing_change_dirs ... ok
+test create_change_creates_change_dir_and_updates_module_md ... ok
+test create_change_in_sub_module_uses_composite_id_format ... ok
+test create_change_in_sub_module_checklist_is_sorted_ascending ... ok
+test create_change_in_sub_module_writes_checklist_to_sub_module_md ... ok
+test create_change_repairs_missing_coordination_links_before_module_lookup ... ok
+test allocation_state_sub_module_keys_sort_after_parent ... ok
+test create_change_in_sub_module_allocates_independent_sequence ... ok
+test create_change_writes_allocation_modules_in_ascending_id_order ... ok
+
+test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+```
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
+```
+
+```output
+    Finished `test` profile [optimized + debuginfo] target(s) in 0.30s
+     Running tests/init_coordination.rs (target/debug/deps/init_coordination-5fe7bf043430e821)
+
+running 5 tests
+test init_no_coordination_worktree_writes_embedded_storage ... ok
+test init_without_git_remote_falls_back_gracefully ... ok
+test init_upgrade_does_not_touch_coordination_storage ... ok
+test init_with_git_remote_creates_coordination_worktree ... ok
+test init_update_repairs_missing_coordination_symlink ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s
+
+```

--- a/demos/001-37-fix-worktree-symlink-recovery/wave-3-docs-and-validation.md
+++ b/demos/001-37-fix-worktree-symlink-recovery/wave-3-docs-and-validation.md
@@ -1,0 +1,45 @@
+# Wave 3: Docs and Validation
+
+*2026-04-30T10:57:24Z by Showboat 0.6.1*
+<!-- showboat-id: 147a3839-c7f0-4a6f-a9c8-c7004927bf7d -->
+
+Updated worktree instructions to document automatic Ito wiring via worktree ensure and the init update repair fallback, then re-ran docs and strict change validation.
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
+```
+
+```output
+    Finished `test` profile [optimized + debuginfo] target(s) in 0.36s
+     Running tests/init_coordination.rs (target/debug/deps/init_coordination-5fe7bf043430e821)
+
+running 5 tests
+test init_no_coordination_worktree_writes_embedded_storage ... ok
+test init_without_git_remote_falls_back_gracefully ... ok
+test init_upgrade_does_not_touch_coordination_storage ... ok
+test init_with_git_remote_creates_coordination_worktree ... ok
+test init_update_repairs_missing_coordination_symlink ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.03s
+
+```
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && make docs
+```
+
+```output
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
+   Generated /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery/target/doc/ito_backend/index.html and 9 other files
+rm -rf docs/rustdoc
+cp -R target/doc docs/rustdoc
+```
+
+```bash
+cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && ito validate 001-37_fix-worktree-symlink-recovery --strict
+```
+
+```output
+Change '001-37_fix-worktree-symlink-recovery' is valid
+```

--- a/demos/001-37-fix-worktree-symlink-recovery/wave-3-docs-and-validation.md
+++ b/demos/001-37-fix-worktree-symlink-recovery/wave-3-docs-and-validation.md
@@ -6,7 +6,7 @@
 Updated worktree instructions to document automatic Ito wiring via worktree ensure and the init update repair fallback, then re-ran docs and strict change validation.
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && cargo test -p ito-cli --test init_coordination
 ```
 
 ```output
@@ -25,19 +25,19 @@ test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 ```
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && make docs
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && make docs
 ```
 
 ```output
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
     Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
-   Generated /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery/target/doc/ito_backend/index.html and 9 other files
+   Generated <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery/target/doc/ito_backend/index.html and 9 other files
 rm -rf docs/rustdoc
 cp -R target/doc docs/rustdoc
 ```
 
 ```bash
-cd /Users/jack/Code/withakay/ito/ito-worktrees/001-37_fix-worktree-symlink-recovery && ito validate 001-37_fix-worktree-symlink-recovery --strict
+cd <repo-root>/ito-worktrees/001-37_fix-worktree-symlink-recovery && ito validate 001-37_fix-worktree-symlink-recovery --strict
 ```
 
 ```output

--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -100,6 +100,8 @@ Rules of thumb:
 - Do work inside a worktree (not the bare repo root).
 - Create feature worktrees under `ito-worktrees/`.
 - Do not remove the locked `main` worktree.
+- Prefer `ito worktree ensure --change <id>` over raw `git worktree add` so Ito can initialize the worktree correctly.
+- If you inherit an older or manually created worktree and `.ito/changes`, `.ito/specs`, `.ito/modules`, `.ito/workflows`, or `.ito/audit` are missing or stale, repair the worktree with `ito init --update --tools none` before creating or applying changes.
 
 Also: when testing changes, use the binary built in the same worktree you edited (worktrees do not share `target/`).
 

--- a/issues.md
+++ b/issues.md
@@ -12,11 +12,11 @@ This file records the exact commands and observations from the session so future
 
 In the main worktree, these paths are symlinks:
 
-- `.ito/audit -> /Users/jack/.local/share/ito/withakay/ito/.ito/audit`
-- `.ito/changes -> /Users/jack/.local/share/ito/withakay/ito/.ito/changes`
-- `.ito/modules -> /Users/jack/.local/share/ito/withakay/ito/.ito/modules`
-- `.ito/specs -> /Users/jack/.local/share/ito/withakay/ito/.ito/specs`
-- `.ito/workflows -> /Users/jack/.local/share/ito/withakay/ito/.ito/workflows`
+- `.ito/audit -> ~/.local/share/ito/<org>/<repo>/.ito/audit`
+- `.ito/changes -> ~/.local/share/ito/<org>/<repo>/.ito/changes`
+- `.ito/modules -> ~/.local/share/ito/<org>/<repo>/.ito/modules`
+- `.ito/specs -> ~/.local/share/ito/<org>/<repo>/.ito/specs`
+- `.ito/workflows -> ~/.local/share/ito/<org>/<repo>/.ito/workflows`
 
 Those symlinks were missing in newly created worktrees until `ito init --update --tools none` was run inside each worktree.
 
@@ -35,12 +35,12 @@ Observed rule: create a temporary proposal worktree first when no final change I
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito`
+- `<repo-root>`
 
 Command:
 
 ```bash
-git worktree add "/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow" -b proposal-ddd-workflow main
+git worktree add "<repo-root>/ito-worktrees/proposal-ddd-workflow" -b proposal-ddd-workflow main
 ```
 
 Result:
@@ -52,7 +52,7 @@ Result:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Command:
 
@@ -82,7 +82,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Commands:
 
@@ -105,8 +105,8 @@ Conclusion:
 
 Workdirs:
 
-- Main: `/Users/jack/Code/withakay/ito/main`
-- Temp: `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- Main: `<repo-root>/main`
+- Temp: `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Command used in both places:
 
@@ -127,7 +127,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Command:
 
@@ -148,7 +148,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Commands:
 
@@ -186,9 +186,9 @@ ito path project-root && ito path worktrees-root && ito path worktree-root
 
 Result:
 
-- `project-root` -> `/Users/jack/Code/withakay/ito`
-- `worktrees-root` -> `/Users/jack/Code/withakay/ito/ito-worktrees`
-- `worktree-root` -> `/Users/jack/Code/withakay/ito/main`
+- `project-root` -> `<repo-root>`
+- `worktrees-root` -> `<repo-root>/ito-worktrees`
+- `worktree-root` -> `<repo-root>/main`
 
 Conclusion:
 
@@ -198,7 +198,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+- `<repo-root>/ito-worktrees/proposal-ddd-workflow`
 
 Command:
 
@@ -211,7 +211,7 @@ Result:
 - Ito created the final worktree path:
 
 ```text
-/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow
+<repo-root>/ito-worktrees/001-34_add-ddd-discovery-workflow
 ```
 
 - But immediately after creation, the new final worktree still had no `.ito/changes`, `.ito/specs`, `.ito/modules`, `.ito/workflows`, or `.ito/audit` paths.
@@ -224,7 +224,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow`
+- `<repo-root>/ito-worktrees/001-34_add-ddd-discovery-workflow`
 
 Command:
 
@@ -245,7 +245,7 @@ Conclusion:
 
 Workdir:
 
-- `/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow`
+- `<repo-root>/ito-worktrees/001-34_add-ddd-discovery-workflow`
 
 Command:
 

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,390 @@
+# Worktree Symlink Recovery Notes
+
+Date: 2026-04-30
+
+## Summary
+
+While creating a new Ito change in a fresh worktree, `ito create change` failed before it could scaffold the change. The first failure mode was clearly caused by missing `.ito` coordination symlinks in the new worktree. After wiring those symlinks with `ito init --update --tools none`, `ito create change` still failed with a generic `I/O error: No such file or directory`, so a second issue likely exists beyond the missing symlinks.
+
+This file records the exact commands and observations from the session so future agents can recover more quickly and so Ito can be improved to self-heal or auto-wire worktrees.
+
+## Expected Baseline
+
+In the main worktree, these paths are symlinks:
+
+- `.ito/audit -> /Users/jack/.local/share/ito/withakay/ito/.ito/audit`
+- `.ito/changes -> /Users/jack/.local/share/ito/withakay/ito/.ito/changes`
+- `.ito/modules -> /Users/jack/.local/share/ito/withakay/ito/.ito/modules`
+- `.ito/specs -> /Users/jack/.local/share/ito/withakay/ito/.ito/specs`
+- `.ito/workflows -> /Users/jack/.local/share/ito/withakay/ito/.ito/workflows`
+
+Those symlinks were missing in newly created worktrees until `ito init --update --tools none` was run inside each worktree.
+
+## Commands Tried
+
+### 1. Confirm worktree layout guidance
+
+Read guidance from:
+
+- `AGENTS.md`
+- `.ito/AGENTS.md`
+
+Observed rule: create a temporary proposal worktree first when no final change ID exists yet, then create the final change worktree before editing generated artifacts.
+
+### 2. Create a temporary proposal worktree manually
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito`
+
+Command:
+
+```bash
+git worktree add "/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow" -b proposal-ddd-workflow main
+```
+
+Result:
+
+- Worktree was created successfully.
+- No `.ito` coordination symlink wiring happened automatically.
+
+### 3. Try to create the change immediately in the temporary worktree
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Command:
+
+```bash
+ito create change "add-ddd-discovery-workflow" --module 001 --schema spec-driven
+```
+
+Result:
+
+- Ito printed warnings that the following were regular directories rather than symlinks to the coordination worktree:
+  - `.ito/changes`
+  - `.ito/specs`
+  - `.ito/modules`
+  - `.ito/workflows`
+  - `.ito/audit`
+- Ito then failed with:
+
+```text
+Error: Module '001' not found
+```
+
+Conclusion:
+
+- Missing coordination symlinks prevented the worktree from seeing shared module/change/spec state.
+
+### 4. Ask Ito how worktree setup is supposed to work
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Commands:
+
+```bash
+ito worktree --help
+ito agent instruction worktree-init
+```
+
+Result:
+
+- `ito worktree` advertised `ensure`, `setup`, and `validate`.
+- `ito agent instruction worktree-init` documented how to use `ito worktree ensure --change <change-id>`.
+- The instruction did **not** explain how to wire `.ito` coordination symlinks in a temporary proposal worktree created via raw `git worktree add`.
+
+Conclusion:
+
+- The documented worktree path does not appear to cover the temporary proposal worktree recovery case.
+
+### 5. Compare main worktree vs temporary worktree symlink state
+
+Workdirs:
+
+- Main: `/Users/jack/Code/withakay/ito/main`
+- Temp: `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Command used in both places:
+
+```bash
+ls -ld ".ito/changes" ".ito/specs" ".ito/modules" ".ito/workflows" ".ito/audit"
+```
+
+Result:
+
+- Main worktree: all five paths were symlinks.
+- Temporary proposal worktree: most of the paths were absent, and `.ito/modules` existed only as a regular directory.
+
+Conclusion:
+
+- Fresh worktrees were not inheriting or creating the expected coordination links.
+
+### 6. Try Ito init as a recovery step inside the temporary worktree
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Command:
+
+```bash
+ito init --update --tools none
+```
+
+Result:
+
+- Ito initialized the worktree.
+- Afterward, the same `ls -ld` check showed all expected `.ito/*` coordination symlinks were present.
+
+Conclusion:
+
+- `ito init --update --tools none` is an effective manual recovery step for missing `.ito` coordination symlinks in a fresh worktree.
+
+### 7. Re-sync and retry after symlink recovery in the temporary worktree
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Commands:
+
+```bash
+ito sync
+ito list --modules
+ito create change "add-ddd-discovery-workflow" --module 001 --schema spec-driven
+```
+
+Result:
+
+- `ito sync` succeeded.
+- `ito list --modules` showed module `001_workflow-enhancements` correctly.
+- `ito create change` still failed, but now with a generic error instead of the symlink/module warning:
+
+```text
+Error: I/O error: No such file or directory (os error 2)
+```
+
+Conclusion:
+
+- Fixing the symlinks solved the first problem, but there is likely a second bug in `ito create change` for this workflow.
+
+### 8. Try Ito path helpers to inspect configured locations
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/main`
+
+Command:
+
+```bash
+ito path project-root && ito path worktrees-root && ito path worktree-root
+```
+
+Result:
+
+- `project-root` -> `/Users/jack/Code/withakay/ito`
+- `worktrees-root` -> `/Users/jack/Code/withakay/ito/ito-worktrees`
+- `worktree-root` -> `/Users/jack/Code/withakay/ito/main`
+
+Conclusion:
+
+- Path configuration matched the documented bare/control layout.
+
+### 9. Try Ito-managed final change worktree creation
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/proposal-ddd-workflow`
+
+Command:
+
+```bash
+ito worktree ensure --change "001-34_add-ddd-discovery-workflow"
+```
+
+Result:
+
+- Ito created the final worktree path:
+
+```text
+/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow
+```
+
+- But immediately after creation, the new final worktree still had no `.ito/changes`, `.ito/specs`, `.ito/modules`, `.ito/workflows`, or `.ito/audit` paths.
+
+Conclusion:
+
+- `ito worktree ensure` appears to create the worktree directory/branch, but it did **not** wire the expected coordination symlinks in this run.
+
+### 10. Try Ito init as a recovery step inside the final change worktree
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow`
+
+Command:
+
+```bash
+ito init --update --tools none
+```
+
+Result:
+
+- Ito initialized the worktree.
+- The expected `.ito/*` coordination symlinks were created successfully.
+
+Conclusion:
+
+- The same recovery step works in both temporary and final worktrees.
+
+### 11. Retry change creation inside the final change worktree after recovery
+
+Workdir:
+
+- `/Users/jack/Code/withakay/ito/ito-worktrees/001-34_add-ddd-discovery-workflow`
+
+Command:
+
+```bash
+ito create change "add-ddd-discovery-workflow" --module 001 --schema spec-driven
+```
+
+Result:
+
+- Same generic error remained:
+
+```text
+Error: I/O error: No such file or directory (os error 2)
+```
+
+Conclusion:
+
+- Even with symlinks fixed, `ito create change` still needs deeper debugging.
+
+### 12. Workaround used to proceed
+
+Workaround:
+
+- Manually scaffolded `.ito/changes/001-34_add-ddd-discovery-workflow/...`
+- Updated `.ito/modules/001_workflow-enhancements/module.md`
+- Ran:
+
+```bash
+ito validate 001-34_add-ddd-discovery-workflow --strict
+ito audit reconcile --change 001-34_add-ddd-discovery-workflow
+ito audit validate --change 001-34_add-ddd-discovery-workflow
+```
+
+Result:
+
+- Validation and audit passed.
+
+## What We Learned
+
+### Reliable manual recovery step
+
+If a new worktree is missing `.ito` coordination symlinks, this recovered them in both test cases:
+
+```bash
+ito init --update --tools none
+```
+
+### Important distinction
+
+- Raw `git worktree add ...` created a usable Git worktree but not a fully wired Ito worktree.
+- `ito worktree ensure --change <id>` also did not appear to wire the `.ito` coordination symlinks in this session.
+- `ito create change ...` could not recover from the missing symlinks automatically.
+
+## Product Gaps To Fix
+
+### Gap 1: Fresh worktrees are not Ito-ready
+
+Ideal behavior:
+
+- A worktree created for Ito work should already contain the expected `.ito/*` coordination symlinks.
+
+Potential fixes:
+
+- Make `ito worktree ensure` run the equivalent of the symlink-wiring part of `ito init --update --tools none` automatically.
+- Add a dedicated `ito worktree repair` or `ito worktree init` command that only wires coordination state for the current worktree.
+
+### Gap 2: Temporary proposal worktree path is underspecified
+
+Ideal behavior:
+
+- The documented temp-worktree flow should include the exact recovery or setup command needed after raw `git worktree add`.
+
+Potential fixes:
+
+- Update `ito agent instruction worktree-init` to document the required follow-up step for temporary proposal worktrees.
+- If raw `git worktree add` remains the recommended temp-worktree path, explicitly mention running:
+
+```bash
+ito init --update --tools none
+```
+
+### Gap 3: `ito create change` error is not actionable
+
+Ideal behavior:
+
+- If `.ito` symlinks are missing, `ito create change` should either repair them or fail with a direct hint.
+
+Potential fixes:
+
+- Detect missing coordination symlinks and print:
+
+```text
+This worktree is missing Ito coordination symlinks. Run `ito init --update --tools none` in this worktree, then retry.
+```
+
+- Better: offer automatic repair before proceeding.
+
+### Gap 4: Generic `os error 2` remains after symlink recovery
+
+Ideal behavior:
+
+- `ito create change` should report the exact missing path and operation.
+
+Potential fixes:
+
+- Improve the error context in the create-change path so the message answers:
+  - what path was missing
+  - during which step
+  - how to fix it
+
+## Suggested Future Repro Checklist
+
+For the next debugging pass, try this exact sequence and capture the first failing path in Rust logs if available:
+
+```bash
+git worktree add "<temp-worktree>" -b "<temp-branch>" main
+cd "<temp-worktree>"
+ls -ld .ito/changes .ito/specs .ito/modules .ito/workflows .ito/audit
+ito init --update --tools none
+ls -ld .ito/changes .ito/specs .ito/modules .ito/workflows .ito/audit
+ito sync
+ito list --modules
+ito create change "<name>" --module 001 --schema spec-driven
+```
+
+Then separately:
+
+```bash
+ito worktree ensure --change "<change-id>"
+cd "$(ito path worktree --change <change-id>)"
+ls -ld .ito/changes .ito/specs .ito/modules .ito/workflows .ito/audit
+ito init --update --tools none
+ito create change "<name>" --module 001 --schema spec-driven
+```
+
+## Short Recommendation
+
+The most useful short-term fix for agents is:
+
+1. After any new worktree is created, run `ito init --update --tools none` in that worktree.
+2. If `ito create change` still fails, improve its error reporting to expose the missing path.
+3. Long term, make `ito worktree ensure` create a fully wired Ito worktree by default.

--- a/ito-rs/crates/ito-cli/tests/init_coordination.rs
+++ b/ito-rs/crates/ito-cli/tests/init_coordination.rs
@@ -224,3 +224,80 @@ fn init_with_git_remote_creates_coordination_worktree() {
         "config.json should contain worktree storage mode; got:\n{config}"
     );
 }
+
+/// Verifies that `ito init --update` repairs missing coordination links in an
+/// existing worktree-backed repo.
+#[test]
+#[cfg(unix)]
+fn init_update_repairs_missing_coordination_symlink() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+    fixtures::git_init_with_initial_commit(repo.path());
+
+    let remote = fixtures::make_bare_remote();
+    fixtures::add_origin(repo.path(), remote.path());
+
+    let push = std::process::Command::new("git")
+        .args(["push", "origin", "HEAD:main"])
+        .current_dir(repo.path())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .expect("git push should run");
+    assert!(
+        push.status.success(),
+        "git push failed: {}",
+        String::from_utf8_lossy(&push.stderr)
+    );
+
+    fixtures::write(
+        repo.path().join(".ito/config.json"),
+        "{\n  \"backend\": { \"project\": { \"org\": \"testorg\", \"repo\": \"testrepo\" } }\n}\n",
+    );
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "init",
+            repo.path().to_string_lossy().as_ref(),
+            "--tools",
+            "none",
+            "--update",
+        ],
+        repo.path(),
+        home.path(),
+    );
+    assert_eq!(out.code, 0, "initial init --update failed: {}", out.stderr);
+
+    let modules_link = repo.path().join(".ito/modules");
+    let metadata = std::fs::symlink_metadata(&modules_link).expect("modules symlink metadata");
+    assert!(
+        metadata.file_type().is_symlink(),
+        ".ito/modules should exist as a symlink after initial init --update"
+    );
+    std::fs::remove_file(&modules_link).expect("remove modules symlink");
+    assert!(!modules_link.exists(), "modules symlink should be removed");
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "init",
+            repo.path().to_string_lossy().as_ref(),
+            "--tools",
+            "none",
+            "--update",
+        ],
+        repo.path(),
+        home.path(),
+    );
+    assert_eq!(out.code, 0, "repair init --update failed: {}", out.stderr);
+
+    assert!(
+        std::fs::read_link(&modules_link).is_ok(),
+        ".ito/modules should be restored as a coordination symlink"
+    );
+}

--- a/ito-rs/crates/ito-core/src/coordination_worktree.rs
+++ b/ito-rs/crates/ito-core/src/coordination_worktree.rs
@@ -318,6 +318,55 @@ pub fn provision_coordination_worktree(
     Ok(Some(CoordinationStorage::Worktree))
 }
 
+/// Repair or create the current worktree's coordination links when storage mode
+/// is `worktree`.
+///
+/// This is the worktree-local counterpart to [`provision_coordination_worktree`].
+/// It does not create the coordination worktree itself and it does not touch the
+/// project `.gitignore`; it only rewires the current checkout's `.ito/*`
+/// entries so they point at the already-resolved coordination worktree.
+///
+/// # Errors
+///
+/// Returns `Ok(())` immediately when coordination storage mode is not
+/// [`CoordinationStorage::Worktree`].
+///
+/// Returns [`CoreError`] when worktree storage is enabled but the coordination
+/// worktree path cannot be resolved, the worktree does not exist, or the
+/// symlink wiring operation fails.
+pub(crate) fn repair_current_worktree_coordination_links(
+    project_root: &Path,
+    ito_path: &Path,
+    typed: &ItoConfig,
+) -> CoreResult<()> {
+    let CoordinationStorage::Worktree = typed.changes.coordination_branch.storage else {
+        return Ok(());
+    };
+
+    let worktree_path = resolved_coordination_worktree_path(project_root, ito_path, typed, false)?;
+    if !worktree_path.is_dir() {
+        return Err(CoreError::process(format!(
+            "Coordination worktree not found at '{}'.\n\
+             Fix: run `ito init --update` from a project checkout with coordination worktrees enabled, or recreate the coordination worktree before retrying.",
+            worktree_path.display()
+        )));
+    }
+
+    std::fs::create_dir_all(ito_path).map_err(|err| {
+        CoreError::io(
+            format!(
+                "Cannot create Ito directory '{}' before wiring coordination links.\n\
+                 Fix: ensure the worktree path is writable.",
+                ito_path.display()
+            ),
+            err,
+        )
+    })?;
+
+    let worktree_ito_path = worktree_path.join(".ito");
+    wire_coordination_symlinks(ito_path, &worktree_ito_path)
+}
+
 // ── Testable inner implementations ───────────────────────────────────────────
 
 pub(crate) fn auto_commit_coordination_with_runner(

--- a/ito-rs/crates/ito-core/src/create/mod.rs
+++ b/ito-rs/crates/ito-core/src/create/mod.rs
@@ -18,6 +18,10 @@ use std::time::Duration;
 use ito_common::fs::StdFs;
 use ito_common::id::{parse_change_id, parse_module_id, parse_sub_module_id};
 use ito_common::paths;
+use ito_config::types::{CoordinationStorage, ItoConfig};
+use ito_config::{ConfigContext, load_cascading_project_config};
+
+use crate::coordination_worktree::repair_current_worktree_coordination_links;
 
 #[derive(Debug, thiserror::Error)]
 /// Errors that can occur while creating modules or changes.
@@ -72,6 +76,10 @@ pub enum CreateError {
     /// Underlying I/O error.
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
+
+    /// Coordination-worktree wiring error.
+    #[error("{0}")]
+    CoordinationWiring(String),
 
     /// JSON serialization/deserialization error.
     #[error("JSON error: {0}")]
@@ -320,6 +328,8 @@ fn create_change_inner(
     let name = name.trim();
     validate_change_name(name)?;
 
+    repair_coordination_wiring_for_change_creation(ito_path)?;
+
     let modules_dir = paths::modules_dir(ito_path);
 
     // Ensure modules dir exists.
@@ -404,6 +414,46 @@ fn create_change_inner(
         change_id: folder,
         change_dir,
     })
+}
+
+fn repair_coordination_wiring_for_change_creation(ito_path: &Path) -> Result<(), CreateError> {
+    let config_path = ito_path.join("config.json");
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    let Some(project_root) = ito_path.parent() else {
+        return Ok(());
+    };
+
+    let ctx = ConfigContext::from_process_env();
+    let loaded = load_cascading_project_config(project_root, ito_path, &ctx);
+    let typed: ItoConfig = serde_json::from_value(loaded.merged).map_err(|err| {
+        CreateError::CoordinationWiring(format!(
+            "Cannot parse Ito configuration before creating a change.\n\
+             Ito path: {}\n\
+             Underlying error: {err}\n\
+             Fix: run `ito config check` (or inspect your config files), then retry.",
+            ito_path.display()
+        ))
+    })?;
+
+    let CoordinationStorage::Worktree = typed.changes.coordination_branch.storage else {
+        return Ok(());
+    };
+
+    repair_current_worktree_coordination_links(project_root, ito_path, &typed).map_err(|err| {
+        CreateError::CoordinationWiring(format!(
+            "Current worktree is missing required Ito coordination wiring.\n\
+             Ito path: {}\n\
+             Expected shared paths: .ito/changes, .ito/specs, .ito/modules, .ito/workflows, .ito/audit\n\
+             Underlying error: {err}\n\
+             Fix: run `ito init --update --tools none` in this worktree, then retry.",
+            ito_path.display()
+        ))
+    })?;
+
+    Ok(())
 }
 
 /// Identifies where the checklist entry for a new change should be written.

--- a/ito-rs/crates/ito-core/src/worktree_ensure.rs
+++ b/ito-rs/crates/ito-core/src/worktree_ensure.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use ito_config::types::ItoConfig;
 
+use crate::coordination_worktree::repair_current_worktree_coordination_links;
 use crate::errors::{CoreError, CoreResult};
 use crate::process::{ProcessRequest, ProcessRunner, SystemProcessRunner};
 use crate::repo_paths::{ResolvedEnv, ResolvedWorktreePaths, WorktreeFeature, WorktreeSelector};
@@ -86,12 +87,14 @@ pub(crate) fn ensure_worktree_with_runner(
     if worktree_path.is_dir() {
         let git_entry = worktree_path.join(".git");
         let has_git = git_entry.exists();
+        let ito_path = worktree_path.join(".ito");
         let has_marker = has_git && {
             resolve_gitdir(&git_entry)
                 .map(|gitdir| gitdir.join(INIT_MARKER).exists())
                 .unwrap_or(false)
         };
         if has_git && has_marker {
+            repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
             return Ok(worktree_path);
         }
         // If the directory exists with .git but no marker, re-run init.
@@ -104,6 +107,7 @@ pub(crate) fn ensure_worktree_with_runner(
                 &worktree_path,
                 &config.worktrees,
             )?;
+            repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
             write_init_marker(&worktree_path)?;
             return Ok(worktree_path);
         }
@@ -143,6 +147,9 @@ pub(crate) fn ensure_worktree_with_runner(
         &worktree_path,
         &config.worktrees,
     )?;
+
+    let ito_path = worktree_path.join(".ito");
+    repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
 
     // Write marker to indicate initialization completed successfully.
     write_init_marker(&worktree_path)?;

--- a/ito-rs/crates/ito-core/src/worktree_ensure.rs
+++ b/ito-rs/crates/ito-core/src/worktree_ensure.rs
@@ -100,6 +100,7 @@ pub(crate) fn ensure_worktree_with_runner(
         // If the directory exists with .git but no marker, re-run init.
         // If no .git at all, fall through to creation (the dir is stale).
         if has_git {
+            repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
             let source_root = worktree_paths.main_worktree_root.as_deref().unwrap_or(cwd);
             worktree_init::init_worktree_with_runner(
                 runner,
@@ -107,7 +108,6 @@ pub(crate) fn ensure_worktree_with_runner(
                 &worktree_path,
                 &config.worktrees,
             )?;
-            repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
             write_init_marker(&worktree_path)?;
             return Ok(worktree_path);
         }
@@ -140,6 +140,9 @@ pub(crate) fn ensure_worktree_with_runner(
     // Resolve the source root (main worktree) for file copy.
     let source_root = worktree_paths.main_worktree_root.as_deref().unwrap_or(cwd);
 
+    let ito_path = worktree_path.join(".ito");
+    repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
+
     // Initialize: copy files + run setup.
     worktree_init::init_worktree_with_runner(
         runner,
@@ -147,9 +150,6 @@ pub(crate) fn ensure_worktree_with_runner(
         &worktree_path,
         &config.worktrees,
     )?;
-
-    let ito_path = worktree_path.join(".ito");
-    repair_current_worktree_coordination_links(&env.project_root, &ito_path, config)?;
 
     // Write marker to indicate initialization completed successfully.
     write_init_marker(&worktree_path)?;

--- a/ito-rs/crates/ito-core/src/worktree_init.rs
+++ b/ito-rs/crates/ito-core/src/worktree_init.rs
@@ -122,7 +122,9 @@ pub fn copy_include_files(
 /// 2. Run setup commands from `config.init.setup` in `dest_root` (if configured).
 ///
 /// Coordination symlink wiring is handled separately by the caller because it
-/// requires the `.ito/` path context which this function does not own.
+/// requires the `.ito/` path context which this function does not own. Today
+/// that means `ito worktree ensure` wires new and partially initialized
+/// worktrees, while `ito init --update` can repair the current worktree.
 ///
 /// # Errors
 ///

--- a/ito-rs/crates/ito-core/tests/create.rs
+++ b/ito-rs/crates/ito-core/tests/create.rs
@@ -389,3 +389,63 @@ fn create_change_in_sub_module_rejects_missing_sub_module_dir() {
         "expected SubModuleNotFound, got {err:?}"
     );
 }
+
+#[test]
+#[cfg(unix)]
+fn create_change_repairs_missing_coordination_links_before_module_lookup() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    std::fs::create_dir_all(&ito).expect("create ito dir");
+
+    let coordination_root = td.path().join("coordination-worktree");
+    let coordination_ito = coordination_root.join(".ito");
+    for dir in ["changes", "specs", "modules", "workflows", "audit"] {
+        std::fs::create_dir_all(coordination_ito.join(dir)).expect("create coordination dirs");
+    }
+    write(
+        coordination_ito.join("modules/001_demo/module.md"),
+        "# Demo\n\n## Purpose\nfixture\n\n## Scope\n- fixture\n\n## Changes\n<!-- Changes will be listed here as they are created -->\n",
+    );
+
+    write(
+        ito.join("config.json"),
+        &format!(
+            "{{\n  \"changes\": {{\n    \"coordination_branch\": {{\n      \"storage\": \"worktree\",\n      \"worktree_path\": \"{}\"\n    }}\n  }}\n}}\n",
+            coordination_root.display()
+        ),
+    );
+
+    let created = create_change(&ito, "repair-me", "spec-driven", Some("001"), None)
+        .expect("create change should repair coordination links first");
+    assert_eq!(created.change_id, "001-01_repair-me");
+
+    let modules_link = std::fs::read_link(ito.join("modules")).expect("modules symlink");
+    assert_eq!(modules_link, coordination_ito.join("modules"));
+}
+
+#[test]
+fn create_change_reports_actionable_error_when_coordination_worktree_missing() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    std::fs::create_dir_all(&ito).expect("create ito dir");
+
+    let missing_coordination_root = td.path().join("missing-coordination-worktree");
+    write(
+        ito.join("config.json"),
+        &format!(
+            "{{\n  \"changes\": {{\n    \"coordination_branch\": {{\n      \"storage\": \"worktree\",\n      \"worktree_path\": \"{}\"\n    }}\n  }}\n}}\n",
+            missing_coordination_root.display()
+        ),
+    );
+
+    let err = create_change(&ito, "needs-wiring", "spec-driven", Some("001"), None)
+        .expect_err("missing coordination worktree should fail");
+    let CreateError::CoordinationWiring(message) = err else {
+        panic!("expected CoordinationWiring, got {err:?}");
+    };
+    assert!(message.contains("Current worktree is missing required Ito coordination wiring"));
+    assert!(message.contains("ito init --update --tools none"));
+    assert!(message.contains(missing_coordination_root.to_string_lossy().as_ref()));
+}

--- a/ito-rs/crates/ito-core/tests/worktree_ensure_e2e.rs
+++ b/ito-rs/crates/ito-core/tests/worktree_ensure_e2e.rs
@@ -34,7 +34,8 @@ fn run_git(cwd: &Path, args: &[&str]) {
 #[test]
 fn ensure_worktree_creates_and_initializes_with_include_files() {
     use ito_config::types::{
-        ItoConfig, WorktreeInitConfig, WorktreeLayoutConfig, WorktreeStrategy,
+        CoordinationStorage, ItoConfig, WorktreeInitConfig, WorktreeLayoutConfig,
+        WorktreeStrategy,
     };
     use ito_core::repo_paths::{GitRepoKind, ResolvedEnv, ResolvedWorktreePaths, WorktreeFeature};
     use ito_core::worktree_ensure::ensure_worktree;
@@ -47,10 +48,18 @@ fn ensure_worktree_creates_and_initializes_with_include_files() {
     fs::write(project_root.join(".env"), "SECRET=test123").unwrap();
 
     let worktrees_root = tmp.path().join("ito-worktrees");
+    let coordination_root = tmp.path().join("coordination");
+    let coordination_ito = coordination_root.join(".ito");
+    for dir in ["changes", "specs", "modules", "workflows", "audit"] {
+        fs::create_dir_all(coordination_ito.join(dir)).unwrap();
+    }
 
     let mut config = ItoConfig::default();
     config.worktrees.enabled = true;
     config.worktrees.strategy = WorktreeStrategy::CheckoutSiblings;
+    config.changes.coordination_branch.storage = CoordinationStorage::Worktree;
+    config.changes.coordination_branch.worktree_path =
+        Some(coordination_root.to_string_lossy().to_string());
     config.worktrees.layout = WorktreeLayoutConfig {
         base_dir: None,
         dir_name: "ito-worktrees".to_string(),
@@ -86,9 +95,77 @@ fn ensure_worktree_creates_and_initializes_with_include_files() {
     assert!(env_file.exists(), ".env should be copied to worktree");
     assert_eq!(fs::read_to_string(&env_file).unwrap(), "SECRET=test123");
 
+    for dir in ["changes", "specs", "modules", "workflows", "audit"] {
+        let path = wt_path.join(".ito").join(dir);
+        let target = fs::read_link(&path).unwrap_or_else(|err| {
+            panic!("{dir} should be a coordination symlink: {err}");
+        });
+        assert_eq!(target, coordination_ito.join(dir));
+    }
+
     // Second call: idempotent — returns the same path without error.
     let result2 = ensure_worktree("test-change", &config, &env, &paths, &project_root);
     assert_eq!(result2.unwrap(), wt_path);
+}
+
+#[test]
+#[cfg(unix)]
+fn ensure_worktree_repairs_missing_coordination_links_in_existing_worktree() {
+    use ito_config::types::{
+        CoordinationStorage, ItoConfig, WorktreeInitConfig, WorktreeLayoutConfig,
+        WorktreeStrategy,
+    };
+    use ito_core::repo_paths::{GitRepoKind, ResolvedEnv, ResolvedWorktreePaths, WorktreeFeature};
+    use ito_core::worktree_ensure::ensure_worktree;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path().join("repo");
+    init_git_repo(&project_root);
+
+    let worktrees_root = tmp.path().join("ito-worktrees");
+    let coordination_root = tmp.path().join("coordination");
+    let coordination_ito = coordination_root.join(".ito");
+    for dir in ["changes", "specs", "modules", "workflows", "audit"] {
+        fs::create_dir_all(coordination_ito.join(dir)).unwrap();
+    }
+
+    let mut config = ItoConfig::default();
+    config.worktrees.enabled = true;
+    config.worktrees.strategy = WorktreeStrategy::CheckoutSiblings;
+    config.changes.coordination_branch.storage = CoordinationStorage::Worktree;
+    config.changes.coordination_branch.worktree_path =
+        Some(coordination_root.to_string_lossy().to_string());
+    config.worktrees.layout = WorktreeLayoutConfig {
+        base_dir: None,
+        dir_name: "ito-worktrees".to_string(),
+    };
+    config.worktrees.init = WorktreeInitConfig {
+        include: vec![],
+        setup: None,
+    };
+
+    let env = ResolvedEnv {
+        worktree_root: project_root.clone(),
+        project_root: project_root.clone(),
+        ito_root: project_root.join(".ito"),
+        git_repo_kind: GitRepoKind::NonBare,
+    };
+
+    let paths = ResolvedWorktreePaths {
+        feature: WorktreeFeature::Enabled,
+        strategy: WorktreeStrategy::CheckoutSiblings,
+        worktrees_root: Some(worktrees_root.clone()),
+        main_worktree_root: Some(project_root.clone()),
+    };
+
+    let wt_path = ensure_worktree("repair-test", &config, &env, &paths, &project_root).unwrap();
+    std::fs::remove_file(wt_path.join(".ito/modules")).expect("remove broken symlink");
+
+    let repaired = ensure_worktree("repair-test", &config, &env, &paths, &project_root).unwrap();
+    assert_eq!(repaired, wt_path);
+
+    let target = std::fs::read_link(wt_path.join(".ito/modules")).expect("modules symlink restored");
+    assert_eq!(target, coordination_ito.join("modules"));
 }
 
 #[test]
@@ -121,7 +198,8 @@ fn ensure_worktree_disabled_returns_cwd() {
 #[test]
 fn ensure_worktree_with_setup_script() {
     use ito_config::types::{
-        ItoConfig, WorktreeInitConfig, WorktreeLayoutConfig, WorktreeSetupConfig, WorktreeStrategy,
+        CoordinationStorage, ItoConfig, WorktreeInitConfig, WorktreeLayoutConfig,
+        WorktreeSetupConfig, WorktreeStrategy,
     };
     use ito_core::repo_paths::{GitRepoKind, ResolvedEnv, ResolvedWorktreePaths, WorktreeFeature};
     use ito_core::worktree_ensure::ensure_worktree;
@@ -135,6 +213,7 @@ fn ensure_worktree_with_setup_script() {
     let mut config = ItoConfig::default();
     config.worktrees.enabled = true;
     config.worktrees.strategy = WorktreeStrategy::CheckoutSiblings;
+    config.changes.coordination_branch.storage = CoordinationStorage::Embedded;
     config.worktrees.layout = WorktreeLayoutConfig {
         base_dir: None,
         dir_name: "ito-worktrees".to_string(),

--- a/ito-rs/crates/ito-core/tests/worktree_ensure_e2e.rs
+++ b/ito-rs/crates/ito-core/tests/worktree_ensure_e2e.rs
@@ -95,12 +95,14 @@ fn ensure_worktree_creates_and_initializes_with_include_files() {
     assert!(env_file.exists(), ".env should be copied to worktree");
     assert_eq!(fs::read_to_string(&env_file).unwrap(), "SECRET=test123");
 
-    for dir in ["changes", "specs", "modules", "workflows", "audit"] {
-        let path = wt_path.join(".ito").join(dir);
-        let target = fs::read_link(&path).unwrap_or_else(|err| {
-            panic!("{dir} should be a coordination symlink: {err}");
-        });
-        assert_eq!(target, coordination_ito.join(dir));
+    if cfg!(unix) {
+        for dir in ["changes", "specs", "modules", "workflows", "audit"] {
+            let path = wt_path.join(".ito").join(dir);
+            let target = fs::read_link(&path).unwrap_or_else(|err| {
+                panic!("{dir} should be a coordination symlink: {err}");
+            });
+            assert_eq!(target, coordination_ito.join(dir));
+        }
     }
 
     // Second call: idempotent — returns the same path without error.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -46,6 +46,8 @@ CHANGE_DIR=$(ito worktree ensure --change "{{ instructions.changeName | replace(
 ```
 
 This creates the dedicated change worktree (if absent), copies include files, and runs setup commands.
+It should also leave the worktree Ito-ready, including the `.ito/*` coordination links when
+coordination storage mode is `worktree`.
 All subsequent file operations should use `$CHANGE_DIR` as the working directory.
 
 After `ito worktree ensure`, run the sync from inside the change worktree if you did not just run it there:
@@ -53,6 +55,14 @@ After `ito worktree ensure`, run the sync from inside the change worktree if you
 ```bash
 cd "$CHANGE_DIR"
 ito sync
+```
+
+If you are recovering an older or manually created worktree whose `.ito/*` links are missing or stale,
+repair it in place with:
+
+```bash
+cd "$CHANGE_DIR"
+ito init --update --tools none
 ```
 
 <details>

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktree-init.md.j2
@@ -31,6 +31,17 @@ echo "Working directory: $WORKTREE_PATH"
 {% endif %}
 ```
 
+`ito worktree ensure` should leave the worktree Ito-ready, including the `.ito/changes`,
+`.ito/specs`, `.ito/modules`, `.ito/workflows`, and `.ito/audit` coordination links when
+coordination storage mode is `worktree`.
+
+If you are recovering an older or manually created worktree whose `.ito/*` links are missing or stale,
+repair it in place with:
+
+```bash
+ito init --update --tools none
+```
+
 All subsequent file operations should use `$WORKTREE_PATH` as the working directory.
 
 ### Include Files


### PR DESCRIPTION
## Summary
- wire and repair `.ito` coordination links during `ito worktree ensure` so ensured worktrees are immediately Ito-ready
- add create-change recovery/error handling plus regression coverage for missing worktree wiring and `ito init --update` repair behavior
- document the preferred `ito worktree ensure` flow, move Showboat demos to repo-root `demos/`, and include the reproduced session log in `issues.md`

## Verification
- cargo test -p ito-core --test worktree_ensure_e2e
- cargo test -p ito-core --test create
- cargo test -p ito-cli --test init_coordination
- make docs
- ito validate 001-37_fix-worktree-symlink-recovery --strict
- ito audit validate --change 001-37_fix-worktree-symlink-recovery

## Review
- Ran CodeRabbit review and fixed its test-hardening finding in `init_coordination.rs`
- A second CodeRabbit run hit the org hourly cap after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic coordination link initialization when creating development branches.
  * New repair functionality to recover missing or stale coordination links in existing branches.

* **Documentation**
  * Updated workflow instructions with explicit initialization requirements and recovery guidance.
  * Added remediation steps and specific commands for repairing branches with missing coordination metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->