### PR TITLE
feat(001-32): add flexible planning workflow

### DIFF
--- a/.claude/commands/ito-plan.md
+++ b/.claude/commands/ito-plan.md
@@ -1,0 +1,21 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/.claude/skills/ito-plan/SKILL.md
+++ b/.claude/skills/ito-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/.claude/skills/ito/SKILL.md
+++ b/.claude/skills/ito/SKILL.md
@@ -34,6 +34,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`

--- a/.codex/prompts/ito-plan.md
+++ b/.codex/prompts/ito-plan.md
@@ -1,0 +1,21 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/.codex/skills/ito-plan/SKILL.md
+++ b/.codex/skills/ito-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/.codex/skills/ito/SKILL.md
+++ b/.codex/skills/ito/SKILL.md
@@ -34,6 +34,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`

--- a/.github/prompts/ito-plan.prompt.md
+++ b/.github/prompts/ito-plan.prompt.md
@@ -1,0 +1,21 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/.github/skills/ito-plan/SKILL.md
+++ b/.github/skills/ito-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/.github/skills/ito/SKILL.md
+++ b/.github/skills/ito/SKILL.md
@@ -34,6 +34,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`

--- a/.opencode/commands/ito-plan.md
+++ b/.opencode/commands/ito-plan.md
@@ -1,0 +1,21 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/.opencode/skills/ito-plan/SKILL.md
+++ b/.opencode/skills/ito-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/.opencode/skills/ito/SKILL.md
+++ b/.opencode/skills/ito/SKILL.md
@@ -34,6 +34,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`

--- a/.pi/commands/ito-plan.md
+++ b/.pi/commands/ito-plan.md
@@ -1,0 +1,21 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/.pi/skills/ito-plan/SKILL.md
+++ b/.pi/skills/ito-plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+<!--ITO:VERSION:0.1.30-->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/.pi/skills/ito/SKILL.md
+++ b/.pi/skills/ito/SKILL.md
@@ -34,6 +34,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Ito centers work around a small set of versioned artifacts under `.ito/`.
 - Modules: optional grouping of related changes with validation of scope and naming.
 - Validation: checks that changes/modules/specs follow conventions and are internally consistent.
 - Agent-facing instructions: generated instruction artifacts (`ito agent instruction ...`) and tool adapters installed by `ito init` / `ito update`.
-- Optional project planning: templates for `.ito/planning/{PROJECT,ROADMAP,STATE}.md` (`ito plan ...`; edit `STATE.md` directly).
+- Optional project planning: flexible markdown plans under `.ito/planning/` via `/ito-plan`, with deeper research under `.ito/research/`.
 - Optional local docs server: browse `.ito/` artifacts over HTTP (`ito serve ...`, requires `caddy`).
 
 ## Core Workflow
@@ -190,10 +190,10 @@ See `docs/backend-client-mode.md` for full documentation and `infra/helm/ito-bac
   modules/                # Optional grouping of changes
     <NNN_module-name>/
       module.md
-  planning/               # Optional project planning artifacts
-    PROJECT.md
-    ROADMAP.md
-    STATE.md
+  planning/               # Optional flexible project planning artifacts
+    <topic>.md
+  research/               # Optional supporting deep-dive research
+    <topic>/
 ```
 
 ## Contributing

