### PR TITLE
fix(templates): keep OpenCode Ito agents top-level

### DIFF
--- a/ito-rs/crates/ito-cli/tests/init_more.rs
+++ b/ito-rs/crates/ito-cli/tests/init_more.rs
@@ -87,15 +87,20 @@ fn init_with_tools_opencode_installs_orchestrator_agent_template() {
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
 
     let agent_path = repo.path().join(".opencode/agents/ito-orchestrator.md");
+    let general_path = repo.path().join(".opencode/agents/ito-general.md");
     assert!(
         agent_path.exists(),
         "expected ito-orchestrator agent template"
     );
+    assert!(general_path.exists(), "expected ito-general agent template");
 
     let contents = std::fs::read_to_string(agent_path).expect("read agent");
+    let general = std::fs::read_to_string(general_path).expect("read general agent");
     assert!(!contents.contains("{{model}}"));
     assert!(!contents.contains("{{variant}}"));
     assert!(contents.contains("model:"));
+    assert!(!contents.contains("mode: subagent"));
+    assert!(!general.contains("mode: subagent"));
 }
 
 #[test]
@@ -121,6 +126,7 @@ fn init_update_with_tools_all_installs_all_orchestrator_agent_templates() {
         .expect("read opencode orchestrator");
     assert!(!contents.contains("{{model}}"));
     assert!(!contents.contains("{{variant}}"));
+    assert!(!contents.contains("mode: subagent"));
 }
 
 #[test]
@@ -136,6 +142,7 @@ fn init_update_refreshes_existing_opencode_orchestrator_agent_template() {
     fixtures::write(
         &agent_path,
         r#"---
+mode: subagent
 model: "old-model"
 ---
 
@@ -166,6 +173,7 @@ custom suffix
     assert!(contents.contains("You are an orchestrator."));
     assert!(!contents.contains("stale orchestrator body"));
     assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
+    assert!(!contents.contains("mode: subagent"));
 }
 
 #[test]
@@ -181,6 +189,7 @@ fn init_update_preserves_existing_markerless_opencode_agent_template_body() {
     fixtures::write(
         &agent_path,
         r#"---
+mode: subagent
 model: "old-model"
 ---
 
@@ -204,6 +213,7 @@ legacy custom orchestrator body
     assert!(!contents.contains("You are an orchestrator."));
     assert!(!contents.contains("old-model"));
     assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
+    assert!(!contents.contains("mode: subagent"));
 }
 
 #[test]
@@ -219,6 +229,7 @@ fn init_update_preserves_existing_partial_marker_opencode_agent_template_body() 
     fixtures::write(
         &agent_path,
         r#"---
+mode: subagent
 model: "old-model"
 ---
 
@@ -248,6 +259,7 @@ legacy partial-marker orchestrator body
     assert!(!contents.contains("You are an orchestrator."));
     assert!(!contents.contains("old-model"));
     assert!(contents.contains(&format!("model: \"{}\"", expected_opencode_general_model())));
+    assert!(!contents.contains("mode: subagent"));
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/src/installers/mod.rs
+++ b/ito-rs/crates/ito-core/src/installers/mod.rs
@@ -1015,8 +1015,12 @@ fn update_agent_model_field(path: &Path, new_model: &str) -> CoreResult<()> {
     let frontmatter = &rest[..end_idx];
     let body = &rest[end_idx + 4..]; // Skip "\n---"
 
-    // Update model field in frontmatter using simple string replacement
-    let updated_frontmatter = update_model_in_yaml(frontmatter, new_model);
+    // Update model field in frontmatter and scrub stale OpenCode-only subagent metadata.
+    let updated_frontmatter = update_model_in_yaml(
+        frontmatter,
+        new_model,
+        should_strip_opencode_subagent_mode(path),
+    );
 
     // Reconstruct file
     let updated = format!("---{}\n---{}", updated_frontmatter, body);
@@ -1026,17 +1030,43 @@ fn update_agent_model_field(path: &Path, new_model: &str) -> CoreResult<()> {
     Ok(())
 }
 
+fn should_strip_opencode_subagent_mode(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(agent_dir) = parent.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(opencode_dir) = parent
+        .parent()
+        .and_then(|ancestor| ancestor.file_name())
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+
+    agent_dir == "agents" && opencode_dir == ".opencode"
+}
+
 /// Replace or insert the `model` field in YAML frontmatter.
-fn update_model_in_yaml(yaml: &str, new_model: &str) -> String {
-    let mut lines: Vec<String> = yaml.lines().map(|l| l.to_string()).collect();
+fn update_model_in_yaml(yaml: &str, new_model: &str, strip_subagent_mode: bool) -> String {
+    let mut lines = Vec::new();
     let mut found = false;
 
-    for line in &mut lines {
-        if line.trim_start().starts_with("model:") {
-            *line = format!("model: \"{}\"", new_model);
-            found = true;
-            break;
+    for line in yaml.lines() {
+        let trimmed = line.trim_start();
+        if strip_subagent_mode
+            && (trimmed == "mode: subagent" || trimmed.starts_with("subagent:"))
+        {
+            continue;
         }
+        if trimmed.starts_with("model:") {
+            lines.push(format!("model: \"{}\"", new_model));
+            found = true;
+            continue;
+        }
+
+        lines.push(line.to_string());
     }
 
     // If no model field found, add it
@@ -1209,12 +1239,30 @@ mod tests {
     #[test]
     fn update_model_in_yaml_replaces_or_inserts() {
         let yaml = "name: test\nmodel: \"old\"\n";
-        let updated = update_model_in_yaml(yaml, "new");
+        let updated = update_model_in_yaml(yaml, "new", false);
         assert!(updated.contains("model: \"new\""));
 
         let yaml = "name: test\n";
-        let updated = update_model_in_yaml(yaml, "new");
+        let updated = update_model_in_yaml(yaml, "new", false);
         assert!(updated.contains("model: \"new\""));
+    }
+
+    #[test]
+    fn update_model_in_yaml_strips_stale_opencode_subagent_fields_when_requested() {
+        let yaml = "description: test\nmode: subagent\nsubagent: true\nmodel: \"old\"\n";
+        let updated = update_model_in_yaml(yaml, "new", true);
+        assert!(updated.contains("model: \"new\""));
+        assert!(!updated.contains("mode: subagent"));
+        assert!(!updated.contains("subagent:"));
+    }
+
+    #[test]
+    fn should_strip_opencode_subagent_mode_matches_opencode_agents_only() {
+        let td = tempfile::tempdir().unwrap();
+        let opencode = td.path().join(".opencode/agents/ito-general.md");
+        let claude = td.path().join(".claude/agents/ito-general.md");
+        assert!(should_strip_opencode_subagent_mode(&opencode));
+        assert!(!should_strip_opencode_subagent_mode(&claude));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- strip stale `mode: subagent` / `subagent:` frontmatter from existing `.opencode/agents/*.md` files during template refresh
- add focused OpenCode install/update regression coverage for `ito-general` and `ito-orchestrator`
- preserve the existing body-preservation behavior for legacy agent files while normalizing their frontmatter

## Verification
- cargo test -p ito-core installers::tests::update_model_in_yaml_strips_stale_opencode_subagent_fields_when_requested -- --nocapture
- cargo test -p ito-core installers::tests::should_strip_opencode_subagent_mode_matches_opencode_agents_only -- --nocapture
- cargo test -p ito-cli --test init_more init_with_tools_opencode_installs_orchestrator_agent_template -- --nocapture
- cargo test -p ito-cli --test init_more init_update_with_tools_all_installs_all_orchestrator_agent_templates -- --nocapture
- cargo test -p ito-cli --test init_more init_update_refreshes_existing_opencode_orchestrator_agent_template -- --nocapture
- cargo test -p ito-cli --test init_more init_update_preserves_existing_markerless_opencode_agent_template_body -- --nocapture
- cargo test -p ito-cli --test init_more init_update_preserves_existing_partial_marker_opencode_agent_template_body -- --nocapture
- ito validate 019-13_fix-opencode-agent-mode --strict

## Notes
- The broad `cargo test -p ito-cli --test init_more` suite still has an unrelated pre-existing GitHub Copilot assertion failure, so verification was scoped to the OpenCode cases touched by this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent template initialization now properly removes legacy metadata fields during setup and updates, ensuring clean template installation across orchestrator and general agent types.

* **Tests**
  * Enhanced test coverage to validate correct handling of agent templates and deprecated metadata removal during initialization and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->