--- a/ito-rs/crates/ito-cli/src/cli.rs
+++ b/ito-rs/crates/ito-cli/src/cli.rs
@@ -221,10 +221,10 @@ pub enum Commands {
     #[command(verbatim_doc_comment, visible_alias = "ts")]
     Tasks(TasksArgs),
 
-    /// Initialize and track project roadmap
+    /// Initialize and inspect the planning workspace
     ///
-    /// Creates planning structure for milestones and tracks overall progress
-    /// across multiple changes and modules.
+    /// Creates `.ito/planning/` for free-form planning documents and lists
+    /// existing plans before proposal creation.
     ///
     /// Examples:
     ///   ito plan init
@@ -494,11 +494,11 @@ pub struct PlanArgs {
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum PlanAction {
-    /// Initialize planning structure
+    /// Initialize planning workspace
     #[command(visible_alias = "in")]
     Init,
 
-    /// Show current milestone progress
+    /// Show planning workspace status
     #[command(visible_alias = "st")]
     Status,
 }

--- a/ito-rs/crates/ito-cli/src/commands/plan.rs
+++ b/ito-rs/crates/ito-cli/src/commands/plan.rs
@@ -76,14 +76,17 @@ pub(crate) fn handle_plan_clap(rt: &Runtime, args: &PlanArgs) -> CliResult<()> {
             println!("Research path: {}", summary.research_dir.display());
             println!();
 
-            if let Some(notice) = summary.planning_notice {
+            if let Some(notice) = &summary.planning_notice {
                 println!("{notice}");
-                return Ok(());
             }
 
-            if let Some(notice) = summary.research_notice {
+            if let Some(notice) = &summary.research_notice {
                 println!("{notice}");
                 println!();
+            }
+
+            if summary.planning_notice.is_some() {
+                return Ok(());
             }
 
             println!("Planning Documents");

--- a/ito-rs/crates/ito-cli/src/commands/plan.rs
+++ b/ito-rs/crates/ito-cli/src/commands/plan.rs
@@ -66,64 +66,35 @@ pub(crate) fn handle_plan_clap(rt: &Runtime, args: &PlanArgs) -> CliResult<()> {
                 ))
             })?;
 
+            let summary = planning_init::summarize_planning_workspace(&status);
+
             println!("Planning Workspace");
             println!("────────────────────────────────────────");
-            println!(
-                "Planning: {}",
-                if status.planning_exists {
-                    "available"
-                } else if status.planning_invalid {
-                    "invalid"
-                } else {
-                    "missing"
-                }
-            );
-            println!("Path: {}", status.planning_dir.display());
-            println!(
-                "Research: {}",
-                if status.research_exists {
-                    "available"
-                } else if status.research_invalid {
-                    "invalid"
-                } else {
-                    "missing"
-                }
-            );
-            println!("Research path: {}", status.research_dir.display());
+            println!("Planning: {}", summary.planning_status);
+            println!("Path: {}", summary.planning_dir.display());
+            println!("Research: {}", summary.research_status);
+            println!("Research path: {}", summary.research_dir.display());
             println!();
 
-            if status.planning_invalid {
-                println!(
-                    "Planning path is not a directory. Rename or remove it, then run `ito plan init`."
-                );
+            if let Some(notice) = summary.planning_notice {
+                println!("{notice}");
                 return Ok(());
             }
 
-            if status.research_invalid {
-                println!(
-                    "Research path is not a directory. Rename or remove it before storing deep-dive research."
-                );
+            if let Some(notice) = summary.research_notice {
+                println!("{notice}");
                 println!();
             }
 
             println!("Planning Documents");
             println!("────────────────────────────────────────");
 
-            if !status.planning_exists {
-                println!("No planning workspace found. Run `ito plan init` to create one.");
+            if let Some(notice) = summary.documents_notice {
+                println!("{notice}");
                 return Ok(());
             }
 
-            if status.planning_documents.is_empty() {
-                println!("No planning documents yet. Use /ito-plan to create the first plan.");
-                return Ok(());
-            }
-
-            for document in &status.planning_documents {
-                let name = document
-                    .file_name()
-                    .unwrap_or_else(|| document.as_os_str())
-                    .to_string_lossy();
+            for name in summary.document_names {
                 println!("  - {name}");
             }
 

--- a/ito-rs/crates/ito-cli/src/commands/plan.rs
+++ b/ito-rs/crates/ito-cli/src/commands/plan.rs
@@ -1,8 +1,7 @@
 use crate::cli::{PlanAction, PlanArgs};
-use crate::cli_error::{CliError, CliResult, to_cli_error};
+use crate::cli_error::{CliError, CliResult};
 use crate::runtime::Runtime;
 use ito_core::audit::{Actor, AuditEventBuilder, EntityType, ops};
-use ito_core::domain::planning as wf_planning;
 use ito_core::planning_init;
 
 pub(crate) fn handle_plan_clap(rt: &Runtime, args: &PlanArgs) -> CliResult<()> {
@@ -11,18 +10,27 @@ pub(crate) fn handle_plan_clap(rt: &Runtime, args: &PlanArgs) -> CliResult<()> {
     };
 
     let ito_path = rt.ito_path();
-    let ito_dir = ito_path
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| ".ito".to_string());
-    let current_date = ito_core::time::now_date();
-
     match action {
         PlanAction::Init => {
-            planning_init::init_planning_structure(ito_path, &current_date, &ito_dir)
-                .map_err(to_cli_error)?;
+            let status = planning_init::read_planning_workspace_status(ito_path).map_err(|e| {
+                CliError::msg(format!(
+                    "Could not inspect planning workspace: {e}. Check directory permissions and disk space."
+                ))
+            })?;
 
-            // Emit audit event for planning init
+            if status.planning_invalid {
+                return Err(CliError::msg(format!(
+                    "Could not create planning workspace: {} exists but is not a directory. Rename or remove it, then run `ito plan init`.",
+                    status.planning_dir.display()
+                )));
+            }
+
+            planning_init::init_planning_structure(ito_path).map_err(|e| {
+                CliError::msg(format!(
+                    "Could not create planning workspace: {e}. Check directory permissions and disk space."
+                ))
+            })?;
+
             if let Some(event) = AuditEventBuilder::new()
                 .entity(EntityType::Planning)
                 .entity_id("planning-structure")
@@ -36,44 +44,89 @@ pub(crate) fn handle_plan_clap(rt: &Runtime, args: &PlanArgs) -> CliResult<()> {
                 rt.emit_audit_event(&event);
             }
 
-            eprintln!("✔ Planning structure initialized");
-            println!("Created:");
-            println!("  - {}/planning/PROJECT.md", ito_dir);
-            println!("  - {}/planning/ROADMAP.md", ito_dir);
-            println!("  - {}/planning/STATE.md", ito_dir);
+            eprintln!("✔ Planning workspace available");
+            if status.research_invalid {
+                eprintln!(
+                    "Warning: {} exists but is not a directory. Rename or remove it before storing deep-dive research.",
+                    status.research_dir.display()
+                );
+            }
+            println!("Planning workspace:");
+            println!("  - {}", status.planning_dir.display());
+            println!(
+                "Create plan documents with /ito-plan; supporting research can live under {}.",
+                status.research_dir.display()
+            );
             Ok(())
         }
         PlanAction::Status => {
-            let contents = planning_init::read_planning_status(ito_path).map_err(|_| {
-                CliError::msg("ROADMAP.md not found. Run \"ito init\" or \"ito plan init\" first.")
+            let status = planning_init::read_planning_workspace_status(ito_path).map_err(|e| {
+                CliError::msg(format!(
+                    "Could not read planning workspace status: {e}. Check directory permissions and disk space."
+                ))
             })?;
 
-            let Some((milestone, status, phase)) = wf_planning::read_current_progress(&contents)
-            else {
-                return Err(CliError::msg(
-                    "Could not find current milestone section in ROADMAP.md",
-                ));
-            };
-            let phases = wf_planning::read_phase_rows(&contents);
-
-            println!("Current Progress");
+            println!("Planning Workspace");
             println!("────────────────────────────────────────");
-            println!("Milestone: {milestone}");
-            println!("Status: {status}");
-            println!("Phase: {phase}");
-            println!();
-            println!("Phases");
-            println!("────────────────────────────────────────");
-            for (num, name, st, _changes) in phases {
-                let icon = if st.eq_ignore_ascii_case("Complete") {
-                    "✓"
-                } else if st.eq_ignore_ascii_case("In Progress") {
-                    "●"
+            println!(
+                "Planning: {}",
+                if status.planning_exists {
+                    "available"
+                } else if status.planning_invalid {
+                    "invalid"
                 } else {
-                    "○"
-                };
-                println!("  {icon} Phase {num}: {name} [{st}]");
+                    "missing"
+                }
+            );
+            println!("Path: {}", status.planning_dir.display());
+            println!(
+                "Research: {}",
+                if status.research_exists {
+                    "available"
+                } else if status.research_invalid {
+                    "invalid"
+                } else {
+                    "missing"
+                }
+            );
+            println!("Research path: {}", status.research_dir.display());
+            println!();
+
+            if status.planning_invalid {
+                println!(
+                    "Planning path is not a directory. Rename or remove it, then run `ito plan init`."
+                );
+                return Ok(());
             }
+
+            if status.research_invalid {
+                println!(
+                    "Research path is not a directory. Rename or remove it before storing deep-dive research."
+                );
+                println!();
+            }
+
+            println!("Planning Documents");
+            println!("────────────────────────────────────────");
+
+            if !status.planning_exists {
+                println!("No planning workspace found. Run `ito plan init` to create one.");
+                return Ok(());
+            }
+
+            if status.planning_documents.is_empty() {
+                println!("No planning documents yet. Use /ito-plan to create the first plan.");
+                return Ok(());
+            }
+
+            for document in &status.planning_documents {
+                let name = document
+                    .file_name()
+                    .unwrap_or_else(|| document.as_os_str())
+                    .to_string_lossy();
+                println!("  - {name}");
+            }
+
             Ok(())
         }
     }

--- a/ito-rs/crates/ito-cli/tests/init_agent_activation.rs
+++ b/ito-rs/crates/ito-cli/tests/init_agent_activation.rs
@@ -87,6 +87,53 @@ fn init_update_adds_activation_to_existing_agent_frontmatter() {
     assert!(delegated.contains("mode: subagent"));
 }
 
+#[test]
+fn init_update_installs_ito_plan_command_and_skill_for_all_harnesses() {
+    let base = fixtures::make_empty_repo();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+
+    let repo_path = repo.path().to_string_lossy();
+    let argv = ["init", repo_path.as_ref(), "--tools", "all", "--update"];
+    let out = run_rust_candidate(rust_path, &argv, repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    for rel in ito_plan_command_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read command");
+        assert!(
+            contents.contains("Load and follow the `ito-plan` skill"),
+            "expected {rel} to load the ito-plan skill"
+        );
+        assert!(
+            contents.contains("$ARGUMENTS"),
+            "expected {rel} to pass through user arguments"
+        );
+    }
+
+    for rel in ito_plan_skill_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read skill");
+        assert!(
+            contents.contains("Turn an open-ended idea into a useful planning artifact"),
+            "expected {rel} to contain planning workflow guidance"
+        );
+        assert!(
+            contents.contains(".ito/research/"),
+            "expected {rel} to describe research artifact location"
+        );
+    }
+
+    for rel in generic_ito_skill_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read ito skill");
+        assert!(
+            contents.contains("`ito plan init/status` are CLI workspace commands"),
+            "expected {rel} to keep ito plan routed to the CLI"
+        );
+    }
+}
+
 fn direct_agent_paths() -> Vec<String> {
     let mut paths = Vec::new();
     for root in [
@@ -128,5 +175,35 @@ fn opencode_delegated_agent_paths() -> Vec<String> {
         ".opencode/agents/ito-worker.md".to_string(),
         ".opencode/agents/ito-reviewer.md".to_string(),
         ".opencode/agents/ito-test-runner.md".to_string(),
+    ]
+}
+
+fn ito_plan_command_paths() -> Vec<String> {
+    vec![
+        ".claude/commands/ito-plan.md".to_string(),
+        ".codex/prompts/ito-plan.md".to_string(),
+        ".github/prompts/ito-plan.prompt.md".to_string(),
+        ".opencode/commands/ito-plan.md".to_string(),
+        ".pi/commands/ito-plan.md".to_string(),
+    ]
+}
+
+fn ito_plan_skill_paths() -> Vec<String> {
+    vec![
+        ".claude/skills/ito-plan/SKILL.md".to_string(),
+        ".codex/skills/ito-plan/SKILL.md".to_string(),
+        ".github/skills/ito-plan/SKILL.md".to_string(),
+        ".opencode/skills/ito-plan/SKILL.md".to_string(),
+        ".pi/skills/ito-plan/SKILL.md".to_string(),
+    ]
+}
+
+fn generic_ito_skill_paths() -> Vec<String> {
+    vec![
+        ".claude/skills/ito/SKILL.md".to_string(),
+        ".codex/skills/ito/SKILL.md".to_string(),
+        ".github/skills/ito/SKILL.md".to_string(),
+        ".opencode/skills/ito/SKILL.md".to_string(),
+        ".pi/skills/ito/SKILL.md".to_string(),
     ]
 }

--- a/ito-rs/crates/ito-cli/tests/misc_more.rs
+++ b/ito-rs/crates/ito-cli/tests/misc_more.rs
@@ -10,7 +10,7 @@ use ito_test_support::rust_candidate_command;
 use ito_test_support::pty::run_pty;
 
 #[test]
-fn plan_status_errors_when_roadmap_missing() {
+fn plan_status_reports_missing_workspace() {
     let base = fixtures::make_empty_repo();
     let repo = tempfile::tempdir().expect("work");
     let home = tempfile::tempdir().expect("home");
@@ -20,8 +20,8 @@ fn plan_status_errors_when_roadmap_missing() {
     std::fs::create_dir_all(repo.path().join(".ito")).unwrap();
 
     let out = run_rust_candidate(rust_path, &["plan", "status"], repo.path(), home.path());
-    assert_ne!(out.code, 0);
-    assert!(out.stderr.contains("ROADMAP.md not found"));
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Planning: missing"));
 }
 
 #[test]

--- a/ito-rs/crates/ito-cli/tests/plan_state_more.rs
+++ b/ito-rs/crates/ito-cli/tests/plan_state_more.rs
@@ -100,6 +100,7 @@ fn plan_init_creates_structure() {
         out.stdout
             .contains(&ctx.repo.path().join(".ito/research").display().to_string())
     );
+    assert!(ctx.repo.path().join(".ito/research").is_dir());
     assert!(!ctx.repo.path().join(".ito/planning/PROJECT.md").exists());
     assert!(!ctx.repo.path().join(".ito/planning/ROADMAP.md").exists());
     assert!(!ctx.repo.path().join(".ito/planning/STATE.md").exists());
@@ -253,6 +254,11 @@ fn plan_status_lists_markdown_documents() {
     std::fs::create_dir_all(ctx.repo.path().join(".ito/planning")).unwrap();
     std::fs::create_dir_all(ctx.repo.path().join(".ito/research")).unwrap();
     std::fs::write(ctx.repo.path().join(".ito/planning/topic.md"), "# Topic\n").unwrap();
+    std::fs::write(
+        ctx.repo.path().join(".ito/planning/notes.markdown"),
+        "# Notes\n",
+    )
+    .unwrap();
     std::fs::write(ctx.repo.path().join(".ito/planning/notes.txt"), "ignore\n").unwrap();
 
     let out = run_rust_candidate(
@@ -264,5 +270,6 @@ fn plan_status_lists_markdown_documents() {
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
     assert!(out.stdout.contains("Research: available"));
     assert!(out.stdout.contains("topic.md"));
+    assert!(out.stdout.contains("notes.markdown"));
     assert!(!out.stdout.contains("notes.txt"));
 }

--- a/ito-rs/crates/ito-cli/tests/plan_state_more.rs
+++ b/ito-rs/crates/ito-cli/tests/plan_state_more.rs
@@ -25,7 +25,7 @@ fn setup() -> Ctx {
 }
 
 #[test]
-fn plan_status_fails_without_roadmap() {
+fn plan_status_reports_missing_workspace_without_error() {
     let ctx = setup();
     let rust_path = assert_cmd::cargo::cargo_bin!("ito");
     let out = run_rust_candidate(
@@ -34,8 +34,50 @@ fn plan_status_fails_without_roadmap() {
         ctx.repo.path(),
         ctx.home.path(),
     );
-    assert_ne!(out.code, 0);
-    assert!(out.stderr.contains("ROADMAP.md not found"));
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Planning Workspace"));
+    assert!(out.stdout.contains("Planning: missing"));
+    assert!(out.stdout.contains("Run `ito plan init`"));
+}
+
+#[test]
+fn plan_status_reports_invalid_workspace_without_init_hint_loop() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::write(ctx.repo.path().join(".ito/planning"), "not a directory\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "status"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Planning: invalid"));
+    assert!(out.stdout.contains("Planning path is not a directory"));
+    assert!(out.stdout.contains("Rename or remove it"));
+}
+
+#[test]
+fn plan_status_reports_invalid_research_workspace() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::create_dir_all(ctx.repo.path().join(".ito/planning")).unwrap();
+    std::fs::write(ctx.repo.path().join(".ito/planning/topic.md"), "# Topic\n").unwrap();
+    std::fs::write(ctx.repo.path().join(".ito/research"), "not a directory\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "status"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Research: invalid"));
+    assert!(out.stdout.contains("Research path is not a directory"));
+    assert!(out.stdout.contains("before storing deep-dive research"));
+    assert!(out.stdout.contains("Planning Documents"));
+    assert!(out.stdout.contains("topic.md"));
 }
 
 #[test]
@@ -49,8 +91,134 @@ fn plan_init_creates_structure() {
         ctx.home.path(),
     );
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
-    assert!(out.stderr.contains("Planning structure initialized"));
-    assert!(out.stdout.contains(".ito/planning/STATE.md"));
+    assert!(out.stderr.contains("Planning workspace available"));
+    assert!(
+        out.stdout
+            .contains(&ctx.repo.path().join(".ito/planning").display().to_string())
+    );
+    assert!(
+        out.stdout
+            .contains(&ctx.repo.path().join(".ito/research").display().to_string())
+    );
+    assert!(!ctx.repo.path().join(".ito/planning/PROJECT.md").exists());
+    assert!(!ctx.repo.path().join(".ito/planning/ROADMAP.md").exists());
+    assert!(!ctx.repo.path().join(".ito/planning/STATE.md").exists());
+}
+
+#[test]
+fn plan_init_prints_configured_workspace_paths() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::write(
+        ctx.repo.path().join("ito.json"),
+        r#"{"projectPath":".custom-ito"}"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(ctx.repo.path().join(".custom-ito")).unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "init"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(
+        out.stdout.contains(
+            &ctx.repo
+                .path()
+                .join(".custom-ito/planning")
+                .display()
+                .to_string()
+        ),
+        "stdout={}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains(
+            &ctx.repo
+                .path()
+                .join(".custom-ito/research")
+                .display()
+                .to_string()
+        ),
+        "stdout={}",
+        out.stdout
+    );
+}
+
+#[test]
+fn plan_init_is_idempotent() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "init"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    let plan_dir = ctx.repo.path().join(".ito/planning");
+    std::fs::write(plan_dir.join("topic.md"), "# Topic\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "init"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert_eq!(
+        std::fs::read_to_string(plan_dir.join("topic.md")).unwrap(),
+        "# Topic\n"
+    );
+    assert!(!plan_dir.join("PROJECT.md").exists());
+    assert!(!plan_dir.join("ROADMAP.md").exists());
+    assert!(!plan_dir.join("STATE.md").exists());
+}
+
+#[test]
+fn plan_init_reports_conflicting_planning_file() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::write(ctx.repo.path().join(".ito/planning"), "not a directory\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "init"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_ne!(out.code, 0);
+    assert!(out.stderr.contains("Could not create planning workspace"));
+    assert!(out.stderr.contains("exists but is not a directory"));
+    assert!(out.stderr.contains("Rename or remove it"));
+    assert!(
+        !out.stderr
+            .contains("Check directory permissions and disk space")
+    );
+}
+
+#[test]
+fn plan_init_warns_about_conflicting_research_file() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::write(ctx.repo.path().join(".ito/research"), "not a directory\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "init"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stderr.contains("Planning workspace available"));
+    assert!(out.stderr.contains("exists but is not a directory"));
+    assert!(out.stderr.contains("before storing deep-dive research"));
+    assert!(out.stdout.contains("supporting research can live"));
+    assert!(ctx.repo.path().join(".ito/planning").is_dir());
 }
 
 #[test]
@@ -72,6 +240,29 @@ fn plan_status_succeeds_after_init() {
         ctx.home.path(),
     );
     assert_eq!(out.code, 0, "stderr={}", out.stderr);
-    assert!(out.stdout.contains("Current Progress"));
-    assert!(out.stdout.contains("Phases"));
+    assert!(out.stdout.contains("Planning Workspace"));
+    assert!(out.stdout.contains("Planning: available"));
+    assert!(out.stdout.contains("No planning documents yet"));
+    assert!(out.stdout.contains("/ito-plan"));
+}
+
+#[test]
+fn plan_status_lists_markdown_documents() {
+    let ctx = setup();
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+    std::fs::create_dir_all(ctx.repo.path().join(".ito/planning")).unwrap();
+    std::fs::create_dir_all(ctx.repo.path().join(".ito/research")).unwrap();
+    std::fs::write(ctx.repo.path().join(".ito/planning/topic.md"), "# Topic\n").unwrap();
+    std::fs::write(ctx.repo.path().join(".ito/planning/notes.txt"), "ignore\n").unwrap();
+
+    let out = run_rust_candidate(
+        rust_path,
+        &["plan", "status"],
+        ctx.repo.path(),
+        ctx.home.path(),
+    );
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(out.stdout.contains("Research: available"));
+    assert!(out.stdout.contains("topic.md"));
+    assert!(!out.stdout.contains("notes.txt"));
 }

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help.snap
@@ -19,7 +19,7 @@ Commands:
   sync          Validate and synchronize coordination worktree state
   grep          Search Ito change artifacts using a regular expression [aliases: gr]
   tasks         Manage implementation tasks for a change [aliases: ts]
-  plan          Initialize and track project roadmap [aliases: pl]
+  plan          Initialize and inspect the planning workspace [aliases: pl]
   agent         Generate instructions and context for AI coding agents [aliases: ag]
   ralph         Run an AI agent loop to implement a change [aliases: ra]
   init          Set up Ito in a project [aliases: in]

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_all.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_all.snap
@@ -25,7 +25,7 @@ Commands:
   sync          Validate and synchronize coordination worktree state
   grep          Search Ito change artifacts using a regular expression [aliases: gr]
   tasks         Manage implementation tasks for a change [aliases: ts]
-  plan          Initialize and track project roadmap [aliases: pl]
+  plan          Initialize and inspect the planning workspace [aliases: pl]
   agent         Generate instructions and context for AI coding agents [aliases: ag]
   ralph         Run an AI agent loop to implement a change [aliases: ra]
   init          Set up Ito in a project [aliases: in]
@@ -184,10 +184,10 @@ Options:
 
 ito plan
 --------
-Initialize and track project roadmap
+Initialize and inspect the planning workspace
 
-Creates planning structure for milestones and tracks overall progress
-across multiple changes and modules.
+Creates `.ito/planning/` for free-form planning documents and lists
+existing plans before proposal creation.
 
 Examples:
   ito plan init
@@ -196,8 +196,8 @@ Examples:
 Usage: ito plan <COMMAND>
 
 Commands:
-  init    Initialize planning structure [aliases: in]
-  status  Show current milestone progress [aliases: st]
+  init    Initialize planning workspace [aliases: in]
+  status  Show planning workspace status [aliases: st]
 
 Options:
   -h, --help

--- a/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_subcommand_all.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/cli_snapshots__ito_help_subcommand_all.snap
@@ -25,7 +25,7 @@ Commands:
   sync          Validate and synchronize coordination worktree state
   grep          Search Ito change artifacts using a regular expression [aliases: gr]
   tasks         Manage implementation tasks for a change [aliases: ts]
-  plan          Initialize and track project roadmap [aliases: pl]
+  plan          Initialize and inspect the planning workspace [aliases: pl]
   agent         Generate instructions and context for AI coding agents [aliases: ag]
   ralph         Run an AI agent loop to implement a change [aliases: ra]
   init          Set up Ito in a project [aliases: in]
@@ -184,10 +184,10 @@ Options:
 
 ito plan
 --------
-Initialize and track project roadmap
+Initialize and inspect the planning workspace
 
-Creates planning structure for milestones and tracks overall progress
-across multiple changes and modules.
+Creates `.ito/planning/` for free-form planning documents and lists
+existing plans before proposal creation.
 
 Examples:
   ito plan init
@@ -196,8 +196,8 @@ Examples:
 Usage: ito plan <COMMAND>
 
 Commands:
-  init    Initialize planning structure [aliases: in]
-  status  Show current milestone progress [aliases: st]
+  init    Initialize planning workspace [aliases: in]
+  status  Show planning workspace status [aliases: st]
 
 Options:
   -h, --help

--- a/ito-rs/crates/ito-cli/tests/snapshots/parity_help_version__parity_help.snap
+++ b/ito-rs/crates/ito-cli/tests/snapshots/parity_help_version__parity_help.snap
@@ -15,8 +15,9 @@ Commands:
   init [options] [path]            Initialize Ito in your project
   update [options] [path]          Update Ito instruction files
   tasks                            Track execution tasks for a change
-  plan                             Project planning tools
-  state                            View and update planning/STATE.md
+  plan                             Initialize and inspect the planning
+                                   workspace
+  state                            View and update project state
   workflow                         Manage and run workflows
   list [options]                   List items (changes by default). Use --specs
                                    or --modules to list other items.

--- a/ito-rs/crates/ito-cli/tests/update_smoke.rs
+++ b/ito-rs/crates/ito-cli/tests/update_smoke.rs
@@ -141,6 +141,51 @@ fn update_installs_adapter_files_from_local_ito_skills() {
 }
 
 #[test]
+fn update_installs_ito_plan_command_and_skill_for_all_harnesses() {
+    let repo = tempfile::tempdir().expect("repo");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    write(repo.path().join("README.md"), "# temp\n");
+    write_local_ito_skills(repo.path());
+
+    let out = run_rust_candidate(rust_path, &["update", "."], repo.path(), home.path());
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+
+    for rel in ito_plan_command_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read command");
+        assert!(
+            contents.contains("Load and follow the `ito-plan` skill"),
+            "expected {rel} to load the ito-plan skill"
+        );
+        assert!(
+            contents.contains("$ARGUMENTS"),
+            "expected {rel} to pass through user arguments"
+        );
+    }
+
+    for rel in ito_plan_skill_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read skill");
+        assert!(
+            contents.contains("Turn an open-ended idea into a useful planning artifact"),
+            "expected {rel} to contain planning workflow guidance"
+        );
+        assert!(
+            contents.contains(".ito/research/"),
+            "expected {rel} to describe research artifact location"
+        );
+    }
+
+    for rel in generic_ito_skill_paths() {
+        let contents = std::fs::read_to_string(repo.path().join(&rel)).expect("read ito skill");
+        assert!(
+            contents.contains("`ito plan init/status` are CLI workspace commands"),
+            "expected {rel} to keep ito plan routed to the CLI"
+        );
+    }
+}
+
+#[test]
 fn update_merges_claude_settings_without_clobbering_user_keys() {
     let repo = tempfile::tempdir().expect("repo");
     let home = tempfile::tempdir().expect("home");
@@ -170,6 +215,36 @@ fn update_merges_claude_settings_without_clobbering_user_keys() {
         value.pointer("/hooks/PreToolUse").is_some(),
         "ito hook config should be merged into settings"
     );
+}
+
+fn ito_plan_command_paths() -> Vec<String> {
+    vec![
+        ".claude/commands/ito-plan.md".to_string(),
+        ".codex/prompts/ito-plan.md".to_string(),
+        ".github/prompts/ito-plan.prompt.md".to_string(),
+        ".opencode/commands/ito-plan.md".to_string(),
+        ".pi/commands/ito-plan.md".to_string(),
+    ]
+}
+
+fn ito_plan_skill_paths() -> Vec<String> {
+    vec![
+        ".claude/skills/ito-plan/SKILL.md".to_string(),
+        ".codex/skills/ito-plan/SKILL.md".to_string(),
+        ".github/skills/ito-plan/SKILL.md".to_string(),
+        ".opencode/skills/ito-plan/SKILL.md".to_string(),
+        ".pi/skills/ito-plan/SKILL.md".to_string(),
+    ]
+}
+
+fn generic_ito_skill_paths() -> Vec<String> {
+    vec![
+        ".claude/skills/ito/SKILL.md".to_string(),
+        ".codex/skills/ito/SKILL.md".to_string(),
+        ".github/skills/ito/SKILL.md".to_string(),
+        ".opencode/skills/ito/SKILL.md".to_string(),
+        ".pi/skills/ito/SKILL.md".to_string(),
+    ]
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/src/planning_init.rs
+++ b/ito-rs/crates/ito-core/src/planning_init.rs
@@ -64,6 +64,20 @@ pub fn init_planning_structure(ito_path: &Path) -> CoreResult<()> {
     let planning = planning_dir(ito_path);
     std::fs::create_dir_all(&planning)
         .map_err(|e| workspace_io_error("creating planning workspace", &planning, e))?;
+    let research = research_dir(ito_path);
+    match std::fs::metadata(&research) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {}
+        Err(err) if err.kind() == ErrorKind::NotFound => std::fs::create_dir_all(&research)
+            .map_err(|e| workspace_io_error("creating research workspace", &research, e))?,
+        Err(err) => {
+            return Err(workspace_io_error(
+                "inspecting research workspace",
+                &research,
+                err,
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -128,10 +142,11 @@ pub fn read_planning_workspace_status(ito_path: &Path) -> CoreResult<PlanningWor
             let file_type = entry.file_type().map_err(|e| {
                 workspace_io_error("reading planning workspace entry metadata", &path, e)
             })?;
-            let is_markdown = path
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+            let mut is_markdown = false;
+            if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
+                is_markdown =
+                    ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown");
+            }
             if is_markdown && file_type.is_file() {
                 planning_documents.push(path);
             }

--- a/ito-rs/crates/ito-core/src/planning_init.rs
+++ b/ito-rs/crates/ito-core/src/planning_init.rs
@@ -27,6 +27,27 @@ pub struct PlanningWorkspaceStatus {
     pub research_invalid: bool,
 }
 
+/// Adapter-ready summary for `ito plan status` rendering.
+#[derive(Debug, Eq, PartialEq)]
+pub struct PlanningWorkspaceSummary {
+    /// Planning workspace availability label.
+    pub planning_status: &'static str,
+    /// Path to the planning workspace.
+    pub planning_dir: PathBuf,
+    /// Research workspace availability label.
+    pub research_status: &'static str,
+    /// Path to the research workspace.
+    pub research_dir: PathBuf,
+    /// Planning-specific notice to display before the documents section.
+    pub planning_notice: Option<String>,
+    /// Research-specific notice to display before the documents section.
+    pub research_notice: Option<String>,
+    /// Documents-section message when there is nothing to list.
+    pub documents_notice: Option<String>,
+    /// Prepared planning document names for rendering.
+    pub document_names: Vec<String>,
+}
+
 struct WorkspacePathState {
     exists: bool,
     invalid: bool,
@@ -40,9 +61,50 @@ struct WorkspacePathState {
 ///
 /// Returns an error if the planning workspace cannot be created.
 pub fn init_planning_structure(ito_path: &Path) -> CoreResult<()> {
-    std::fs::create_dir_all(planning_dir(ito_path))
-        .map_err(|e| CoreError::io("creating planning workspace", e))?;
+    let planning = planning_dir(ito_path);
+    std::fs::create_dir_all(&planning)
+        .map_err(|e| workspace_io_error("creating planning workspace", &planning, e))?;
     Ok(())
+}
+
+/// Convert planning workspace status into adapter-ready rendering data.
+pub fn summarize_planning_workspace(status: &PlanningWorkspaceStatus) -> PlanningWorkspaceSummary {
+    let document_names = status
+        .planning_documents
+        .iter()
+        .map(|document| {
+            document
+                .file_name()
+                .unwrap_or_else(|| document.as_os_str())
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+
+    PlanningWorkspaceSummary {
+        planning_status: workspace_label(status.planning_exists, status.planning_invalid),
+        planning_dir: status.planning_dir.clone(),
+        research_status: workspace_label(status.research_exists, status.research_invalid),
+        research_dir: status.research_dir.clone(),
+        planning_notice: status.planning_invalid.then(|| {
+            "Planning path is not a directory. Rename or remove it, then run `ito plan init`."
+                .to_string()
+        }),
+        research_notice: status.research_invalid.then(|| {
+            "Research path is not a directory. Rename or remove it before storing deep-dive research."
+                .to_string()
+        }),
+        documents_notice: if status.planning_invalid {
+            None
+        } else if !status.planning_exists {
+            Some("No planning workspace found. Run `ito plan init` to create one.".to_string())
+        } else if status.planning_documents.is_empty() {
+            Some("No planning documents yet. Use /ito-plan to create the first plan.".to_string())
+        } else {
+            None
+        },
+        document_names,
+    }
 }
 
 /// Inspect the flexible planning workspace.
@@ -57,13 +119,15 @@ pub fn read_planning_workspace_status(ito_path: &Path) -> CoreResult<PlanningWor
 
     if planning_state.exists {
         let entries = std::fs::read_dir(&planning)
-            .map_err(|e| CoreError::io("reading planning workspace", e))?;
+            .map_err(|e| workspace_io_error("reading planning workspace", &planning, e))?;
         for entry in entries {
-            let entry = entry.map_err(|e| CoreError::io("reading planning workspace entry", e))?;
+            let entry = entry.map_err(|e| {
+                workspace_io_error("reading planning workspace entry", &planning, e)
+            })?;
             let path = entry.path();
-            let file_type = entry
-                .file_type()
-                .map_err(|e| CoreError::io("reading planning workspace entry metadata", e))?;
+            let file_type = entry.file_type().map_err(|e| {
+                workspace_io_error("reading planning workspace entry metadata", &path, e)
+            })?;
             let is_markdown = path
                 .extension()
                 .and_then(|ext| ext.to_str())
@@ -102,6 +166,31 @@ fn inspect_workspace_path(path: &Path, label: &str) -> CoreResult<WorkspacePathS
             exists: false,
             invalid: false,
         }),
-        Err(err) => Err(CoreError::io(format!("inspecting {label} workspace"), err)),
+        Err(err) => Err(workspace_io_error(
+            format!("inspecting {label} workspace"),
+            path,
+            err,
+        )),
     }
+}
+
+fn workspace_label(exists: bool, invalid: bool) -> &'static str {
+    if exists {
+        "available"
+    } else if invalid {
+        "invalid"
+    } else {
+        "missing"
+    }
+}
+
+fn workspace_io_error(action: impl AsRef<str>, path: &Path, err: std::io::Error) -> CoreError {
+    CoreError::io(
+        format!(
+            "{} at {} (check permissions and parent directories)",
+            action.as_ref(),
+            path.display()
+        ),
+        err,
+    )
 }

--- a/ito-rs/crates/ito-core/src/planning_init.rs
+++ b/ito-rs/crates/ito-core/src/planning_init.rs
@@ -132,7 +132,9 @@ pub fn summarize_planning_workspace(status: &PlanningWorkspaceStatus) -> Plannin
 ///
 /// # Errors
 ///
-/// Returns an error if the planning workspace exists but cannot be read.
+/// Returns an error if:
+/// - The planning workspace exists but cannot be read because directory listing or entry metadata access fails.
+/// - The research workspace path cannot be inspected because filesystem metadata access fails.
 pub fn read_planning_workspace_status(ito_path: &Path) -> CoreResult<PlanningWorkspaceStatus> {
     let planning = planning_dir(ito_path);
     let planning_state = inspect_workspace_path(&planning, "planning")?;

--- a/ito-rs/crates/ito-core/src/planning_init.rs
+++ b/ito-rs/crates/ito-core/src/planning_init.rs
@@ -1,44 +1,107 @@
 //! Planning directory initialization.
 //!
 //! This module owns the filesystem I/O for bootstrapping the planning area.
-//! Pure helpers (path builders, templates, parsers) remain in `ito_domain::planning`.
+//! Pure path helpers remain in `ito_domain::planning`.
 
 use crate::errors::{CoreError, CoreResult};
-use ito_domain::planning::{
-    milestones_dir, planning_dir, project_md_template, roadmap_md_template, state_md_template,
-};
-use std::path::Path;
+use ito_domain::planning::{planning_dir, research_dir};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+/// Current state of the flexible planning workspace.
+#[derive(Debug, Eq, PartialEq)]
+pub struct PlanningWorkspaceStatus {
+    /// Path to the `.ito/planning/` workspace.
+    pub planning_dir: PathBuf,
+    /// Whether the planning workspace directory exists.
+    pub planning_exists: bool,
+    /// Whether the planning path exists but is not a directory.
+    pub planning_invalid: bool,
+    /// Markdown planning documents currently present directly under the workspace.
+    pub planning_documents: Vec<PathBuf>,
+    /// Path to the companion `.ito/research/` workspace.
+    pub research_dir: PathBuf,
+    /// Whether the companion research workspace exists.
+    pub research_exists: bool,
+    /// Whether the research path exists but is not a directory.
+    pub research_invalid: bool,
+}
+
+struct WorkspacePathState {
+    exists: bool,
+    invalid: bool,
+}
 
 /// Initialize the planning directory structure under `ito_path`.
 ///
-/// This is safe to call multiple times; existing files are left unchanged.
-pub fn init_planning_structure(
-    ito_path: &Path,
-    current_date: &str,
-    ito_dir: &str,
-) -> std::io::Result<()> {
-    let planning = planning_dir(ito_path);
-    std::fs::create_dir_all(&planning)?;
-    std::fs::create_dir_all(milestones_dir(ito_path))?;
-
-    let project_path = planning.join("PROJECT.md");
-    if !project_path.exists() {
-        std::fs::write(project_path, project_md_template(None, None))?;
-    }
-    let roadmap_path = planning.join("ROADMAP.md");
-    if !roadmap_path.exists() {
-        std::fs::write(roadmap_path, roadmap_md_template())?;
-    }
-    let state_path = planning.join("STATE.md");
-    if !state_path.exists() {
-        std::fs::write(state_path, state_md_template(current_date, ito_dir))?;
-    }
+/// This is safe to call multiple times; existing planning documents are left unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the planning workspace cannot be created.
+pub fn init_planning_structure(ito_path: &Path) -> CoreResult<()> {
+    std::fs::create_dir_all(planning_dir(ito_path))
+        .map_err(|e| CoreError::io("creating planning workspace", e))?;
     Ok(())
 }
 
-/// Read the contents of `planning/ROADMAP.md`.
-pub fn read_planning_status(ito_path: &Path) -> CoreResult<String> {
-    let roadmap_path = planning_dir(ito_path).join("ROADMAP.md");
-    ito_common::io::read_to_string(&roadmap_path)
-        .map_err(|e| CoreError::io("reading ROADMAP.md", std::io::Error::other(e)))
+/// Inspect the flexible planning workspace.
+///
+/// # Errors
+///
+/// Returns an error if the planning workspace exists but cannot be read.
+pub fn read_planning_workspace_status(ito_path: &Path) -> CoreResult<PlanningWorkspaceStatus> {
+    let planning = planning_dir(ito_path);
+    let planning_state = inspect_workspace_path(&planning, "planning")?;
+    let mut planning_documents = Vec::new();
+
+    if planning_state.exists {
+        let entries = std::fs::read_dir(&planning)
+            .map_err(|e| CoreError::io("reading planning workspace", e))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| CoreError::io("reading planning workspace entry", e))?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .map_err(|e| CoreError::io("reading planning workspace entry metadata", e))?;
+            let is_markdown = path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("md"));
+            if is_markdown && file_type.is_file() {
+                planning_documents.push(path);
+            }
+        }
+        planning_documents.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+    }
+
+    let research = research_dir(ito_path);
+    let research_state = inspect_workspace_path(&research, "research")?;
+
+    Ok(PlanningWorkspaceStatus {
+        planning_dir: planning,
+        planning_exists: planning_state.exists,
+        planning_invalid: planning_state.invalid,
+        planning_documents,
+        research_dir: research,
+        research_exists: research_state.exists,
+        research_invalid: research_state.invalid,
+    })
+}
+
+fn inspect_workspace_path(path: &Path, label: &str) -> CoreResult<WorkspacePathState> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => {
+            let is_dir = metadata.is_dir();
+            Ok(WorkspacePathState {
+                exists: is_dir,
+                invalid: !is_dir,
+            })
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(WorkspacePathState {
+            exists: false,
+            invalid: false,
+        }),
+        Err(err) => Err(CoreError::io(format!("inspecting {label} workspace"), err)),
+    }
 }

--- a/ito-rs/crates/ito-core/src/planning_init.rs
+++ b/ito-rs/crates/ito-core/src/planning_init.rs
@@ -59,7 +59,10 @@ struct WorkspacePathState {
 ///
 /// # Errors
 ///
-/// Returns an error if the planning workspace cannot be created.
+/// Returns an error if:
+/// - The planning workspace cannot be created because the path is not writable or conflicts with a file.
+/// - The research workspace metadata cannot be inspected because of a filesystem access error.
+/// - The research workspace is missing and cannot be created because the parent path is not writable.
 pub fn init_planning_structure(ito_path: &Path) -> CoreResult<()> {
     let planning = planning_dir(ito_path);
     std::fs::create_dir_all(&planning)
@@ -81,7 +84,11 @@ pub fn init_planning_structure(ito_path: &Path) -> CoreResult<()> {
     Ok(())
 }
 
-/// Convert planning workspace status into adapter-ready rendering data.
+/// Convert a [`PlanningWorkspaceStatus`] into a [`PlanningWorkspaceSummary`] for CLI rendering.
+///
+/// Use this after [`read_planning_workspace_status`] when a command needs stable
+/// user-facing labels, notices, and document names without re-encoding the
+/// workspace-state branching in the adapter layer.
 pub fn summarize_planning_workspace(status: &PlanningWorkspaceStatus) -> PlanningWorkspaceSummary {
     let document_names = status
         .planning_documents

--- a/ito-rs/crates/ito-core/tests/planning_init.rs
+++ b/ito-rs/crates/ito-core/tests/planning_init.rs
@@ -1,47 +1,115 @@
 use ito_core::planning_init;
-use ito_domain::planning::planning_dir;
+use ito_domain::planning::{planning_dir, research_dir};
 use tempfile::tempdir;
 
 #[test]
-fn init_planning_structure_writes_files() {
+fn init_planning_structure_creates_only_workspace() {
     let tmp = tempdir().unwrap();
     let ito_path = tmp.path();
 
-    planning_init::init_planning_structure(ito_path, "test-module", "test-change").unwrap();
+    planning_init::init_planning_structure(ito_path).unwrap();
 
     let plan_dir = planning_dir(ito_path);
     assert!(plan_dir.exists(), "planning dir should exist");
-    assert!(plan_dir.join("PROJECT.md").exists());
-    assert!(plan_dir.join("ROADMAP.md").exists());
-    assert!(plan_dir.join("STATE.md").exists());
+    // Regression guard: the old planning bootstrap created these fixed files.
+    assert!(!plan_dir.join("PROJECT.md").exists());
+    assert!(!plan_dir.join("ROADMAP.md").exists());
+    assert!(!plan_dir.join("STATE.md").exists());
 }
 
 #[test]
-fn read_planning_status_returns_contents_for_existing_roadmap() {
+fn init_planning_structure_preserves_existing_plan_documents() {
     let tmp = tempdir().unwrap();
     let ito_path = tmp.path();
-    let roadmap_content = "# Roadmap\n\n## Current Milestone: v1\n";
-
     let plan_dir = planning_dir(ito_path);
     std::fs::create_dir_all(&plan_dir).unwrap();
-    std::fs::write(plan_dir.join("ROADMAP.md"), roadmap_content).unwrap();
+    std::fs::write(plan_dir.join("existing.md"), "# Existing plan\n").unwrap();
 
-    let result = planning_init::read_planning_status(ito_path).expect("should read ROADMAP.md");
-    assert_eq!(result, roadmap_content);
+    planning_init::init_planning_structure(ito_path).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(plan_dir.join("existing.md")).unwrap(),
+        "# Existing plan\n"
+    );
+    assert!(!plan_dir.join("PROJECT.md").exists());
+    assert!(!plan_dir.join("ROADMAP.md").exists());
+    assert!(!plan_dir.join("STATE.md").exists());
 }
 
 #[test]
-fn read_planning_status_returns_error_for_missing_roadmap() {
+fn init_planning_structure_errors_when_planning_path_is_a_file() {
     let tmp = tempdir().unwrap();
     let ito_path = tmp.path();
-    // Do NOT create planning/ROADMAP.md
 
-    let result = planning_init::read_planning_status(ito_path);
-    assert!(result.is_err(), "should fail for missing ROADMAP.md");
-    let err = result.unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("ROADMAP.md"),
-        "error should mention ROADMAP.md, got: {msg}"
+    std::fs::write(planning_dir(ito_path), "not a directory\n").unwrap();
+
+    assert!(planning_init::init_planning_structure(ito_path).is_err());
+}
+
+#[test]
+fn read_planning_workspace_status_lists_plan_documents() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+    let plan_dir = planning_dir(ito_path);
+    std::fs::create_dir_all(&plan_dir).unwrap();
+    std::fs::write(plan_dir.join("topic.md"), "# Topic\n").unwrap();
+    std::fs::write(plan_dir.join("alpha.md"), "# Alpha\n").unwrap();
+    std::fs::write(plan_dir.join("BETA.MD"), "# Beta\n").unwrap();
+    std::fs::write(plan_dir.join("notes.txt"), "not a plan").unwrap();
+    std::fs::create_dir(plan_dir.join("nested.md")).unwrap();
+
+    let status = planning_init::read_planning_workspace_status(ito_path).expect("status");
+    assert!(status.planning_exists);
+    assert!(!status.planning_invalid);
+    assert!(!status.research_exists);
+    assert!(!status.research_invalid);
+    assert_eq!(
+        status.planning_documents,
+        vec![
+            plan_dir.join("BETA.MD"),
+            plan_dir.join("alpha.md"),
+            plan_dir.join("topic.md")
+        ]
     );
+}
+
+#[test]
+fn read_planning_workspace_status_allows_missing_workspace() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+
+    let status = planning_init::read_planning_workspace_status(ito_path).expect("status");
+    assert!(!status.planning_exists);
+    assert!(!status.planning_invalid);
+    assert!(!status.research_exists);
+    assert!(!status.research_invalid);
+    assert!(status.planning_documents.is_empty());
+}
+
+#[test]
+fn read_planning_workspace_status_reports_conflicting_file() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+
+    std::fs::write(planning_dir(ito_path), "not a directory\n").unwrap();
+
+    let status = planning_init::read_planning_workspace_status(ito_path).expect("status");
+    assert!(!status.planning_exists);
+    assert!(status.planning_invalid);
+    assert!(status.planning_documents.is_empty());
+}
+
+#[test]
+fn read_planning_workspace_status_reports_conflicting_research_file() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+
+    std::fs::write(research_dir(ito_path), "not a directory\n").unwrap();
+
+    let status = planning_init::read_planning_workspace_status(ito_path).expect("status");
+    assert!(!status.planning_exists);
+    assert!(!status.planning_invalid);
+    assert!(status.planning_documents.is_empty());
+    assert!(!status.research_exists);
+    assert!(status.research_invalid);
 }

--- a/ito-rs/crates/ito-core/tests/planning_init.rs
+++ b/ito-rs/crates/ito-core/tests/planning_init.rs
@@ -10,7 +10,9 @@ fn init_planning_structure_creates_only_workspace() {
     planning_init::init_planning_structure(ito_path).unwrap();
 
     let plan_dir = planning_dir(ito_path);
+    let research = research_dir(ito_path);
     assert!(plan_dir.exists(), "planning dir should exist");
+    assert!(research.exists(), "research dir should exist");
     // Regression guard: the old planning bootstrap created these fixed files.
     assert!(!plan_dir.join("PROJECT.md").exists());
     assert!(!plan_dir.join("ROADMAP.md").exists());
@@ -55,6 +57,7 @@ fn read_planning_workspace_status_lists_plan_documents() {
     std::fs::write(plan_dir.join("topic.md"), "# Topic\n").unwrap();
     std::fs::write(plan_dir.join("alpha.md"), "# Alpha\n").unwrap();
     std::fs::write(plan_dir.join("BETA.MD"), "# Beta\n").unwrap();
+    std::fs::write(plan_dir.join("notes.markdown"), "# Notes\n").unwrap();
     std::fs::write(plan_dir.join("notes.txt"), "not a plan").unwrap();
     std::fs::create_dir(plan_dir.join("nested.md")).unwrap();
 
@@ -68,6 +71,7 @@ fn read_planning_workspace_status_lists_plan_documents() {
         vec![
             plan_dir.join("BETA.MD"),
             plan_dir.join("alpha.md"),
+            plan_dir.join("notes.markdown"),
             plan_dir.join("topic.md")
         ]
     );

--- a/ito-rs/crates/ito-core/tests/planning_init.rs
+++ b/ito-rs/crates/ito-core/tests/planning_init.rs
@@ -113,3 +113,42 @@ fn read_planning_workspace_status_reports_conflicting_research_file() {
     assert!(!status.research_exists);
     assert!(status.research_invalid);
 }
+
+#[test]
+fn summarize_planning_workspace_moves_status_logic_to_core() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+    let plan_dir = planning_dir(ito_path);
+    std::fs::create_dir_all(&plan_dir).unwrap();
+    std::fs::write(plan_dir.join("topic.md"), "# Topic\n").unwrap();
+    std::fs::write(research_dir(ito_path), "not a directory\n").unwrap();
+
+    let status = planning_init::read_planning_workspace_status(ito_path).expect("status");
+    let summary = planning_init::summarize_planning_workspace(&status);
+
+    assert_eq!(summary.planning_status, "available");
+    assert_eq!(summary.research_status, "invalid");
+    assert_eq!(
+        summary.research_notice.as_deref(),
+        Some(
+            "Research path is not a directory. Rename or remove it before storing deep-dive research."
+        )
+    );
+    assert_eq!(summary.document_names, vec!["topic.md"]);
+    assert_eq!(summary.documents_notice, None);
+}
+
+#[test]
+fn init_planning_structure_errors_include_workspace_path() {
+    let tmp = tempdir().unwrap();
+    let ito_path = tmp.path();
+    let planning = planning_dir(ito_path);
+
+    std::fs::write(&planning, "not a directory\n").unwrap();
+
+    let err = planning_init::init_planning_structure(ito_path).expect_err("expected error");
+    let rendered = err.to_string();
+    assert!(rendered.contains("creating planning workspace"));
+    assert!(rendered.contains(&planning.display().to_string()));
+    assert!(rendered.contains("check permissions and parent directories"));
+}

--- a/ito-rs/crates/ito-domain/src/planning.rs
+++ b/ito-rs/crates/ito-domain/src/planning.rs
@@ -1,102 +1,20 @@
-//! Project planning templates and helpers.
+//! Project planning path helpers.
 //!
 //! Ito's planning area lives under `{ito_path}/planning`.
-//! This module provides **pure** path helpers, template content, and parsing
-//! utilities.  Filesystem I/O (init) lives in `ito-core`.
+//! This module provides pure path helpers. Filesystem I/O lives in `ito-core`.
 
-use regex::Regex;
 use std::path::{Path, PathBuf};
 
 // Filesystem I/O (init_planning_structure) lives in `ito-core`.
 
 /// Path to the planning directory (`{ito_path}/planning`).
+#[must_use]
 pub fn planning_dir(ito_path: &Path) -> PathBuf {
     ito_path.join("planning")
 }
 
-/// Path to the milestones directory (`{ito_path}/planning/milestones`).
-pub fn milestones_dir(ito_path: &Path) -> PathBuf {
-    planning_dir(ito_path).join("milestones")
-}
-
-/// Default contents for `planning/PROJECT.md`.
-pub fn project_md_template(project_name: Option<&str>, description: Option<&str>) -> String {
-    let project_name = project_name.unwrap_or("[Project Name]");
-    let description =
-        description.unwrap_or("[1-2 sentence description of what we're building and why]");
-    format!(
-        "# Project: {project_name}\n\n## Vision\n{description}\n\n## Core Value Proposition\n[What makes this valuable to users]\n\n## Constraints\n- Technical: [stack, compatibility requirements]\n- Resources: [team size, expertise gaps]\n\n## Stakeholders\n- [Role]: [Concerns and success criteria]\n\n## Out of Scope\n- [Explicitly excluded features/concerns]\n\n## AI Assistant Notes\n[Special instructions for AI tools working on this project]\n- Preferred patterns: [...]\n- Avoid: [...]\n- Always check: [...]\n"
-    )
-}
-
-/// Default contents for `planning/ROADMAP.md`.
-pub fn roadmap_md_template() -> String {
-    "# Roadmap\n\n## Current Milestone: v1-core\n- Status: Not Started\n- Phase: 0 of 0\n\n## Milestones\n\n### v1-core\nTarget: [Define the goal for this milestone]\n\n| Phase | Name | Status | Changes |\n|-------|------|--------|---------|\n| 1 | [Phase Name] | Pending | - |\n\n## Completed Milestones\n[None yet]\n"
-        .to_string()
-}
-
-/// Default contents for `planning/STATE.md`.
-pub fn state_md_template(current_date: &str, ito_dir: &str) -> String {
-    format!(
-        "# Project State\n\nLast Updated: {current_date}\n\n## Current Focus\n[What we're working on right now]\n\n## Recent Decisions\n- {current_date}: Project initialized\n\n## Open Questions\n- [ ] [Question needing resolution]\n\n## Blockers\n[None currently]\n\n## Session Notes\n### {current_date} - Initial Setup\n- Completed: Project planning structure initialized\n- Next: Define project vision and first milestone\n\n---\n## For AI Assistants\nWhen resuming work on this project:\n1. Read this STATE.md first\n2. Check ROADMAP.md for current phase\n3. Review any in-progress changes in `{ito_dir}/changes/`\n4. Continue from \"Current Focus\" above\n"
-    )
-}
-
-// NOTE: `init_planning_structure` was moved to `ito-core` to keep
-// the domain layer free of filesystem I/O.
-
-/// Parse the "Current Milestone" header block from roadmap markdown.
-pub fn read_current_progress(roadmap_contents: &str) -> Option<(String, String, String)> {
-    let re = Regex::new(r"## Current Milestone: (.+)\n- Status: (.+)\n- Phase: (.+)").unwrap();
-    let caps = re.captures(roadmap_contents)?;
-    Some((
-        caps[1].to_string(),
-        caps[2].to_string(),
-        caps[3].to_string(),
-    ))
-}
-
-/// Read phase rows from the roadmap milestone table.
-///
-/// Returns `(phase, name, status, changes)`.
-pub fn read_phase_rows(roadmap_contents: &str) -> Vec<(String, String, String, String)> {
-    let mut rows: Vec<(String, String, String, String)> = Vec::new();
-
-    let mut in_table = false;
-    let mut saw_sep = false;
-    for line in roadmap_contents.lines() {
-        let t = line.trim();
-        if t == "| Phase | Name | Status | Changes |" {
-            in_table = true;
-            saw_sep = false;
-            continue;
-        }
-        if !in_table {
-            continue;
-        }
-        if !saw_sep {
-            if t.starts_with("|-------") {
-                saw_sep = true;
-            }
-            continue;
-        }
-        if t.is_empty() || !t.starts_with('|') {
-            break;
-        }
-
-        let cols: Vec<String> = t
-            .split('|')
-            .map(|c| c.trim().to_string())
-            .filter(|c| !c.is_empty())
-            .collect();
-        if cols.len() >= 4 {
-            rows.push((
-                cols[0].clone(),
-                cols[1].clone(),
-                cols[2].clone(),
-                cols[3].clone(),
-            ));
-        }
-    }
-    rows
+/// Path to the companion research directory (`{ito_path}/research`).
+#[must_use]
+pub fn research_dir(ito_path: &Path) -> PathBuf {
+    ito_path.join("research")
 }

--- a/ito-rs/crates/ito-domain/tests/planning.rs
+++ b/ito-rs/crates/ito-domain/tests/planning.rs
@@ -1,15 +1,9 @@
 use ito_domain::planning;
 
 #[test]
-fn roadmap_parsing_extracts_current_progress_and_phases() {
-    let roadmap = planning::roadmap_md_template();
-    let (milestone, status, phase) = planning::read_current_progress(&roadmap).expect("progress");
-    assert_eq!(milestone, "v1-core");
-    assert_eq!(status, "Not Started");
-    assert_eq!(phase, "0 of 0");
+fn planning_paths_point_to_flexible_workspaces() {
+    let root = std::path::Path::new(".ito");
 
-    let phases = planning::read_phase_rows(&roadmap);
-    assert_eq!(phases.len(), 1);
-    assert_eq!(phases[0].0, "1");
-    assert_eq!(phases[0].2, "Pending");
+    assert_eq!(planning::planning_dir(root), root.join("planning"));
+    assert_eq!(planning::research_dir(root), root.join("research"));
 }

--- a/ito-rs/crates/ito-domain/tests/schema_roundtrip.rs
+++ b/ito-rs/crates/ito-domain/tests/schema_roundtrip.rs
@@ -12,8 +12,8 @@ requires:
     - topic
 
 context_files:
-  - planning/PROJECT.md
-  - planning/STATE.md
+  - planning/topic.md
+  - research/topic/notes.md
 
 waves:
   - id: investigate

--- a/ito-rs/crates/ito-templates/assets/commands/ito-plan.md
+++ b/ito-rs/crates/ito-templates/assets/commands/ito-plan.md
@@ -1,0 +1,20 @@
+---
+name: ito-plan
+description: Explore and shape an idea before creating one or more Ito proposals.
+category: Ito
+tags: [ito, planning]
+---
+
+<PlanningRequest>
+$ARGUMENTS
+</PlanningRequest>
+
+<!-- ITO:START -->
+
+Load and follow the `ito-plan` skill. Pass the <PlanningRequest> block as input unchanged.
+
+Before stateful Ito actions, run `ito audit validate`; if it fails or reports drift, run `ito audit reconcile` then `ito audit reconcile --fix`.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-plan/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-plan/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: ito-plan
+description: Exploratory, question-driven planning before creating Ito change proposals. Use when an idea needs shaping, scoping, sequencing, or research before proposal scaffolding.
+---
+
+<!-- ITO:START -->
+
+# Ito Plan
+
+Use this skill before proposal creation when the user has an idea, rough feature request, product direction, or ambiguous improvement that needs exploration before it becomes one or more Ito changes.
+
+## Goal
+
+Turn an open-ended idea into a useful planning artifact under `.ito/planning/`, with supporting research under `.ito/research/` when deeper investigation is needed.
+
+## Guardrails
+
+- Do not scaffold a change proposal from this skill.
+- Ask clarifying questions before writing a plan; always confirm scope, goals, constraints, or success criteria, even when the request seems clear.
+- Prefer one question at a time; use multiple choice when it reduces user effort.
+- Inspect existing specs, changes, code, and planning documents before asking for facts the repo already contains.
+- Treat planning output as a precursor to one or more later `ito-proposal` runs.
+
+## Planning Questions
+
+Clarify enough to make the plan actionable:
+
+- What problem or opportunity is this addressing?
+- Who is affected, and what outcome would count as success?
+- What constraints, deadlines, compatibility concerns, or non-goals matter?
+- What options or trade-offs need comparison?
+- Could this become one proposal, or should it split into multiple proposals?
+- What evidence is missing and should be researched first?
+
+## Artifact Locations
+
+Use Ito path helpers instead of hard-coded absolute paths:
+
+```bash
+ITO_ROOT="$(ito path ito-root)"
+```
+
+Save planning synthesis as markdown under:
+
+- `$ITO_ROOT/planning/<topic>.md`
+
+Save deeper research evidence under:
+
+- `$ITO_ROOT/research/<topic>/`
+
+Plans should reference relevant research files instead of duplicating long evidence dumps.
+
+## Plan Shape
+
+Use a lightweight structure that fits the topic. A good default is:
+
+```markdown
+# <Topic> Plan
+
+## Context
+## Goals
+## Non-Goals
+## Constraints
+## Options
+## Recommendation
+## Proposal Split
+## Open Questions
+## Research References
+```
+
+Keep the document practical. It should help the next agent create focused proposals, not become a rigid specification.
+
+## Handoff
+
+End with one of these outcomes:
+
+1. **Ready for proposal**: summarize the recommended proposal boundary or boundaries and suggest `ito-proposal` as the next step.
+2. **Needs research**: identify the research topic and save or request research under `.ito/research/` before proposal work.
+3. **Needs more planning**: list the blocking questions and update the plan with current understanding.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito/SKILL.md
@@ -33,6 +33,7 @@ The requested command is provided either:
    - If no command is provided, output a concise error: "Command is required" and show a one-line usage example
 
 2. **Resolve skill target**:
+   - If the command is `plan`, use CLI fallback. `ito plan init/status` are CLI workspace commands; `/ito-plan` is the exploratory planning workflow.
    - Build candidate skill id: `ito-${command}`
    - Determine if that skill is installed/available in this harness
      - OpenCode: check for a directory under `.opencode/skills/`


### PR DESCRIPTION
## Summary
- add a dedicated `/ito-plan` workflow and install it across all supported harnesses
- replace the rigid planning bootstrap with a flexible `.ito/planning/` workspace plus `.ito/research/` guidance
- update CLI behavior, docs, and regression coverage for the new planning model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /ito-plan exploratory planning workflow for question-driven planning before proposals
  * Introduced flexible planning workspace (.ito/planning/ and .ito/research/) discovery and initialization

* **Documentation**
  * Updated README, skill and prompt docs with plan templates, artifact locations, guardrails, and handoff outcomes

* **CLI / UX**
  * `ito plan` init/status now report workspace availability, warnings, and list markdown planning documents (no roadmap scaffolding)

* **Tests**
  * Added/updated tests covering init/update and planning workspace behaviors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/withakay/ito/pull/239)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->