### PR TITLE
feat(001-34): add DDD discovery workflow

### DIFF
--- a/docs/agent-workflow.md
+++ b/docs/agent-workflow.md
@@ -27,7 +27,20 @@ Use a proposal for new capabilities, breaking changes, architectural shifts, or 
 
 If you're unsure, default to proposal-first. It is cheaper than a large rewrite.
 
-### 2) Pick or create a change
+### 2) Decide whether domain discovery is needed
+
+Use the normal fast path for routine, one-context work with clear vocabulary.
+
+Ask the agent to run DDD-oriented discovery before scaffolding when the work is ambiguous, architectural, cross-context, public-contract-changing, policy-heavy, sequencing-heavy, or uses overloaded domain terms. The discovery output should stay proportional:
+
+- `direct`: no extra discovery for routine work.
+- `lightweight`: resolve canonical terms, rejected aliases, and open questions.
+- `bounded-context`: name primary/supporting contexts, model ownership, relationship pattern or provisional unknown, consistency expectations, and translation boundaries.
+- `rigorous domain-grill`: challenge fuzzy plans one decision at a time, using repo evidence before asking questions.
+
+For domain-heavy changes, expect the agent to carry the discovery handoff into proposal/spec/task language. Durable terms and boundaries can be proposed in `CONTEXT.md`, `CONTEXT-MAP.md`, or ADR files, but they become canonical only through review and archive/merge.
+
+### 3) Pick or create a change
 
 Humans usually start by asking the agent to discover existing work and scaffold the right thing:
 
@@ -44,7 +57,7 @@ ito create module <name>
 ito create change <name> --module <module-id>
 ```
 
-### 3) Use instruction artifacts to drive execution
+### 4) Use instruction artifacts to drive execution
 
 The most reliable way to keep an agent aligned is to have it fetch and follow the change-specific instructions:
 
@@ -57,7 +70,7 @@ ito agent instruction apply --change <change-id>
 
 As reviewer, you should expect the agent to quote the relevant parts of these instructions back to you (briefly) before implementing.
 
-### 4) Implement tasks and keep task state accurate
+### 5) Implement tasks and keep task state accurate
 
 For enhanced `tasks.md`, prefer task commands so audit events stay consistent:
 
@@ -74,7 +87,7 @@ If someone edits `tasks.md` directly, reconcile immediately:
 ito audit reconcile --fix
 ```
 
-### 5) Validate before calling something done
+### 6) Validate before calling something done
 
 At minimum:
 
@@ -84,7 +97,15 @@ ito audit validate
 ito audit reconcile
 ```
 
-### 6) Archive after merge/deploy
+For changes with a `domain-discovery.md` handoff, also check that proposal validation either enables or intentionally skips these opt-in rules:
+
+- `ubiquitous_language_consistency`
+- `context_boundary_consistency`
+- `domain_documentation_consistency`
+
+### 7) Archive after merge/deploy
+
+Before archive, confirm any approved domain-doc updates from the change package are promoted into the discovered `CONTEXT.md`, `CONTEXT-MAP.md`, or ADR locations. Do not promote rejected or unresolved discovery notes.
 
 ```bash
 ito agent instruction archive --change <change-id>
@@ -100,8 +121,6 @@ Rules of thumb:
 - Do work inside a worktree (not the bare repo root).
 - Create feature worktrees under `ito-worktrees/`.
 - Do not remove the locked `main` worktree.
-- Prefer `ito worktree ensure --change <id>` over raw `git worktree add` so Ito can initialize the worktree correctly.
-- If you inherit an older or manually created worktree and `.ito/changes`, `.ito/specs`, `.ito/modules`, `.ito/workflows`, or `.ito/audit` are missing or stale, repair the worktree with `ito init --update --tools none` before creating or applying changes.
 
 Also: when testing changes, use the binary built in the same worktree you edited (worktrees do not share `target/`).
 

--- a/docs/presentations/march-2026/ito-workflow-diagram.mmd
+++ b/docs/presentations/march-2026/ito-workflow-diagram.mmd
@@ -4,6 +4,9 @@ flowchart TD
         B1[Explore the idea]
         B2[Evaluate approaches]
         B3[Validate design]
+        B4{DDD discovery needed?}
+        B5[Resolve language and boundaries]
+        B6[Create discovery handoff]
     end
 
     subgraph PROPOSE["2. Propose"]
@@ -16,8 +19,9 @@ flowchart TD
 
     subgraph REVIEW["3. Review"]
         R1[Peer review checklist]
-        R2{Verdict?}
-        R3[Address feedback]
+        R2[Check discovery depth and boundaries]
+        R3{Verdict?}
+        R4[Address feedback]
     end
 
     subgraph IMPLEMENT["4. Implement"]
@@ -29,18 +33,21 @@ flowchart TD
 
     subgraph ARCHIVE["5. Archive"]
         A1[Reconcile audit log]
-        A2[Move to archive/]
-        A3[Apply deltas to specs/]
-        A4["Validate: ito validate --strict"]
+        A2[Promote approved domain docs]
+        A3[Move to archive/]
+        A4[Apply deltas to specs/]
+        A5["Validate: ito validate --strict"]
     end
 
-    B1 --> B2 --> B3
-    B3 --> P1 --> P2 --> P3 --> P4 --> P5
-    P5 --> R1 --> R2
-    R2 -- "approve" --> I1
-    R2 -- "request-changes" --> R3
-    R3 --> P2
+    B1 --> B2 --> B3 --> B4
+    B4 -- "No" --> P1
+    B4 -- "Yes" --> B5 --> B6 --> P1
+    P1 --> P2 --> P3 --> P4 --> P5
+    P5 --> R1 --> R2 --> R3
+    R3 -- "approve" --> I1
+    R3 -- "request-changes" --> R4
+    R4 --> P2
     I1 --> I2 --> I3 --> I4
     I4 -- "Yes" --> I1
     I4 -- "No" --> A1
-    A1 --> A2 --> A3 --> A4
+    A1 --> A2 --> A3 --> A4 --> A5

--- a/docs/schema-customization.md
+++ b/docs/schema-customization.md
@@ -71,7 +71,7 @@ ito templates schemas export -f ".ito/templates/schemas" --force
 
 ## Validation Rules Extension
 
-Schema validation configs can opt into additional checks without changing validator IDs. Add a `rules:` map under an artifact entry, and use the optional top-level `proposal:` entry when proposal-only checks are needed.
+Schema validation configs can opt into additional checks without changing validator IDs. Add a `rules:` map under an artifact entry, and use the optional top-level `proposal:` entry when proposal-only checks are needed. Domain-discovery rules can run from either `proposal.rules` or an artifact rule such as `artifacts.specs.rules`, so schemas without `proposal.md` can still validate a `domain-discovery.md` handoff.
 
 ```yaml
 version: 1
@@ -88,6 +88,9 @@ proposal:
   validate_as: ito.delta-specs.v1
   rules:
     capabilities_consistency: error
+    ubiquitous_language_consistency: warning
+    context_boundary_consistency: warning
+    domain_documentation_consistency: warning
 tracking:
   source: apply_tracks
   required: true
@@ -102,7 +105,12 @@ Current v1 rule names:
 - `ui_mechanics`: warn when non-UI requirements describe click/wait/selector mechanics
 - `contract_refs`: validate requirement-level `Contract Refs` syntax and related proposal anchors
 - `capabilities_consistency`: compare proposal capability lists against change-local deltas and baseline `.ito/specs/`
+- `ubiquitous_language_consistency`: compare rejected aliases from `domain-discovery.md` against proposal, spec, design, and task language
+- `context_boundary_consistency`: warn when cross-context discovery omits affected contexts, ownership, relationship framing, or translation boundaries
+- `domain_documentation_consistency`: compare proposed `CONTEXT.md`, `CONTEXT-MAP.md`, and ADR term definitions against `domain-discovery.md`
 - `task_quality`: enforce enhanced-task quality checks for `Files`, `Action`, `Verify`, `Done When`, `Requirements`, `Status`, and `Updated At`
+
+The domain-language and boundary rules are quiet unless the change includes `domain-discovery.md` with the relevant DDD handoff tables populated. `ubiquitous_language_consistency` reads rejected aliases from `## Rejected Aliases / Overloaded Terms`; `context_boundary_consistency` reads `## Domain Discovery Summary`, `## Bounded Context Map`, and `## Model Ownership`; `domain_documentation_consistency` compares `## Ubiquitous Language` term definitions against proposed domain docs.
 
 Built-in `spec-driven` defaults stay quiet in v1: the shipped schema exports the rule machinery, but it does not enable any of these new rules until you opt in through a project-local `validation.yaml` override.
 

--- a/ito-rs/crates/ito-cli/src/app/manifesto_instructions.rs
+++ b/ito-rs/crates/ito-cli/src/app/manifesto_instructions.rs
@@ -36,7 +36,15 @@ const MANIFESTO_PROFILES: &[&str] = &[
     "full",
 ];
 const MANIFESTO_OPERATIONS: &[&str] = &[
-    "proposal", "specs", "design", "tasks", "apply", "review", "archive", "finish",
+    "domain-discovery",
+    "proposal",
+    "specs",
+    "design",
+    "tasks",
+    "apply",
+    "review",
+    "archive",
+    "finish",
 ];
 
 #[derive(Debug, Clone)]
@@ -169,7 +177,17 @@ pub(super) fn handle_manifesto_instruction(
             status
                 .artifacts
                 .iter()
-                .filter(|artifact| artifact.status != "done")
+                .filter(|artifact| artifact.status != "done" && artifact.status != "optional")
+                .map(|artifact| artifact.id.clone())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        let optional_artifacts = if let Some(status) = &change_status {
+            status
+                .artifacts
+                .iter()
+                .filter(|artifact| artifact.status == "optional")
                 .map(|artifact| artifact.id.clone())
                 .collect::<Vec<_>>()
         } else {
@@ -226,6 +244,7 @@ pub(super) fn handle_manifesto_instruction(
             "module_name": module_name,
             "available_artifacts": available_artifacts,
             "missing_artifacts": missing_artifacts,
+            "optional_artifacts": optional_artifacts,
             "state": state,
         })
     } else {
@@ -243,6 +262,7 @@ pub(super) fn handle_manifesto_instruction(
             "module_name": Value::Null,
             "available_artifacts": Vec::<String>::new(),
             "missing_artifacts": Vec::<String>::new(),
+            "optional_artifacts": Vec::<String>::new(),
             "state": state,
         })
     };
@@ -261,6 +281,7 @@ pub(super) fn handle_manifesto_instruction(
         "schema": change_json.get("schema").cloned().unwrap_or(Value::Null),
         "operation": request.operation,
         "artifacts": {
+            "domain-discovery": artifact_capsule_state(&change_json, "domain-discovery"),
             "proposal": artifact_capsule_state(&change_json, "proposal"),
             "specs": artifact_capsule_state(&change_json, "specs"),
             "design": artifact_capsule_state(&change_json, "design"),
@@ -419,10 +440,11 @@ fn resolve_manifesto_state(
     if review_status == "pending-approval" || review_status == "changes-requested" {
         return "review-needed".to_string();
     }
-    if change.work_status().to_string() == "draft"
-        || (change_status
-            .is_some_and(|status| !status.apply_requires.is_empty() && !status.is_complete)
-            && !change.artifacts_complete())
+    let apply_artifacts_complete = change_status.is_some_and(apply_requirements_complete);
+    let apply_artifacts_incomplete =
+        change_status.is_some_and(|status| !apply_requirements_complete(status));
+    if (change.work_status().to_string() == "draft" && !apply_artifacts_complete)
+        || apply_artifacts_incomplete
     {
         return "proposal-drafting".to_string();
     }
@@ -440,6 +462,19 @@ fn resolve_manifesto_state(
     }
 
     "apply-ready".to_string()
+}
+
+fn apply_requirements_complete(status: &core_templates::ChangeStatus) -> bool {
+    if status.apply_requires.is_empty() {
+        return true;
+    }
+
+    status.apply_requires.iter().all(|required| {
+        status
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.id == *required && artifact.status == "done")
+    })
 }
 
 fn render_manifesto_instruction_bodies(
@@ -490,28 +525,24 @@ fn render_manifesto_instruction_body(
     let ito_path = rt.ito_path();
     let project_root = ito_path.parent().unwrap_or(ito_path);
     let ctx = rt.ctx();
-    let resolved = rt.resolved_config();
-    let testing_policy = testing_policy_from_merged(&resolved.merged);
+    let cfg = rt.resolved_config();
+    let testing_policy = testing_policy_from_merged(&cfg.merged);
     let user_guidance =
         core_templates::load_composed_user_guidance(ito_path, artifact).unwrap_or(None);
 
     match artifact {
-        "proposal" | "specs" | "design" | "tasks" => {
-            let resolved_instr =
+        "domain-discovery" | "proposal" | "specs" | "design" | "tasks" => {
+            let resolved =
                 core_templates::resolve_instructions(ito_path, change_id, None, artifact, ctx)
                     .map_err(to_cli_error)?;
-            render_artifact_instructions_text(
-                &resolved_instr,
-                user_guidance.as_deref(),
-                &testing_policy,
-            )
+            render_artifact_instructions_text(&resolved, user_guidance.as_deref(), &testing_policy)
         }
         "apply" => {
             let apply = core_templates::compute_apply_instructions(ito_path, change_id, None, ctx)
                 .map_err(to_cli_error)?;
             let worktree_config =
-                worktree_config_from_merged_with_paths(&resolved.merged, project_root, ito_path);
-            let memory_template = memory_template_config_from_merged(&resolved.merged);
+                worktree_config_from_merged_with_paths(&cfg.merged, project_root, ito_path);
+            let memory_template = memory_template_config_from_merged(&cfg.merged);
             Ok(render_apply_instructions_text(
                 &apply,
                 &testing_policy,
@@ -534,7 +565,7 @@ fn render_manifesto_instruction_body(
                 .map_err(to_cli_error)
         }
         "archive" => {
-            let archive = archive_instruction_config_from_merged(&resolved.merged)?;
+            let archive = archive_instruction_config_from_merged(&cfg.merged)?;
             ito_templates::instructions::render_instruction_template(
                 "agent/archive.md.j2",
                 &json!({
@@ -547,9 +578,9 @@ fn render_manifesto_instruction_body(
         }
         "finish" => {
             let worktree =
-                worktree_config_from_merged_with_paths(&resolved.merged, project_root, ito_path);
-            let archive = archive_instruction_config_from_merged(&resolved.merged)?;
-            let memory = memory_template_config_from_merged(&resolved.merged);
+                worktree_config_from_merged_with_paths(&cfg.merged, project_root, ito_path);
+            let archive = archive_instruction_config_from_merged(&cfg.merged)?;
+            let memory = memory_template_config_from_merged(&cfg.merged);
             ito_templates::instructions::render_instruction_template(
                 "agent/finish.md.j2",
                 &json!({
@@ -569,7 +600,14 @@ fn render_manifesto_instruction_body(
 fn allowed_manifesto_artifacts(state: &str, profile: &str, review_status: &str) -> Vec<String> {
     let state_ops: &[&str] = match state {
         "no-change-selected" => &[],
-        "proposal-drafting" => &["proposal", "specs", "design", "tasks", "review"],
+        "proposal-drafting" => &[
+            "domain-discovery",
+            "proposal",
+            "specs",
+            "design",
+            "tasks",
+            "review",
+        ],
         "review-needed" => &["review"],
         "apply-ready" => &["apply"],
         "applying" => &["apply", "review"],
@@ -580,12 +618,27 @@ fn allowed_manifesto_artifacts(state: &str, profile: &str, review_status: &str) 
     };
     let profile_ops: &[&str] = match profile {
         "planning" => &[],
-        "proposal-only" => &["proposal", "specs", "design", "tasks", "review"],
+        "proposal-only" => &[
+            "domain-discovery",
+            "proposal",
+            "specs",
+            "design",
+            "tasks",
+            "review",
+        ],
         "review-only" => &["review"],
         "apply" => &["apply", "review"],
         "archive" => &["archive", "finish"],
         "full" => &[
-            "proposal", "specs", "design", "tasks", "apply", "review", "archive", "finish",
+            "domain-discovery",
+            "proposal",
+            "specs",
+            "design",
+            "tasks",
+            "apply",
+            "review",
+            "archive",
+            "finish",
         ],
         _ => &[],
     };
@@ -792,5 +845,163 @@ fn artifact_capsule_state(change: &Value, artifact: &str) -> &'static str {
                 .filter_map(Value::as_str)
                 .any(|item| item == artifact)
         });
-    if available { "done" } else { "missing" }
+    if available {
+        return "done";
+    }
+
+    let optional = change
+        .get("optional_artifacts")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|item| item == artifact)
+        });
+    if optional { "optional" } else { "missing" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ito_core::{ProgressInfo, TaskItem, TasksFormat, TasksParseResult};
+
+    fn draft_change_with_pending_task() -> Change {
+        Change {
+            id: "000-01_test-change".to_string(),
+            module_id: Some("000".to_string()),
+            sub_module_id: None,
+            path: std::path::PathBuf::from("/tmp/000-01_test-change"),
+            proposal: Some("## Why\nCustom workflow.\n".to_string()),
+            design: None,
+            specs: Vec::new(),
+            tasks: TasksParseResult {
+                format: TasksFormat::Checkbox,
+                tasks: Vec::<TaskItem>::new(),
+                waves: Vec::new(),
+                diagnostics: Vec::new(),
+                progress: ProgressInfo {
+                    total: 1,
+                    complete: 0,
+                    shelved: 0,
+                    in_progress: 0,
+                    pending: 1,
+                    remaining: 1,
+                },
+            },
+            orchestrate: Default::default(),
+            last_modified: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn manifesto_state_uses_schema_status_for_custom_artifacts() {
+        let change = Some(draft_change_with_pending_task());
+        let schema_status = core_templates::ChangeStatus {
+            change_name: "000-01_test-change".to_string(),
+            schema_name: "custom".to_string(),
+            is_complete: true,
+            apply_requires: vec!["proposal".to_string()],
+            artifacts: vec![core_templates::ArtifactStatus {
+                id: "proposal".to_string(),
+                output_path: "proposal.md".to_string(),
+                status: "done".to_string(),
+                missing_deps: Vec::new(),
+            }],
+        };
+
+        let state = resolve_manifesto_state(
+            false,
+            &change,
+            Some(&schema_status),
+            "unknown",
+            "not-requested",
+        );
+
+        assert_eq!(state, "apply-ready");
+    }
+
+    #[test]
+    fn manifesto_state_reports_drafting_for_incomplete_schema_artifacts() {
+        let change = Some(draft_change_with_pending_task());
+        let schema_status = core_templates::ChangeStatus {
+            change_name: "000-01_test-change".to_string(),
+            schema_name: "custom".to_string(),
+            is_complete: false,
+            apply_requires: vec!["proposal".to_string()],
+            artifacts: Vec::new(),
+        };
+
+        let state = resolve_manifesto_state(
+            false,
+            &change,
+            Some(&schema_status),
+            "unknown",
+            "not-requested",
+        );
+
+        assert_eq!(state, "proposal-drafting");
+    }
+
+    #[test]
+    fn manifesto_state_uses_apply_requirements_not_all_required_artifacts() {
+        let change = Some(draft_change_with_pending_task());
+        let schema_status = core_templates::ChangeStatus {
+            change_name: "000-01_test-change".to_string(),
+            schema_name: "custom".to_string(),
+            is_complete: false,
+            apply_requires: vec!["proposal".to_string()],
+            artifacts: vec![
+                core_templates::ArtifactStatus {
+                    id: "proposal".to_string(),
+                    output_path: "proposal.md".to_string(),
+                    status: "done".to_string(),
+                    missing_deps: Vec::new(),
+                },
+                core_templates::ArtifactStatus {
+                    id: "analysis".to_string(),
+                    output_path: "analysis.md".to_string(),
+                    status: "ready".to_string(),
+                    missing_deps: Vec::new(),
+                },
+            ],
+        };
+
+        let state = resolve_manifesto_state(
+            false,
+            &change,
+            Some(&schema_status),
+            "unknown",
+            "not-requested",
+        );
+
+        assert_eq!(state, "apply-ready");
+    }
+
+    #[test]
+    fn manifesto_state_treats_empty_apply_requirements_as_apply_ready() {
+        let change = Some(draft_change_with_pending_task());
+        let schema_status = core_templates::ChangeStatus {
+            change_name: "000-01_test-change".to_string(),
+            schema_name: "custom".to_string(),
+            is_complete: false,
+            apply_requires: Vec::new(),
+            artifacts: vec![core_templates::ArtifactStatus {
+                id: "proposal".to_string(),
+                output_path: "proposal.md".to_string(),
+                status: "ready".to_string(),
+                missing_deps: Vec::new(),
+            }],
+        };
+
+        let state = resolve_manifesto_state(
+            false,
+            &change,
+            Some(&schema_status),
+            "unknown",
+            "not-requested",
+        );
+
+        assert_eq!(state, "apply-ready");
+    }
 }

--- a/ito-rs/crates/ito-cli/src/app/status.rs
+++ b/ito-rs/crates/ito-cli/src/app/status.rs
@@ -103,7 +103,7 @@ pub(crate) fn handle_status(rt: &Runtime, args: &[String]) -> CliResult<()> {
         }
     }
     if status.is_complete {
-        println!("\nAll artifacts complete!");
+        println!("\nAll required artifacts complete!");
     }
 
     Ok(())

--- a/ito-rs/crates/ito-cli/src/app/status.rs
+++ b/ito-rs/crates/ito-cli/src/app/status.rs
@@ -65,7 +65,11 @@ pub(crate) fn handle_status(rt: &Runtime, args: &[String]) -> CliResult<()> {
         return Ok(());
     }
 
-    let total = status.artifacts.len();
+    let total = status
+        .artifacts
+        .iter()
+        .filter(|a| a.status != "optional")
+        .count();
     let done = status
         .artifacts
         .iter()
@@ -78,6 +82,8 @@ pub(crate) fn handle_status(rt: &Runtime, args: &[String]) -> CliResult<()> {
     for a in &status.artifacts {
         let mark = if a.status == "done" {
             "[x]"
+        } else if a.status == "optional" {
+            "[~]"
         } else if a.status == "blocked" {
             "[-]"
         } else {
@@ -90,6 +96,8 @@ pub(crate) fn handle_status(rt: &Runtime, args: &[String]) -> CliResult<()> {
                 a.id,
                 a.missing_deps.join(", ")
             );
+        } else if a.status == "optional" {
+            println!("{mark} {} (optional)", a.id);
         } else {
             println!("{mark} {}", a.id);
         }

--- a/ito-rs/crates/ito-cli/tests/cli_smoke.rs
+++ b/ito-rs/crates/ito-cli/tests/cli_smoke.rs
@@ -183,7 +183,7 @@ artifacts:
         "stdout={}",
         out.stdout
     );
-    assert!(out.stdout.contains("All artifacts complete!"));
+    assert!(out.stdout.contains("All required artifacts complete!"));
 
     write(
         repo.path()

--- a/ito-rs/crates/ito-cli/tests/cli_smoke.rs
+++ b/ito-rs/crates/ito-cli/tests/cli_smoke.rs
@@ -111,6 +111,109 @@ fn cli_top_level_serve_api_help_shows_backend_migration_guidance() {
 }
 
 #[test]
+fn status_marks_optional_artifacts_without_counting_them_as_incomplete() {
+    let repo = make_base_repo();
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    write(
+        repo.path()
+            .join(".ito/templates/schemas/spec-driven/schema.yaml"),
+        r#"name: spec-driven
+version: 1
+artifacts:
+  - id: domain-discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: []
+  - id: proposal
+    generates: proposal.md
+    template: proposal.md
+    requires: []
+"#,
+    );
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/.ito.yaml"),
+        "schema: spec-driven\n",
+    );
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/proposal.md"),
+        "## Why\nOptional discovery is not needed.\n",
+    );
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/design.md"),
+        "# Design\n\nNo special design required.\n",
+    );
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/specs/alpha/spec.md"),
+        "## ADDED Requirements\n\n### Requirement: Optional Artifact Status\nThe system SHALL treat omitted optional artifacts as non-blocking.\n\n#### Scenario: Status renders optional artifact\n- **WHEN** status renders a change with a missing optional artifact\n- **THEN** the required progress remains complete\n",
+    );
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/tasks.md"),
+        "# Tasks\n\n- [x] Verify optional artifact status\n",
+    );
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "status",
+            "--change",
+            "000-02_optional-artifact",
+            "--schema",
+            "spec-driven",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(
+        out.stdout.contains("Progress: 4/4 artifacts complete"),
+        "stdout={}",
+        out.stdout
+    );
+    assert!(
+        out.stdout.contains("[~] domain-discovery (optional)"),
+        "stdout={}",
+        out.stdout
+    );
+    assert!(out.stdout.contains("All artifacts complete!"));
+
+    write(
+        repo.path()
+            .join(".ito/changes/000-02_optional-artifact/domain-discovery.md"),
+        "# Domain Discovery\n\nDiscovery was explicitly captured.\n",
+    );
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "status",
+            "--change",
+            "000-02_optional-artifact",
+            "--schema",
+            "spec-driven",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    assert!(
+        out.stdout.contains("Progress: 5/5 artifacts complete"),
+        "stdout={}",
+        out.stdout
+    );
+    assert!(out.stdout.contains("[x] domain-discovery"));
+}
+
+#[test]
 fn list_show_validate_smoke() {
     let base = make_base_repo();
     let repo = tempfile::tempdir().expect("work");

--- a/ito-rs/crates/ito-cli/tests/instructions_more.rs
+++ b/ito-rs/crates/ito-cli/tests/instructions_more.rs
@@ -235,6 +235,52 @@ fn agent_instruction_manifesto_change_scope_json_reports_state() {
     assert_eq!(v["state"], "proposal-drafting");
     assert_eq!(v["variant"], "light");
     assert_eq!(v["profile"], "full");
+    assert!(
+        v["instruction"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("\"domain-discovery\": \"optional\"")
+    );
+}
+
+#[test]
+fn agent_instruction_manifesto_reports_domain_discovery_artifact() {
+    let base = fixtures::make_repo_with_spec_change_fixture();
+    let repo = tempfile::tempdir().expect("work");
+    let home = tempfile::tempdir().expect("home");
+    let rust_path = assert_cmd::cargo::cargo_bin!("ito");
+
+    fixtures::reset_repo(repo.path(), base.path());
+    fixtures::write(
+        repo.path()
+            .join(".ito/changes/000-01_test-change/domain-discovery.md"),
+        "# Domain Discovery\n\n## Domain Discovery Summary\n\n- **Primary bounded context**: Test\n",
+    );
+
+    let out = run_rust_candidate(
+        rust_path,
+        &[
+            "agent",
+            "instruction",
+            "manifesto",
+            "--change",
+            "000-01_test-change",
+            "--variant",
+            "full",
+            "--operation",
+            "domain-discovery",
+            "--json",
+        ],
+        repo.path(),
+        home.path(),
+    );
+
+    assert_eq!(out.code, 0, "stderr={}", out.stderr);
+    let v: serde_json::Value = serde_json::from_str(&out.stdout).expect("valid json");
+    let instruction = v["instruction"].as_str().unwrap_or_default();
+    assert!(instruction.contains("\"domain-discovery\": \"done\""));
+    assert!(instruction.contains("### `domain-discovery`"));
+    assert!(instruction.contains("<artifact id=\"domain-discovery\""));
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/src/templates/mod.rs
+++ b/ito-rs/crates/ito-core/src/templates/mod.rs
@@ -357,7 +357,8 @@ pub fn resolve_schema(
 ///
 /// `ChangeStatus` describing the change name, resolved schema, overall completion flag,
 /// the set of artifact ids required for apply, and a list of `ArtifactStatus` entries where each
-/// artifact is labeled `done`, `ready`, or `blocked` and includes any missing dependency ids.
+/// artifact is labeled `done`, `ready`, `blocked`, or `optional` and includes any missing
+/// dependency ids. Optional artifacts do not count against the overall completion flag.
 ///
 /// # Errors
 ///
@@ -394,8 +395,14 @@ pub fn compute_change_status(
     }
 
     let mut artifacts_out: Vec<ArtifactStatus> = Vec::new();
-    let mut done_count: usize = 0;
+    let mut required_done_count: usize = 0;
     let done_by_id = compute_done_by_id(&change_dir, &resolved.schema);
+    let required_count = resolved
+        .schema
+        .artifacts
+        .iter()
+        .filter(|artifact| !artifact.optional)
+        .count();
 
     let order = build_order(&resolved.schema);
     for id in order {
@@ -413,8 +420,12 @@ pub fn compute_change_status(
         }
 
         let status = if done {
-            done_count += 1;
+            if !a.optional {
+                required_done_count += 1;
+            }
             "done".to_string()
+        } else if a.optional {
+            "optional".to_string()
         } else if missing.is_empty() {
             "ready".to_string()
         } else {
@@ -428,21 +439,23 @@ pub fn compute_change_status(
         });
     }
 
-    let all_artifact_ids: Vec<String> = resolved
+    let required_artifact_ids: Vec<String> = resolved
         .schema
         .artifacts
         .iter()
+        .filter(|artifact| !artifact.optional)
         .map(|a| a.id.clone())
         .collect();
     let apply_requires: Vec<String> = match resolved.schema.apply.as_ref() {
         Some(apply) => apply
             .requires
             .clone()
-            .unwrap_or_else(|| all_artifact_ids.clone()),
-        None => all_artifact_ids.clone(),
+            .unwrap_or_else(|| required_artifact_ids.clone()),
+        None => required_artifact_ids,
     };
+    let apply_requires = expand_artifact_requirements(&resolved.schema, &apply_requires);
 
-    let is_complete = done_count == resolved.schema.artifacts.len();
+    let is_complete = required_done_count == required_count;
     Ok(ChangeStatus {
         change_name: change.to_string(),
         schema_name: resolved.schema.name,
@@ -450,6 +463,30 @@ pub fn compute_change_status(
         apply_requires,
         artifacts: artifacts_out,
     })
+}
+
+fn expand_artifact_requirements(schema: &SchemaYaml, roots: &[String]) -> Vec<String> {
+    let mut required = BTreeSet::new();
+    for root in roots {
+        collect_artifact_requirement(schema, root, &mut required);
+    }
+
+    build_order(schema)
+        .into_iter()
+        .filter(|id| required.contains(id))
+        .collect()
+}
+
+fn collect_artifact_requirement(schema: &SchemaYaml, id: &str, required: &mut BTreeSet<String>) {
+    if !required.insert(id.to_string()) {
+        return;
+    }
+    let Some(artifact) = schema.artifacts.iter().find(|artifact| artifact.id == id) else {
+        return;
+    };
+    for dependency in &artifact.requires {
+        collect_artifact_requirement(schema, dependency, required);
+    }
 }
 
 /// Computes a deterministic topological build order of artifact ids for the given schema.
@@ -476,6 +513,7 @@ pub fn compute_change_status(
 ///             description: None,
 ///             template: "a.tpl".to_string(),
 ///             instruction: None,
+///             optional: false,
 ///             requires: vec![],
 ///         },
 ///         ArtifactYaml {
@@ -484,6 +522,7 @@ pub fn compute_change_status(
 ///             description: None,
 ///             template: "b.tpl".to_string(),
 ///             instruction: None,
+///             optional: false,
 ///             requires: vec!["a".to_string()],
 ///         },
 ///         ArtifactYaml {
@@ -492,6 +531,7 @@ pub fn compute_change_status(
 ///             description: None,
 ///             template: "c.tpl".to_string(),
 ///             instruction: None,
+///             optional: false,
 ///             requires: vec!["a".to_string()],
 ///         },
 ///     ],
@@ -505,9 +545,10 @@ pub fn compute_change_status(
 fn build_order(schema: &SchemaYaml) -> Vec<String> {
     // Match TS ArtifactGraph.getBuildOrder (Kahn's algorithm with deterministic sorting
     // of roots + newlyReady only).
-    let mut in_degree: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-    let mut dependents: std::collections::HashMap<String, Vec<String>> =
-        std::collections::HashMap::new();
+    let mut in_degree: std::collections::BTreeMap<String, usize> =
+        std::collections::BTreeMap::new();
+    let mut dependents: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
 
     for a in &schema.artifacts {
         in_degree.insert(a.id.clone(), a.requires.len());
@@ -705,6 +746,9 @@ pub fn resolve_instructions(
 }
 
 /// Compute apply-stage instructions and progress for a change.
+///
+/// Optional schema artifacts do not block apply by default; they only block when explicitly listed
+/// in `apply.requires`.
 pub fn compute_apply_instructions(
     ito_path: &Path,
     change: &str,
@@ -725,19 +769,24 @@ pub fn compute_apply_instructions(
 
     let schema = &resolved.schema;
     let apply = schema.apply.as_ref();
-    let all_artifact_ids: Vec<String> = schema.artifacts.iter().map(|a| a.id.clone()).collect();
+    let required_artifact_ids: Vec<String> = schema
+        .artifacts
+        .iter()
+        .filter(|artifact| !artifact.optional)
+        .map(|a| a.id.clone())
+        .collect();
 
     // Determine required artifacts and tracking file from schema.
-    // Match TS: apply.requires ?? allArtifacts (nullish coalescing).
-    let required_artifact_ids: Vec<String> = apply
+    // Explicit apply.requires wins; otherwise only non-optional artifacts block apply.
+    let apply_required_artifact_ids: Vec<String> = apply
         .and_then(|a| a.requires.clone())
-        .unwrap_or_else(|| all_artifact_ids.clone());
+        .unwrap_or(required_artifact_ids);
     let tracks_file: Option<String> = apply.and_then(|a| a.tracks.clone());
     let schema_instruction: Option<String> = apply.and_then(|a| a.instruction.clone());
 
     // Check which required artifacts are missing.
     let mut missing_artifacts: Vec<String> = Vec::new();
-    for artifact_id in &required_artifact_ids {
+    for artifact_id in &apply_required_artifact_ids {
         let Some(artifact) = schema.artifacts.iter().find(|a| a.id == *artifact_id) else {
             continue;
         };

--- a/ito-rs/crates/ito-core/src/templates/review.rs
+++ b/ito-rs/crates/ito-core/src/templates/review.rs
@@ -77,6 +77,7 @@ pub fn compute_review_context(
                 .to_string_lossy()
                 .to_string(),
             present: artifact_done(&change_dir, &artifact.generates),
+            optional: artifact.optional,
         });
     }
 

--- a/ito-rs/crates/ito-core/src/templates/types.rs
+++ b/ito-rs/crates/ito-core/src/templates/types.rs
@@ -47,7 +47,7 @@ pub struct ArtifactStatus {
     /// Path (relative to the change directory) the artifact should generate.
     pub output_path: String,
 
-    /// Computed state: `done`, `ready`, or `blocked`.
+    /// Computed state: `done`, `ready`, `blocked`, or `optional`.
     pub status: String,
     #[serde(rename = "missingDeps", skip_serializing_if = "Vec::is_empty")]
     /// Artifact ids that are required but not yet complete.
@@ -64,7 +64,7 @@ pub struct ChangeStatus {
     /// Resolved schema name.
     pub schema_name: String,
     #[serde(rename = "isComplete")]
-    /// Whether all schema artifacts are complete.
+    /// Whether all required schema artifacts are complete.
     pub is_complete: bool,
     #[serde(rename = "applyRequires")]
     /// Artifacts required before "apply" is allowed.
@@ -227,6 +227,8 @@ pub struct ReviewArtifactInfo {
     pub path: String,
     /// Whether the artifact currently exists in the change directory.
     pub present: bool,
+    /// Whether the artifact is optional in the selected schema.
+    pub optional: bool,
 }
 
 /// Serializable validation issue payload for review templates.
@@ -433,6 +435,9 @@ pub struct ArtifactYaml {
     #[serde(default)]
     /// Optional additional instruction text.
     pub instruction: Option<String>,
+    #[serde(default)]
+    /// Whether this artifact is available as a workflow aid without being required for completion.
+    pub optional: bool,
     #[serde(default)]
     /// Artifact ids that must be completed first.
     pub requires: Vec<String>,

--- a/ito-rs/crates/ito-core/src/validate/delta_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate/delta_rules.rs
@@ -6,6 +6,10 @@ use crate::show::read_change_proposal_markdown;
 use ito_common::fs::StdFs;
 use regex::Regex;
 
+use super::domain_discovery_rules::{
+    validate_context_boundary_consistency_rule, validate_domain_documentation_consistency_rule,
+    validate_ubiquitous_language_consistency_rule,
+};
 use super::rules_engine::rule_issue;
 use super::{
     ArtifactValidatorContext, CoreResult, DomainChangeRepository, LEVEL_ERROR, LEVEL_INFO,
@@ -34,11 +38,31 @@ static INLINE_CODE_TOKEN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"`([^`]+)`").expect("valid inline code regex"));
 
 pub(super) fn artifact_rules() -> &'static [&'static str] {
-    &["contract_refs", "scenario_grammar", "ui_mechanics"]
+    &[
+        "context_boundary_consistency",
+        "contract_refs",
+        "domain_documentation_consistency",
+        "scenario_grammar",
+        "ubiquitous_language_consistency",
+        "ui_mechanics",
+    ]
+}
+
+pub(super) fn domain_discovery_artifact_rules() -> &'static [&'static str] {
+    &[
+        "context_boundary_consistency",
+        "domain_documentation_consistency",
+        "ubiquitous_language_consistency",
+    ]
 }
 
 pub(super) fn proposal_rules() -> &'static [&'static str] {
-    &["capabilities_consistency"]
+    &[
+        "capabilities_consistency",
+        "context_boundary_consistency",
+        "domain_documentation_consistency",
+        "ubiquitous_language_consistency",
+    ]
 }
 
 pub(super) fn run_artifact_rule(
@@ -49,6 +73,13 @@ pub(super) fn run_artifact_rule(
     level: ValidationLevelYaml,
 ) -> CoreResult<()> {
     match rule_name {
+        "context_boundary_consistency" => {
+            rep.extend(validate_context_boundary_consistency_rule(
+                change_repo,
+                ctx.change_id,
+                level,
+            )?);
+        }
         "scenario_grammar" => rep.extend(validate_scenario_grammar_rule(
             change_repo,
             ctx.change_id,
@@ -64,6 +95,21 @@ pub(super) fn run_artifact_rule(
             ctx.change_id,
             level,
         )?),
+        "domain_documentation_consistency" => {
+            rep.extend(validate_domain_documentation_consistency_rule(
+                change_repo,
+                ctx.ito_path,
+                ctx.change_id,
+                level,
+            )?);
+        }
+        "ubiquitous_language_consistency" => {
+            rep.extend(validate_ubiquitous_language_consistency_rule(
+                change_repo,
+                ctx.change_id,
+                level,
+            )?);
+        }
         _ => {}
     }
     Ok(())
@@ -76,13 +122,38 @@ pub(super) fn run_proposal_rule(
     rule_name: &str,
     level: ValidationLevelYaml,
 ) -> CoreResult<()> {
-    if rule_name == "capabilities_consistency" {
-        rep.extend(validate_capabilities_consistency_rule(
-            change_repo,
-            ctx.ito_path,
-            ctx.change_id,
-            level,
-        )?);
+    match rule_name {
+        "capabilities_consistency" => {
+            rep.extend(validate_capabilities_consistency_rule(
+                change_repo,
+                ctx.ito_path,
+                ctx.change_id,
+                level,
+            )?);
+        }
+        "context_boundary_consistency" => {
+            rep.extend(validate_context_boundary_consistency_rule(
+                change_repo,
+                ctx.change_id,
+                level,
+            )?);
+        }
+        "domain_documentation_consistency" => {
+            rep.extend(validate_domain_documentation_consistency_rule(
+                change_repo,
+                ctx.ito_path,
+                ctx.change_id,
+                level,
+            )?);
+        }
+        "ubiquitous_language_consistency" => {
+            rep.extend(validate_ubiquitous_language_consistency_rule(
+                change_repo,
+                ctx.change_id,
+                level,
+            )?);
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/ito-rs/crates/ito-core/src/validate/domain_discovery_rules.rs
+++ b/ito-rs/crates/ito-core/src/validate/domain_discovery_rules.rs
@@ -1,0 +1,1152 @@
+//! Domain discovery validation rules for optional DDD handoff artifacts.
+//!
+//! These rules connect lightweight discovery outputs to proposal/spec/task text so
+//! terminology, context boundaries, and lazily updated domain docs do not drift.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error_bridge::IntoCoreResult;
+
+use super::rules_engine::rule_issue;
+use super::{
+    CoreResult, DomainChangeRepository, ValidationIssue, ValidationLevelYaml, ValidatorId,
+};
+
+pub(super) fn validate_ubiquitous_language_consistency_rule(
+    change_repo: &(impl DomainChangeRepository + ?Sized),
+    change_id: &str,
+    level: ValidationLevelYaml,
+) -> CoreResult<Vec<ValidationIssue>> {
+    let change = change_repo.get(change_id).into_core()?;
+    let Some(discovery) = read_domain_discovery_markdown(&change.path) else {
+        return Ok(Vec::new());
+    };
+    let handoff = parse_domain_discovery_handoff(&discovery);
+    if handoff.rejected_aliases.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let corpus = normalize_for_domain_match(&build_language_validation_corpus(&change));
+    let mut issues = Vec::new();
+    for alias in handoff.rejected_aliases {
+        if !normalized_text_contains_term(&corpus, &alias.alias) {
+            continue;
+        }
+        issues.push(rule_issue(
+            ValidatorId::DeltaSpecsV1,
+            "ubiquitous_language_consistency",
+            level.as_level_str(),
+            "domain-discovery.ubiquitous-language",
+            format!(
+                "Rejected alias '{}' appears in proposal, specs, or tasks; use canonical term '{}' instead",
+                alias.alias, alias.canonical_term
+            ),
+        ));
+    }
+
+    Ok(issues)
+}
+
+pub(super) fn validate_domain_documentation_consistency_rule(
+    change_repo: &(impl DomainChangeRepository + ?Sized),
+    ito_path: &Path,
+    change_id: &str,
+    level: ValidationLevelYaml,
+) -> CoreResult<Vec<ValidationIssue>> {
+    let change = change_repo.get(change_id).into_core()?;
+    let Some(discovery) = read_domain_discovery_markdown(&change.path) else {
+        return Ok(Vec::new());
+    };
+    let handoff = parse_domain_discovery_handoff(&discovery);
+    if handoff.terms.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut issues = Vec::new();
+    let project_root = ito_path.parent().map(Path::to_path_buf);
+    for path in collect_domain_document_paths(&change.path)
+        .into_iter()
+        .chain(collect_existing_domain_document_paths(
+            project_root.as_deref(),
+            &change.path,
+        ))
+    {
+        let Ok(markdown) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let doc_terms = parse_ubiquitous_language_terms(&markdown);
+        for term in &handoff.terms {
+            let Some(doc_term) = doc_terms
+                .iter()
+                .find(|candidate| same_domain_term(&candidate.term, &term.term))
+            else {
+                continue;
+            };
+            if same_definition(&doc_term.definition, &term.definition) {
+                continue;
+            }
+            if terms_belong_to_different_contexts(term, doc_term) {
+                continue;
+            }
+
+            let report_path =
+                report_path_for_domain_document(&change.path, project_root.as_deref(), &path);
+            issues.push(rule_issue(
+                ValidatorId::DeltaSpecsV1,
+                "domain_documentation_consistency",
+                level.as_level_str(),
+                report_path,
+                format!(
+                    "Proposed domain documentation defines '{}' differently from domain-discovery.md",
+                    term.term
+                ),
+            ));
+        }
+    }
+
+    Ok(issues)
+}
+
+pub(super) fn validate_context_boundary_consistency_rule(
+    change_repo: &(impl DomainChangeRepository + ?Sized),
+    change_id: &str,
+    level: ValidationLevelYaml,
+) -> CoreResult<Vec<ValidationIssue>> {
+    let change = change_repo.get(change_id).into_core()?;
+    let Some(discovery) = read_domain_discovery_markdown(&change.path) else {
+        if corpus_suggests_cross_context(&build_language_validation_corpus(&change)) {
+            return Ok(vec![rule_issue(
+                ValidatorId::DeltaSpecsV1,
+                "context_boundary_consistency",
+                level.as_level_str(),
+                "domain-discovery.bounded-context-map",
+                "Cross-context proposal is missing domain discovery boundary framing",
+            )]);
+        }
+        return Ok(Vec::new());
+    };
+    let handoff = parse_domain_discovery_handoff(&discovery);
+    let corpus_requires_boundary_review =
+        corpus_suggests_cross_context(&build_language_validation_corpus(&change));
+    if !handoff.needs_context_boundary_review() && !corpus_requires_boundary_review {
+        return Ok(Vec::new());
+    }
+
+    let mut missing = Vec::new();
+    if corpus_requires_boundary_review && handoff.affected_context_count() < 2 {
+        missing.push("affected contexts");
+    }
+    if !handoff.has_context_ownership() {
+        missing.push("context ownership");
+    }
+    if !handoff.has_relationship_framing() {
+        missing.push("relationship pattern or provisional unknown");
+    }
+    if !handoff.has_translation_boundary() {
+        missing.push("translation boundary");
+    }
+    if missing.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    Ok(vec![rule_issue(
+        ValidatorId::DeltaSpecsV1,
+        "context_boundary_consistency",
+        level.as_level_str(),
+        "domain-discovery.bounded-context-map",
+        format!(
+            "Cross-context domain discovery is missing {}",
+            missing.join(", ")
+        ),
+    )])
+}
+
+#[derive(Debug, Default)]
+struct DomainDiscoveryHandoff {
+    terms: Vec<DomainTerm>,
+    rejected_aliases: Vec<RejectedAlias>,
+    primary_context: Option<String>,
+    supporting_contexts: Vec<String>,
+    bounded_contexts: Vec<BoundedContext>,
+    translation_required: Option<String>,
+}
+
+#[derive(Debug)]
+struct DomainTerm {
+    term: String,
+    definition: String,
+    owner_context: String,
+}
+
+#[derive(Debug)]
+struct RejectedAlias {
+    alias: String,
+    canonical_term: String,
+}
+
+#[derive(Debug)]
+struct BoundedContext {
+    context: String,
+    responsibilities: String,
+    owner: String,
+    owned_language: String,
+    relationship_pattern: String,
+}
+
+impl DomainDiscoveryHandoff {
+    fn needs_context_boundary_review(&self) -> bool {
+        self.affected_context_count() > 1
+    }
+
+    fn affected_context_count(&self) -> usize {
+        self.affected_contexts().len()
+    }
+
+    fn has_context_ownership(&self) -> bool {
+        let affected_contexts = self.affected_contexts();
+        let owned_contexts = self
+            .bounded_contexts
+            .iter()
+            .filter(|context| {
+                is_meaningful_domain_value(&context.context)
+                    && is_meaningful_domain_value(&context.responsibilities)
+                    && is_meaningful_domain_value(&context.owner)
+                    && is_meaningful_domain_value(&context.owned_language)
+            })
+            .map(|context| normalize_for_domain_match(&context.context))
+            .collect::<BTreeSet<_>>();
+        !affected_contexts.is_empty() && affected_contexts.is_subset(&owned_contexts)
+    }
+
+    fn affected_contexts(&self) -> BTreeSet<String> {
+        let mut contexts = BTreeSet::new();
+        if let Some(context) = self.primary_context.as_deref() {
+            insert_meaningful_context(&mut contexts, context);
+        }
+        for context in &self.supporting_contexts {
+            insert_meaningful_context(&mut contexts, context);
+        }
+        for context in &self.bounded_contexts {
+            insert_meaningful_context(&mut contexts, &context.context);
+        }
+        contexts
+    }
+
+    fn has_relationship_framing(&self) -> bool {
+        let affected_contexts = self.affected_contexts();
+        let framed_contexts = self
+            .bounded_contexts
+            .iter()
+            .filter(|context| is_meaningful_domain_value(&context.relationship_pattern))
+            .map(|context| normalize_for_domain_match(&context.context))
+            .collect::<BTreeSet<_>>();
+        !affected_contexts.is_empty() && affected_contexts.is_subset(&framed_contexts)
+    }
+
+    fn has_translation_boundary(&self) -> bool {
+        self.translation_required
+            .as_deref()
+            .is_some_and(is_resolved_translation_boundary_value)
+    }
+
+    fn has_meaningful_content(&self) -> bool {
+        !self.terms.is_empty()
+            || !self.rejected_aliases.is_empty()
+            || self
+                .primary_context
+                .as_deref()
+                .is_some_and(is_meaningful_context)
+            || !self.supporting_contexts.is_empty()
+            || !self.bounded_contexts.is_empty()
+            || self
+                .translation_required
+                .as_deref()
+                .is_some_and(is_meaningful_domain_value)
+    }
+
+    fn has_only_context_summary(&self) -> bool {
+        self.terms.is_empty()
+            && self.rejected_aliases.is_empty()
+            && self.bounded_contexts.is_empty()
+            && self.translation_required.is_none()
+            && (self
+                .primary_context
+                .as_deref()
+                .is_some_and(is_meaningful_context)
+                || !self.supporting_contexts.is_empty())
+    }
+}
+
+fn read_domain_discovery_markdown(change_path: &Path) -> Option<String> {
+    let mut standalone_discovery = None;
+    let mut embedded_discovery = String::new();
+    let mut discovery = String::new();
+    let standalone = change_path.join("domain-discovery.md");
+    if let Ok(markdown) = fs::read_to_string(&standalone) {
+        let handoff = parse_domain_discovery_handoff(&markdown);
+        if handoff.has_meaningful_content() {
+            standalone_discovery = Some((markdown, handoff.has_only_context_summary()));
+        }
+    }
+
+    for path in embedded_domain_discovery_candidate_paths(change_path) {
+        let Ok(markdown) = fs::read_to_string(path) else {
+            continue;
+        };
+        let summary = markdown_section(&markdown, "Domain Discovery Summary");
+        if summary.trim().is_empty() {
+            continue;
+        }
+        let handoff = parse_domain_discovery_handoff(&markdown);
+        if handoff.has_meaningful_content() {
+            embedded_discovery.push_str(&markdown);
+            embedded_discovery.push('\n');
+        }
+    }
+
+    // Do not let a context-only standalone stub hide richer embedded handoff data.
+    if let Some((markdown, has_only_context_summary)) = standalone_discovery
+        && (embedded_discovery.is_empty() || !has_only_context_summary)
+    {
+        discovery.push_str(&markdown);
+        discovery.push('\n');
+    }
+    discovery.push_str(&embedded_discovery);
+
+    if !discovery.is_empty() {
+        return Some(discovery);
+    }
+
+    None
+}
+
+fn parse_domain_discovery_handoff(markdown: &str) -> DomainDiscoveryHandoff {
+    let summary = markdown_section(markdown, "Domain Discovery Summary");
+    let summaries = markdown_sections(markdown, "Domain Discovery Summary");
+    let ownership = markdown_section(markdown, "Model Ownership");
+    let mut terms = parse_ubiquitous_language_terms(markdown);
+    for summary in &summaries {
+        terms.extend(parse_compact_domain_terms(summary));
+    }
+    dedup_domain_terms(&mut terms);
+    let mut rejected_aliases = parse_rejected_aliases(markdown);
+    for summary in &summaries {
+        rejected_aliases.extend(parse_compact_rejected_aliases(summary));
+    }
+    dedup_rejected_aliases(&mut rejected_aliases);
+    let mut bounded_contexts = parse_bounded_contexts(markdown);
+    for summary in &summaries {
+        bounded_contexts.extend(parse_compact_bounded_contexts(summary));
+    }
+    dedup_bounded_contexts(&mut bounded_contexts);
+    DomainDiscoveryHandoff {
+        terms,
+        rejected_aliases,
+        primary_context: parse_summary_field(&summary, "Primary bounded context"),
+        supporting_contexts: parse_context_list_field(&summary, "Supporting contexts"),
+        bounded_contexts,
+        translation_required: parse_summary_field(&ownership, "Translation boundaries")
+            .or_else(|| parse_summary_field(&ownership, "Translation required"))
+            .or_else(|| parse_translation_boundary_field(&ownership, "Translation boundaries"))
+            .or_else(|| parse_translation_boundary_field(&ownership, "Translation required"))
+            .or_else(|| parse_translation_boundary_field(&summary, "Translation boundaries")),
+    }
+}
+
+fn embedded_domain_discovery_candidate_paths(change_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for relative in ["proposal.md", "design.md", "tasks.md"] {
+        paths.push(change_path.join(relative));
+    }
+    let mut spec_paths = Vec::new();
+    collect_markdown_paths(&change_path.join("specs"), &mut spec_paths, 0);
+    spec_paths.sort();
+    paths.extend(spec_paths);
+    paths
+}
+
+fn collect_markdown_paths(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth > EMBEDDED_HANDOFF_MAX_DEPTH_INCLUSIVE {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            collect_markdown_paths(&path, out, depth + 1);
+            continue;
+        }
+        if !metadata.is_file() || path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+        out.push(path);
+    }
+}
+
+fn parse_summary_field(markdown: &str, label: &str) -> Option<String> {
+    parse_summary_field_matching(markdown, label, is_meaningful_domain_value)
+}
+
+fn parse_translation_boundary_field(markdown: &str, label: &str) -> Option<String> {
+    parse_summary_field_matching(markdown, label, is_resolved_translation_boundary_value)
+}
+
+fn parse_summary_field_matching(
+    markdown: &str,
+    label: &str,
+    is_resolved: impl Fn(&str) -> bool,
+) -> Option<String> {
+    for line in markdown.lines() {
+        let line = line.trim();
+        let Some(value) = parse_labeled_bullet(line, label) else {
+            continue;
+        };
+        let value = clean_table_cell(value);
+        if is_resolved(&value) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn parse_labeled_bullet<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    let line = line
+        .strip_prefix("- ")
+        .or_else(|| line.strip_prefix("* "))?;
+    if let Some(line) = line.strip_prefix("**") {
+        let (found, value) = line.split_once("**:")?;
+        if found.trim().eq_ignore_ascii_case(label) {
+            return Some(value);
+        }
+        return None;
+    }
+
+    let (found, value) = line.split_once(':')?;
+    if found.trim().eq_ignore_ascii_case(label) {
+        return Some(value);
+    }
+    None
+}
+
+fn parse_context_list_field(markdown: &str, label: &str) -> Vec<String> {
+    let Some(value) = parse_summary_field(markdown, label) else {
+        return Vec::new();
+    };
+    value
+        .split([',', ';'])
+        .map(clean_table_cell)
+        .filter(|value| is_meaningful_context(value))
+        .collect()
+}
+
+fn parse_bounded_contexts(markdown: &str) -> Vec<BoundedContext> {
+    let section = markdown_section(markdown, "Bounded Context Map");
+    let mut contexts = Vec::new();
+    let mut columns = BoundedContextColumns::default();
+    for row in markdown_table_rows(&section) {
+        if row.len() < 4 {
+            continue;
+        }
+        let context = clean_table_cell(&row[0]);
+        if context.eq_ignore_ascii_case("context") {
+            columns = BoundedContextColumns::from_header(&row);
+            continue;
+        }
+        if context.is_empty() {
+            continue;
+        }
+        contexts.push(BoundedContext {
+            context,
+            responsibilities: columns.cell(&row, columns.responsibilities),
+            owner: columns.cell(&row, columns.owner),
+            owned_language: columns.cell(&row, columns.owned_language),
+            relationship_pattern: columns.cell(&row, columns.relationship_pattern),
+        });
+    }
+    contexts
+}
+
+struct BoundedContextColumns {
+    responsibilities: usize,
+    owner: usize,
+    owned_language: usize,
+    relationship_pattern: usize,
+}
+
+impl Default for BoundedContextColumns {
+    fn default() -> Self {
+        Self {
+            responsibilities: 1,
+            owner: 2,
+            owned_language: 3,
+            relationship_pattern: 4,
+        }
+    }
+}
+
+impl BoundedContextColumns {
+    fn from_header(header: &[String]) -> Self {
+        let default = Self::default();
+        Self {
+            responsibilities: find_header_index(header, &["responsibilities"])
+                .unwrap_or(default.responsibilities),
+            owner: find_header_index(header, &["owner", "owning context"]).unwrap_or(default.owner),
+            owned_language: find_header_index(header, &["owned language", "owned concepts"])
+                .unwrap_or(default.owned_language),
+            relationship_pattern: find_header_index(
+                header,
+                &["relationship pattern", "relationship"],
+            )
+            .unwrap_or(default.relationship_pattern),
+        }
+    }
+
+    fn cell(&self, row: &[String], index: usize) -> String {
+        row.get(index).map(clean_table_cell).unwrap_or_default()
+    }
+}
+
+fn find_header_index(header: &[String], candidates: &[&str]) -> Option<usize> {
+    header.iter().position(|cell| {
+        let cell = normalize_for_domain_match(cell);
+        candidates
+            .iter()
+            .any(|candidate| cell.contains(&normalize_for_domain_match(candidate)))
+    })
+}
+
+fn parse_ubiquitous_language_terms(markdown: &str) -> Vec<DomainTerm> {
+    let section = markdown_section(markdown, "Ubiquitous Language");
+    let mut terms = Vec::new();
+    for row in markdown_table_rows(&section) {
+        if row.len() < 2 {
+            continue;
+        }
+        let term = clean_table_cell(&row[0]);
+        let definition = clean_table_cell(&row[1]);
+        if term.is_empty() || definition.is_empty() || term.eq_ignore_ascii_case("term") {
+            continue;
+        }
+        let owner_context = row.get(2).map(clean_table_cell).unwrap_or_default();
+        terms.push(DomainTerm {
+            term,
+            definition,
+            owner_context,
+        });
+    }
+    terms
+}
+
+fn parse_compact_domain_terms(markdown: &str) -> Vec<DomainTerm> {
+    let Some(value) = parse_summary_field(markdown, "Canonical terms") else {
+        return Vec::new();
+    };
+    let owner_context =
+        parse_summary_field(markdown, "Primary bounded context").unwrap_or_default();
+    parse_arrow_pairs(&value)
+        .into_iter()
+        .map(|(term, definition)| DomainTerm {
+            term,
+            definition,
+            owner_context: owner_context.clone(),
+        })
+        .collect()
+}
+
+fn dedup_domain_terms(terms: &mut Vec<DomainTerm>) {
+    let mut seen = BTreeSet::new();
+    terms.retain(|term| {
+        seen.insert((
+            normalize_for_domain_match(&term.term),
+            normalize_for_domain_match(&term.definition),
+            normalize_for_domain_match(&term.owner_context),
+        ))
+    });
+}
+
+fn parse_rejected_aliases(markdown: &str) -> Vec<RejectedAlias> {
+    let section = markdown_section(markdown, "Rejected Aliases / Overloaded Terms");
+    let mut aliases = Vec::new();
+    for row in markdown_table_rows(&section) {
+        if row.len() < 2 {
+            continue;
+        }
+        let alias = clean_table_cell(&row[0]);
+        let canonical_term = clean_table_cell(&row[1]);
+        if alias.is_empty() || canonical_term.is_empty() || is_rejected_alias_header(&alias) {
+            continue;
+        }
+        aliases.push(RejectedAlias {
+            alias,
+            canonical_term,
+        });
+    }
+    aliases
+}
+
+fn is_rejected_alias_header(alias: &str) -> bool {
+    matches!(
+        normalize_for_domain_match(alias).as_str(),
+        "term or alias" | "alias / term" | "alias" | "term" | "term or aliases"
+    )
+}
+
+fn parse_compact_rejected_aliases(markdown: &str) -> Vec<RejectedAlias> {
+    let Some(value) = parse_summary_field(markdown, "Rejected aliases / overloaded terms") else {
+        return Vec::new();
+    };
+    parse_arrow_pairs(&value)
+        .into_iter()
+        .map(|(alias, canonical_term)| RejectedAlias {
+            alias,
+            canonical_term,
+        })
+        .collect()
+}
+
+fn dedup_rejected_aliases(aliases: &mut Vec<RejectedAlias>) {
+    let mut seen = BTreeSet::new();
+    aliases.retain(|alias| {
+        seen.insert((
+            normalize_for_domain_match(&alias.alias),
+            normalize_for_domain_match(&alias.canonical_term),
+        ))
+    });
+}
+
+fn parse_compact_bounded_contexts(markdown: &str) -> Vec<BoundedContext> {
+    let Some(value) = parse_summary_field(markdown, "Bounded contexts") else {
+        return Vec::new();
+    };
+    let relationship_pattern =
+        parse_summary_field(markdown, "Cross-context relationships").unwrap_or_default();
+    // Compact entries use: `Context -> responsibilities, owner, owned language`.
+    parse_arrow_pairs(&value)
+        .into_iter()
+        .map(|(context, description)| {
+            let parts = description
+                .split(',')
+                .map(clean_table_cell)
+                .collect::<Vec<_>>();
+            let responsibilities = parts.first().cloned().unwrap_or_default();
+            let owner = parts.get(1).cloned().unwrap_or_default();
+            let owned_language = parts.get(2).cloned().unwrap_or_default();
+            BoundedContext {
+                context,
+                responsibilities,
+                owner,
+                owned_language,
+                relationship_pattern: relationship_pattern.clone(),
+            }
+        })
+        .collect()
+}
+
+fn dedup_bounded_contexts(contexts: &mut Vec<BoundedContext>) {
+    let mut seen = BTreeSet::new();
+    contexts.retain(|context| {
+        seen.insert((
+            normalize_for_domain_match(&context.context),
+            normalize_for_domain_match(&context.responsibilities),
+            normalize_for_domain_match(&context.owner),
+            normalize_for_domain_match(&context.owned_language),
+            normalize_for_domain_match(&context.relationship_pattern),
+        ))
+    });
+}
+
+fn parse_arrow_pairs(value: &str) -> Vec<(String, String)> {
+    value
+        .split(';')
+        .filter_map(|entry| {
+            let (left, right) = entry.split_once("->")?;
+            let left = clean_table_cell(left);
+            let right = clean_table_cell(right);
+            if left.is_empty() || right.is_empty() {
+                return None;
+            }
+            Some((left, right))
+        })
+        .collect()
+}
+
+fn markdown_section(markdown: &str, heading: &str) -> String {
+    markdown_sections(markdown, heading).join("")
+}
+
+fn markdown_sections(markdown: &str, heading: &str) -> Vec<String> {
+    let mut sections = Vec::new();
+    let mut section = String::new();
+    let mut in_section = false;
+    for line in markdown.lines() {
+        let line = line.trim_end();
+        if let Some(title) = line.trim().strip_prefix("## ") {
+            if in_section && !section.is_empty() {
+                sections.push(std::mem::take(&mut section));
+            }
+            in_section = title.trim().eq_ignore_ascii_case(heading);
+            continue;
+        }
+        if in_section {
+            section.push_str(line);
+            section.push('\n');
+        }
+    }
+    if in_section && !section.is_empty() {
+        sections.push(section);
+    }
+    sections
+}
+
+fn markdown_table_rows(markdown: &str) -> Vec<Vec<String>> {
+    let mut rows = Vec::new();
+    for line in markdown.lines() {
+        let line = line.trim();
+        if !line.starts_with('|') || !line.ends_with('|') {
+            continue;
+        }
+        if line
+            .chars()
+            .all(|c| c == '|' || c == '-' || c == ':' || c.is_whitespace())
+        {
+            continue;
+        }
+        let row = line
+            .trim_matches('|')
+            .split('|')
+            .map(clean_table_cell)
+            .collect();
+        rows.push(row);
+    }
+    rows
+}
+
+fn clean_table_cell(cell: impl AsRef<str>) -> String {
+    let cell = cell.as_ref().trim();
+    if cell.starts_with("<!--") && cell.ends_with("-->") {
+        return String::new();
+    }
+    cell.trim_matches('`').trim().to_string()
+}
+
+fn insert_meaningful_context(contexts: &mut BTreeSet<String>, context: &str) {
+    if !is_meaningful_context(context) {
+        return;
+    }
+    contexts.insert(normalize_for_domain_match(context));
+}
+
+fn is_meaningful_context(value: &str) -> bool {
+    is_meaningful_domain_value(value)
+}
+
+fn is_meaningful_domain_value(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && !value.starts_with("<!--")
+        && !value.eq_ignore_ascii_case("none")
+        && !value.eq_ignore_ascii_case("n/a")
+        && !value.eq_ignore_ascii_case("not applicable")
+}
+
+fn is_resolved_translation_boundary_value(value: &str) -> bool {
+    let value = value.trim();
+    // "None" is a resolved translation-boundary decision, not a placeholder.
+    !value.is_empty()
+        && !value.starts_with("<!--")
+        && !value.eq_ignore_ascii_case("n/a")
+        && !value.eq_ignore_ascii_case("not applicable")
+}
+
+fn build_language_validation_corpus(change: &ito_domain::changes::Change) -> String {
+    let mut corpus = String::new();
+    if let Some(proposal) = change.proposal.as_deref() {
+        corpus.push_str(&strip_domain_discovery_sections(proposal));
+        corpus.push('\n');
+    }
+    if let Some(design) = change.design.as_deref() {
+        corpus.push_str(&strip_domain_discovery_sections(design));
+        corpus.push('\n');
+    }
+    for spec in &change.specs {
+        corpus.push_str(&strip_domain_discovery_sections(&spec.content));
+        corpus.push('\n');
+    }
+    if let Ok(tasks) = fs::read_to_string(change.path.join("tasks.md")) {
+        corpus.push_str(&strip_domain_discovery_sections(&tasks));
+    }
+    corpus
+}
+
+fn strip_domain_discovery_sections(markdown: &str) -> String {
+    const DISCOVERY_SECTIONS: &[&str] = &[
+        "Domain Discovery Summary",
+        "Ubiquitous Language",
+        "Rejected Aliases / Overloaded Terms",
+        "Bounded Context Map",
+        "Model Ownership",
+        "Consistency Requirements",
+        "Technique Fit",
+        "Event Storming Snapshot",
+        "Evidence Checked",
+        "Proposed Documentation Updates",
+    ];
+
+    let mut stripped = String::new();
+    let mut skipping = false;
+    for line in markdown.lines() {
+        if let Some(title) = line.trim().strip_prefix("## ") {
+            skipping = DISCOVERY_SECTIONS
+                .iter()
+                .any(|section| title.trim().eq_ignore_ascii_case(section));
+        }
+        if skipping {
+            continue;
+        }
+        stripped.push_str(line);
+        stripped.push('\n');
+    }
+    stripped
+}
+
+fn normalized_text_contains_term(text: &str, term: &str) -> bool {
+    let term = normalize_for_domain_match(term);
+    if term.is_empty() {
+        return false;
+    }
+
+    for (idx, _) in text.match_indices(&term) {
+        let before = text
+            .get(..idx)
+            .and_then(|prefix| prefix.chars().next_back());
+        let after = text
+            .get(idx + term.len()..)
+            .and_then(|suffix| suffix.chars().next());
+        if is_term_boundary(before) && is_term_boundary(after) {
+            return true;
+        }
+    }
+    false
+}
+
+fn corpus_suggests_cross_context(corpus: &str) -> bool {
+    let normalized = normalize_for_domain_match(corpus);
+    let strong_signal = [
+        "cross-context",
+        "cross context",
+        "multiple bounded contexts",
+        "more than one bounded context",
+        "spans multiple bounded contexts",
+        "spans multiple contexts",
+        "between bounded contexts",
+        "across bounded contexts",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle));
+    if strong_signal {
+        return true;
+    }
+
+    [
+        "coordinates with",
+        "coordinate with",
+        "integrates with",
+        "integrate with",
+        "collaborates with",
+        "collaborate with",
+        "communicates with",
+        "communicate with",
+        "depends on",
+        "shared between",
+        "shared across",
+    ]
+    .iter()
+    .any(|needle| named_context_sentence_contains(corpus, needle))
+}
+
+fn named_context_sentence_contains(corpus: &str, needle: &str) -> bool {
+    corpus.split(['.', '\n']).any(|sentence| {
+        let normalized_sentence = normalize_for_domain_match(sentence);
+        normalized_sentence.contains(needle)
+            && !mentions_external_integration(&normalized_sentence)
+            && (named_context_count(sentence) >= 2
+                || relationship_phrase_has_domain_terms(&normalized_sentence, needle))
+    })
+}
+
+fn mentions_external_integration(sentence: &str) -> bool {
+    sentence.contains("external")
+        || sentence.contains("third-party")
+        || sentence.contains("third party")
+        || sentence.contains("vendor")
+        || sentence.contains("stripe")
+}
+
+fn relationship_phrase_has_domain_terms(sentence: &str, needle: &str) -> bool {
+    let Some((left, right)) = sentence.split_once(needle) else {
+        return false;
+    };
+    last_domainish_word(left).is_some() && first_domainish_word(right).is_some()
+}
+
+fn last_domainish_word(value: &str) -> Option<&str> {
+    value
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .rev()
+        .find(|word| !is_ignored_relationship_word(word))
+        .filter(|word| is_domainish_word(word))
+}
+
+fn first_domainish_word(value: &str) -> Option<&str> {
+    value
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .find(|word| !is_ignored_relationship_word(word))
+        .filter(|word| is_domainish_word(word))
+}
+
+fn is_domainish_word(word: &str) -> bool {
+    word_looks_like_domain_context(word) && !is_ignored_relationship_word(word)
+}
+
+fn is_ignored_relationship_word(word: &str) -> bool {
+    let word = normalize_for_domain_match(word);
+    if word.is_empty() {
+        return true;
+    }
+    matches!(
+        word.as_str(),
+        "and"
+            | "are"
+            | "but"
+            | "for"
+            | "from"
+            | "need"
+            | "needs"
+            | "not"
+            | "the"
+            | "this"
+            | "through"
+            | "with"
+    )
+}
+
+fn word_looks_like_domain_context(word: &str) -> bool {
+    let word = normalize_for_domain_match(word);
+    word.len() > 2
+        && (word.ends_with('s')
+            || word.ends_with("ing")
+            || word.ends_with("ment")
+            || word.ends_with("tion")
+            || word.ends_with("ship")
+            || matches!(
+                word.as_str(),
+                "auth"
+                    | "catalog"
+                    | "checkout"
+                    | "fulfillment"
+                    | "inventory"
+                    | "invoice"
+                    | "payment"
+                    | "support"
+                    | "user"
+                    | "workspace"
+            ))
+}
+
+fn named_context_count(sentence: &str) -> usize {
+    sentence
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .filter(|word| {
+            let Some(first) = word.chars().next() else {
+                return false;
+            };
+            first.is_ascii_uppercase()
+                && word_looks_like_domain_context(word)
+                && !matches!(
+                    *word,
+                    "A" | "An" | "And" | "But" | "For" | "If" | "In" | "The" | "This"
+                )
+        })
+        .count()
+}
+
+fn is_term_boundary(ch: Option<char>) -> bool {
+    let Some(ch) = ch else {
+        return true;
+    };
+    !ch.is_alphanumeric() && ch != '_'
+}
+
+fn same_domain_term(a: &str, b: &str) -> bool {
+    normalize_for_domain_match(a) == normalize_for_domain_match(b)
+}
+
+fn same_definition(a: &str, b: &str) -> bool {
+    normalize_for_domain_match(a) == normalize_for_domain_match(b)
+}
+
+fn terms_belong_to_different_contexts(a: &DomainTerm, b: &DomainTerm) -> bool {
+    is_meaningful_domain_value(&a.owner_context)
+        && is_meaningful_domain_value(&b.owner_context)
+        && !same_domain_term(&a.owner_context, &b.owner_context)
+}
+
+fn normalize_for_domain_match(value: &str) -> String {
+    let mut normalized = String::with_capacity(value.len());
+    for word in value.split_whitespace() {
+        if !normalized.is_empty() {
+            normalized.push(' ');
+        }
+        normalized.push_str(word);
+    }
+    normalized.make_ascii_lowercase();
+    normalized
+}
+
+fn collect_domain_document_paths(change_path: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect_domain_document_paths_inner(change_path, &mut out, 0);
+    out.sort();
+    out
+}
+
+fn collect_existing_domain_document_paths(
+    project_root: Option<&Path>,
+    change_path: &Path,
+) -> Vec<PathBuf> {
+    let Some(project_root) = project_root else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    collect_existing_domain_document_paths_inner(project_root, change_path, &mut out, 0, false);
+    for root_name in ["docs", "adr", "adrs", "decisions"] {
+        collect_existing_domain_document_paths_inner(
+            &project_root.join(root_name),
+            change_path,
+            &mut out,
+            0,
+            true,
+        );
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+const EMBEDDED_HANDOFF_MAX_DEPTH_INCLUSIVE: usize = 4;
+const DOMAIN_DOCUMENT_MAX_DEPTH_INCLUSIVE: usize = 4;
+
+fn collect_domain_document_paths_inner(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth > DOMAIN_DOCUMENT_MAX_DEPTH_INCLUSIVE {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            collect_domain_document_paths_inner(&path, out, depth + 1);
+            continue;
+        }
+        if !metadata.is_file() || !is_domain_document_path(&path) {
+            continue;
+        }
+        out.push(path);
+    }
+}
+
+fn collect_existing_domain_document_paths_inner(
+    dir: &Path,
+    change_path: &Path,
+    out: &mut Vec<PathBuf>,
+    depth: usize,
+    recursive: bool,
+) {
+    if depth > DOMAIN_DOCUMENT_MAX_DEPTH_INCLUSIVE || dir.starts_with(change_path) {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() {
+            continue;
+        }
+        if metadata.is_dir() {
+            if !recursive {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            if matches!(
+                name,
+                ".git" | ".brv" | ".ito" | "target" | "node_modules" | "vendor" | "dist"
+            ) {
+                continue;
+            }
+            collect_existing_domain_document_paths_inner(&path, change_path, out, depth + 1, true);
+            continue;
+        }
+        if !metadata.is_file() || !is_domain_document_path(&path) {
+            continue;
+        }
+        out.push(path);
+    }
+}
+
+fn is_domain_document_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let name = name.to_ascii_lowercase();
+    if name == "context.md" || name == "context-map.md" {
+        return true;
+    }
+
+    let Some(rest) = name.strip_prefix("adr") else {
+        return false;
+    };
+    if rest == ".md" || rest.starts_with('-') || rest.starts_with('_') {
+        return name.ends_with(".md");
+    }
+    rest.chars().next().is_some_and(|ch| ch.is_ascii_digit()) && name.ends_with(".md")
+}
+
+fn report_path_for_domain_document(
+    change_path: &Path,
+    project_root: Option<&Path>,
+    path: &Path,
+) -> String {
+    if let Ok(path) = path.strip_prefix(change_path) {
+        return path.display().to_string();
+    }
+    if let Some(project_root) = project_root
+        && let Ok(path) = path.strip_prefix(project_root)
+    {
+        return path.display().to_string();
+    }
+    path.display().to_string()
+}

--- a/ito-rs/crates/ito-core/src/validate/mod.rs
+++ b/ito-rs/crates/ito-core/src/validate/mod.rs
@@ -24,6 +24,7 @@ use ito_domain::changes::ChangeRepository as DomainChangeRepository;
 use ito_domain::modules::ModuleRepository as DomainModuleRepository;
 
 mod delta_rules;
+mod domain_discovery_rules;
 mod format_specs;
 mod issue;
 mod repo_integrity;
@@ -283,10 +284,12 @@ fn is_legacy_delta_schema(schema_name: &str) -> bool {
     schema_name == "spec-driven" || schema_name == "tdd"
 }
 
-fn schema_artifact_ids(resolved: &ResolvedSchema) -> Vec<String> {
+fn required_schema_artifact_ids(resolved: &ResolvedSchema) -> Vec<String> {
     let mut ids = Vec::new();
     for a in &resolved.schema.artifacts {
-        ids.push(a.id.clone());
+        if !a.optional {
+            ids.push(a.id.clone());
+        }
     }
     ids
 }
@@ -310,8 +313,8 @@ fn validate_apply_required_artifacts(
         Some(apply) => apply
             .requires
             .clone()
-            .unwrap_or_else(|| schema_artifact_ids(resolved)),
-        None => schema_artifact_ids(resolved),
+            .unwrap_or_else(|| required_schema_artifact_ids(resolved)),
+        None => required_schema_artifact_ids(resolved),
     };
 
     for id in required_ids {

--- a/ito-rs/crates/ito-core/src/validate/rules_engine.rs
+++ b/ito-rs/crates/ito-core/src/validate/rules_engine.rs
@@ -137,7 +137,7 @@ fn run_configured_rules(
         }
 
         match (validator_id, target) {
-            (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Artifact { id: "specs" }) => {
+            (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Artifact { .. }) => {
                 delta_rules::run_artifact_rule(rep, change_repo, ctx, rule_name, *level)?;
             }
             (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Proposal) => {
@@ -170,6 +170,15 @@ fn supported_rules_for_target(
 ) -> &'static [&'static str] {
     match (validator_id, target) {
         (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Artifact { id: "specs" }) => {
+            delta_rules::artifact_rules()
+        }
+        (
+            ValidatorId::DeltaSpecsV1,
+            ValidationRuleTarget::Artifact {
+                id: "domain-discovery",
+            },
+        ) => delta_rules::domain_discovery_artifact_rules(),
+        (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Artifact { .. }) => {
             delta_rules::artifact_rules()
         }
         (ValidatorId::DeltaSpecsV1, ValidationRuleTarget::Proposal) => {

--- a/ito-rs/crates/ito-core/tests/templates_apply_instructions.rs
+++ b/ito-rs/crates/ito-core/tests/templates_apply_instructions.rs
@@ -102,3 +102,46 @@ artifacts:
     assert_eq!(r.state, "all_done");
     assert!(r.instruction.contains("ready to be archived"));
 }
+
+#[test]
+fn compute_apply_instructions_ignores_optional_artifacts_when_apply_requires_is_omitted() {
+    let td = tempfile::tempdir().expect("tempdir should succeed");
+    let project_root = td.path();
+    let ito_path = project_root.join(".ito");
+    let change = "demo-change";
+    let change_dir = ito_path.join("changes").join(change);
+    std::fs::create_dir_all(&change_dir).expect("create change dir");
+
+    write(
+        &project_root.join(".ito/templates/schemas/demo/schema.yaml"),
+        r#"name: demo
+version: 1
+artifacts:
+  - id: discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: []
+  - id: proposal
+    generates: proposal.md
+    template: proposal.md
+    requires: []
+"#,
+    );
+
+    let ctx = ConfigContext {
+        project_dir: Some(project_root.to_path_buf()),
+        ..Default::default()
+    };
+
+    let r = compute_apply_instructions(&ito_path, change, Some("demo"), &ctx)
+        .expect("compute_apply_instructions");
+    assert_eq!(r.state, "blocked");
+    assert_eq!(r.missing_artifacts, Some(vec!["proposal".to_string()]));
+
+    write(&change_dir.join("proposal.md"), "ok");
+    let r = compute_apply_instructions(&ito_path, change, Some("demo"), &ctx)
+        .expect("compute_apply_instructions");
+    assert_eq!(r.state, "ready");
+    assert!(r.missing_artifacts.is_none());
+}

--- a/ito-rs/crates/ito-core/tests/templates_change_status.rs
+++ b/ito-rs/crates/ito-core/tests/templates_change_status.rs
@@ -49,7 +49,10 @@ artifacts:
     let status = compute_change_status(&ito_path, "demo-change", Some("demo"), &ctx)
         .expect("compute_change_status");
     assert_eq!(status.schema_name, "demo");
-    assert_eq!(status.apply_requires, vec!["b".to_string()]);
+    assert_eq!(
+        status.apply_requires,
+        vec!["a".to_string(), "b".to_string()]
+    );
     assert!(!status.is_complete);
     assert_eq!(status.artifacts.len(), 2);
 
@@ -109,4 +112,113 @@ fn compute_change_status_rejects_invalid_change_name() {
     let WorkflowError::InvalidChangeName = err else {
         panic!("expected InvalidChangeName");
     };
+}
+
+#[test]
+fn compute_change_status_treats_missing_optional_artifacts_as_non_blocking() {
+    let td = tempfile::tempdir().expect("tempdir should succeed");
+    let project_root = td.path();
+    let ito_path = project_root.join(".ito");
+
+    std::fs::create_dir_all(ito_path.join("changes").join("demo-change"))
+        .expect("create change dir");
+
+    std::fs::create_dir_all(project_root.join(".ito/templates/schemas/demo/templates"))
+        .expect("create schema dirs");
+
+    std::fs::write(
+        project_root.join(".ito/templates/schemas/demo/schema.yaml"),
+        r#"name: demo
+version: 1
+artifacts:
+  - id: discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: []
+  - id: proposal
+    generates: proposal.md
+    template: proposal.md
+    requires: []
+"#,
+    )
+    .expect("write schema.yaml");
+
+    let ctx = ConfigContext {
+        project_dir: Some(project_root.to_path_buf()),
+        ..Default::default()
+    };
+
+    let status = compute_change_status(&ito_path, "demo-change", Some("demo"), &ctx)
+        .expect("compute_change_status");
+    assert_eq!(status.apply_requires, vec!["proposal".to_string()]);
+    assert!(!status.is_complete);
+    assert_eq!(
+        find_artifact(&status.artifacts, "discovery").status,
+        "optional"
+    );
+    assert_eq!(find_artifact(&status.artifacts, "proposal").status, "ready");
+
+    std::fs::write(
+        ito_path
+            .join("changes")
+            .join("demo-change")
+            .join("proposal.md"),
+        "done",
+    )
+    .expect("write proposal.md");
+
+    let status = compute_change_status(&ito_path, "demo-change", Some("demo"), &ctx)
+        .expect("compute_change_status");
+    assert!(status.is_complete);
+    assert_eq!(
+        find_artifact(&status.artifacts, "discovery").status,
+        "optional"
+    );
+}
+
+#[test]
+fn compute_change_status_keeps_optional_artifact_optional_when_dependency_is_missing() {
+    let td = tempfile::tempdir().expect("tempdir should succeed");
+    let project_root = td.path();
+    let ito_path = project_root.join(".ito");
+
+    std::fs::create_dir_all(ito_path.join("changes").join("demo-change"))
+        .expect("create change dir");
+
+    std::fs::create_dir_all(project_root.join(".ito/templates/schemas/demo/templates"))
+        .expect("create schema dirs");
+
+    std::fs::write(
+        project_root.join(".ito/templates/schemas/demo/schema.yaml"),
+        r#"name: demo
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    template: proposal.md
+    requires: []
+  - id: discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: [proposal]
+"#,
+    )
+    .expect("write schema.yaml");
+
+    let ctx = ConfigContext {
+        project_dir: Some(project_root.to_path_buf()),
+        ..Default::default()
+    };
+
+    let status = compute_change_status(&ito_path, "demo-change", Some("demo"), &ctx)
+        .expect("compute_change_status");
+
+    assert_eq!(status.apply_requires, vec!["proposal".to_string()]);
+    assert_eq!(find_artifact(&status.artifacts, "proposal").status, "ready");
+
+    let discovery = find_artifact(&status.artifacts, "discovery");
+    assert_eq!(discovery.status, "optional");
+    assert_eq!(discovery.missing_deps, vec!["proposal".to_string()]);
 }

--- a/ito-rs/crates/ito-core/tests/templates_review_context.rs
+++ b/ito-rs/crates/ito-core/tests/templates_review_context.rs
@@ -43,6 +43,7 @@ artifacts:
   - id: design
     generates: design.md
     template: design.md
+    optional: true
     requires: []
   - id: tasks
     generates: tasks.md
@@ -101,7 +102,7 @@ artifacts:
         review
             .artifacts
             .iter()
-            .any(|a| a.id == "design" && !a.present)
+            .any(|a| a.id == "design" && !a.present && a.optional)
     );
 
     let task_summary = review.task_summary.expect("task summary should exist");

--- a/ito-rs/crates/ito-core/tests/templates_schemas_listing.rs
+++ b/ito-rs/crates/ito-core/tests/templates_schemas_listing.rs
@@ -106,9 +106,58 @@ fn list_schemas_detail_spec_driven_has_expected_artifacts() {
         .expect("spec-driven should be present");
 
     assert!(spec_driven.artifacts.contains(&"proposal".to_string()));
+    assert!(
+        spec_driven
+            .artifacts
+            .contains(&"domain-discovery".to_string())
+    );
     assert!(spec_driven.artifacts.contains(&"specs".to_string()));
     assert!(spec_driven.artifacts.contains(&"design".to_string()));
     assert!(spec_driven.artifacts.contains(&"tasks".to_string()));
+}
+
+#[test]
+fn built_in_schemas_expose_domain_discovery_template_hook() {
+    let root = tempfile::tempdir().expect("tempdir should succeed");
+    let ito_path = root.path().join(".ito");
+    std::fs::create_dir_all(ito_path.join("changes/demo-change")).expect("create change dir");
+
+    let ctx = ConfigContext {
+        project_dir: Some(root.path().to_path_buf()),
+        ..Default::default()
+    };
+
+    for schema in ["spec-driven", "event-driven"] {
+        let out = resolve_instructions(
+            &ito_path,
+            "demo-change",
+            Some(schema),
+            "domain-discovery",
+            &ctx,
+        )
+        .unwrap_or_else(|error| {
+            panic!("{schema} domain discovery template should resolve: {error}")
+        });
+        assert!(
+            out.template.contains("## Domain Discovery Summary"),
+            "{schema} template should include the canonical discovery handoff"
+        );
+        assert!(
+            out.template.contains("## Ubiquitous Language"),
+            "{schema} template should include language capture"
+        );
+        assert!(
+            out.template.contains("## Bounded Context Map"),
+            "{schema} template should include bounded context capture"
+        );
+        assert!(
+            out.instruction
+                .as_deref()
+                .unwrap_or_default()
+                .contains("optional discovery artifact"),
+            "{schema} instructions should identify discovery as optional"
+        );
+    }
 }
 
 #[test]

--- a/ito-rs/crates/ito-core/tests/validate.rs
+++ b/ito-rs/crates/ito-core/tests/validate.rs
@@ -159,6 +159,59 @@ apply:
 }
 
 #[test]
+fn validate_change_default_apply_requirements_ignore_optional_artifacts() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("demo")
+            .join("schema.yaml"),
+        r#"
+name: demo
+version: 1
+artifacts:
+  - id: discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: []
+  - id: proposal
+    generates: proposal.md
+    template: proposal.md
+    requires: []
+"#,
+    );
+
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: demo\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "# Proposal\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let r = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !r.issues.iter().any(|i| {
+            i.path == "artifacts.discovery"
+                && i.message
+                    .contains("Apply-required artifact 'discovery' is missing")
+        }),
+        "optional artifact should not be apply-required by default, got issues: {:?}",
+        r.issues
+    );
+}
+
+#[test]
 fn validate_change_uses_validation_yaml_delta_specs_validator_when_configured() {
     let td = tempfile::tempdir().unwrap();
     let project_root = td.path();

--- a/ito-rs/crates/ito-core/tests/validate_delta_rules.rs
+++ b/ito-rs/crates/ito-core/tests/validate_delta_rules.rs
@@ -755,3 +755,422 @@ fn contract_refs_rule_warns_when_public_contract_has_no_requirement_anchor() {
             && issue.message.contains("Public Contract facet 'openapi'")
     }));
 }
+
+#[test]
+fn ubiquitous_language_consistency_rule_warns_for_rejected_aliases() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| project space | Workspace | Avoid overloading project. |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need a project space for collaboration.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(report.issues.iter().any(|issue| {
+        issue.rule_id.as_deref() == Some("ubiquitous_language_consistency")
+            && issue.level == "WARNING"
+            && issue.message.contains("project space")
+            && issue.message.contains("Workspace")
+    }));
+}
+
+#[test]
+fn ubiquitous_language_consistency_rule_dedups_table_and_summary_aliases() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- Canonical terms: Workspace -> A tenant-scoped collaboration boundary.
+- Rejected aliases / overloaded terms: project space -> Workspace
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| project space | Workspace | Avoid overloading project. |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need a project space for collaboration.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+    let warnings = report
+        .issues
+        .iter()
+        .filter(|issue| issue.rule_id.as_deref() == Some("ubiquitous_language_consistency"))
+        .count();
+
+    assert_eq!(
+        warnings, 1,
+        "duplicate table and summary aliases should warn once, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn ubiquitous_language_consistency_rule_passes_when_aliases_are_absent() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| project space | Workspace | Avoid overloading project. |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need a Workspace for collaboration.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("ubiquitous_language_consistency") }),
+        "consistent language should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn ubiquitous_language_consistency_rule_uses_term_boundaries() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| space | Workspace | Avoid vague vocabulary. |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need a Workspace for collaboration.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("ubiquitous_language_consistency") }),
+        "alias should not match inside another word, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_documentation_consistency_rule_warns_for_conflicting_context_docs() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need clearer collaboration language.\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("docs")
+            .join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Collaboration | proposed update |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+                && issue.level == "WARNING"
+                && issue.message.contains("Workspace")
+                && issue.path.contains("CONTEXT.md")
+        }),
+        "expected domain documentation warning, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_documentation_consistency_rule_passes_for_matching_context_docs() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need clearer collaboration language.\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("docs")
+            .join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | proposed update |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("domain_documentation_consistency") }),
+        "matching domain docs should not warn, got issues: {:?}",
+        report.issues
+    );
+}

--- a/ito-rs/crates/ito-core/tests/validate_domain_discovery_boundary_regressions.rs
+++ b/ito-rs/crates/ito-core/tests/validate_domain_discovery_boundary_regressions.rs
@@ -1,0 +1,473 @@
+use ito_core::change_repository::FsChangeRepository;
+use ito_core::validate::validate_change;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    let Some(parent) = path.parent() else {
+        panic!("path has no parent: {}", path.display());
+    };
+    std::fs::create_dir_all(parent).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+fn write_context_boundary_schema(project_root: &Path, ito: &Path, change_id: &str) {
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_requires_relationship_for_each_affected_context() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Customer/supplier with Billing |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment |  |
+
+## Model Ownership
+
+- **Translation boundaries**: Billing payment status is translated into an Orders-local checkout settlement state.
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders need to coordinate with Billing.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("relationship pattern")
+        }),
+        "partial relationship framing should warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_accepts_explicit_no_translation_boundary() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Shared kernel with Billing |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Shared kernel with Orders |
+
+## Model Ownership
+
+- **Translation boundaries**: None
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders need to coordinate with Billing through a shared kernel.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("context_boundary_consistency") }),
+        "explicit no-translation answer should satisfy the boundary gate, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_warns_when_cross_context_proposal_has_no_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nThis cross-context change spans multiple bounded contexts.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("missing domain discovery")
+        }),
+        "cross-context proposal without handoff should warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_warns_when_proposal_outgrows_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Published language |
+
+## Model Ownership
+
+- **Translation boundaries**: None
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nThis cross-context change spans multiple bounded contexts.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("affected contexts")
+        }),
+        "underreported cross-context handoff should warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn embedded_discovery_handoffs_are_merged_in_artifact_order() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Orders need to coordinate with Billing.
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Customer/supplier with Billing |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Supplier to Orders |
+
+## Model Ownership
+
+- **Translation boundaries**: Billing payment status is translated into an Orders-local checkout settlement state.
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("design.md"),
+        r#"## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Published language |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("context_boundary_consistency")),
+        "complete proposal handoff should not be hidden by a partial design handoff, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn partial_standalone_discovery_does_not_hide_complete_embedded_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Orders need to coordinate with Billing.
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Customer/supplier with Billing |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Supplier to Orders |
+
+## Model Ownership
+
+- **Translation boundaries**: Billing payment status is translated into an Orders-local checkout settlement state.
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("context_boundary_consistency")),
+        "complete embedded handoff should satisfy boundary framing even with partial standalone discovery, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_only_standalone_discovery_does_not_override_embedded_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Billing needs clearer invoice status language.
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Internal Billing model |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("context_boundary_consistency")),
+        "context-only standalone discovery should not make richer embedded Billing discovery look cross-context, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn repeated_embedded_discovery_sections_are_merged_within_one_artifact() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Orders need to coordinate with Billing.
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Customer/supplier with Billing |
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Supplier to Orders |
+
+## Model Ownership
+
+- **Translation boundaries**: Billing payment status is translated into an Orders-local checkout settlement state.
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("context_boundary_consistency")),
+        "repeated sections in one artifact should merge into one handoff, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_detects_lowercase_context_prose_without_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\norders coordinate with billing for settlement.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("missing domain discovery")
+        }),
+        "lowercase cross-context prose without handoff should warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_ignores_obvious_external_vendor_integration() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_context_boundary_schema(project_root, &ito, change_id);
+
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders integrates with Stripe for external payment capture.\nOrders integrates with Slack for notifications.\nBilling coordinates with Salesforce.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("context_boundary_consistency")),
+        "obvious vendor integration should not require bounded-context discovery, got issues: {:?}",
+        report.issues
+    );
+}

--- a/ito-rs/crates/ito-core/tests/validate_domain_discovery_doc_consistency.rs
+++ b/ito-rs/crates/ito-core/tests/validate_domain_discovery_doc_consistency.rs
@@ -1,0 +1,132 @@
+use ito_core::change_repository::FsChangeRepository;
+use ito_core::validate::validate_change;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    let Some(parent) = path.parent() else {
+        panic!("path has no parent: {}", path.display());
+    };
+    std::fs::create_dir_all(parent).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+fn write_domain_doc_schema(project_root: &Path, ito: &Path, change_id: &str) {
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+}
+
+#[test]
+fn compact_canonical_terms_use_primary_context_for_doc_consistency() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_domain_doc_schema(project_root, &ito, change_id);
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Orders need clearer workspace language.
+
+## Domain Discovery Summary
+
+- Primary bounded context: Orders
+- Canonical terms: Workspace -> An Orders-owned collaboration boundary.
+"#,
+    );
+    write(
+        &project_root.join("docs").join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Billing | Existing Billing meaning. |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("domain_documentation_consistency")),
+        "same compact term in a different owner context should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn compact_terms_keep_their_own_embedded_summary_context() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+    write_domain_doc_schema(project_root, &ito, change_id);
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Orders need clearer workspace language.
+
+## Domain Discovery Summary
+
+- Primary bounded context: Orders
+- Canonical terms: Order -> An Orders-owned checkout commitment.
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("design.md"),
+        r#"## Domain Discovery Summary
+
+- Primary bounded context: Billing
+- Canonical terms: Workspace -> A Billing-owned subscription container.
+"#,
+    );
+    write(
+        &project_root.join("docs").join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Billing | Existing Billing meaning. |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report
+            .issues
+            .iter()
+            .any(|issue| issue.rule_id.as_deref() == Some("domain_documentation_consistency")),
+        "later embedded compact terms should keep their own primary context and report same-context drift, got issues: {:?}",
+        report.issues
+    );
+}

--- a/ito-rs/crates/ito-core/tests/validate_domain_discovery_rules.rs
+++ b/ito-rs/crates/ito-core/tests/validate_domain_discovery_rules.rs
@@ -1,0 +1,1164 @@
+use ito_core::change_repository::FsChangeRepository;
+use ito_core::validate::validate_change;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    let Some(parent) = path.parent() else {
+        panic!("path has no parent: {}", path.display());
+    };
+    std::fs::create_dir_all(parent).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+#[test]
+fn context_boundary_consistency_rule_warns_for_incomplete_cross_context_framing() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Order lifecycle. |  | Order |  |
+| Billing |  |  | Invoice |  |
+
+## Model Ownership
+
+- **Translation required**: <!-- Where external concepts become local concepts, or None. -->
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders need to coordinate with Billing.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.level == "WARNING"
+                && issue.message.contains("context ownership")
+                && issue.message.contains("relationship pattern")
+                && issue.message.contains("translation boundary")
+        }),
+        "expected context boundary warning, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_passes_for_explicit_relationship_and_translation() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Owns order lifecycle and checkout decisions. | Orders owner | Order, checkout | Customer/supplier with Billing |
+| Billing | Owns invoice creation and payment status. | Billing owner | Invoice, payment | Supplier to Orders |
+
+## Model Ownership
+
+- **Translation boundaries**: Billing payment status is translated into an Orders-local checkout settlement state.
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders need to coordinate with Billing.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("context_boundary_consistency") }),
+        "framed cross-context discovery should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_rules_parse_embedded_compact_discovery_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n    context_boundary_consistency: warning\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Users need a project space for checkout collaboration.
+
+## Domain Discovery Summary
+
+- Primary problem: checkout needs consistent collaboration language.
+- Discovery depth: bounded-context because checkout crosses contexts.
+- Business/domain capability: checkout collaboration
+- Primary bounded context: Orders
+- Supporting contexts: Billing
+- Model ownership: Orders owns checkout rules; Billing owns invoice rules.
+- Canonical terms: Workspace -> A tenant-scoped collaboration boundary.
+- Rejected aliases / overloaded terms: project space -> Workspace
+- Bounded contexts: Orders -> checkout lifecycle, Orders owner, Order and checkout, ; Billing -> invoice settlement, Billing owner, Invoice and payment,
+- Cross-context relationships: customer/supplier with published language and translation boundary.
+- Translation boundaries: Billing payment status becomes an Orders-local checkout settlement state.
+"#,
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("docs")
+            .join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Orders | proposed update |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("ubiquitous_language_consistency")
+                && issue.message.contains("project space")
+        }),
+        "compact rejected alias should warn, got issues: {:?}",
+        report.issues
+    );
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+                && issue.message.contains("Workspace")
+        }),
+        "compact canonical term should drive doc consistency, got issues: {:?}",
+        report.issues
+    );
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("context_boundary_consistency") }),
+        "compact context handoff is fully framed and should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_rules_parse_embedded_full_discovery_sections() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n    context_boundary_consistency: warning\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Users need a project space for checkout collaboration.
+
+## Domain Discovery Summary
+
+- Primary problem: checkout needs consistent collaboration language.
+- Discovery depth: bounded-context because checkout crosses contexts.
+- Business/domain capability: checkout collaboration
+- Primary bounded context: Orders
+- Supporting contexts: Billing
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Orders | canonical |
+
+## Rejected Aliases / Overloaded Terms
+
+| Alias / Term | Prefer | Reason |
+| --- | --- | --- |
+| project space | Workspace | Avoids conflict with Ito project terminology. |
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned language | Relationship pattern |
+| --- | --- | --- | --- | --- |
+| Orders | checkout lifecycle | Orders owner | Order and checkout | customer/supplier |
+| Billing | invoice settlement | Billing owner | Invoice and payment | supplier |
+
+## Model Ownership
+
+- Translation boundaries: Billing payment status becomes an Orders-local checkout settlement state.
+"#,
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("docs")
+            .join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Orders | proposed update |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("ubiquitous_language_consistency")
+                && issue.message.contains("project space")
+        }),
+        "embedded full rejected alias table should warn, got issues: {:?}",
+        report.issues
+    );
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+                && issue.message.contains("Workspace")
+        }),
+        "embedded full canonical term table should drive doc consistency, got issues: {:?}",
+        report.issues
+    );
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("context_boundary_consistency") }),
+        "embedded full context handoff is fully framed and should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_uses_header_columns_for_owner_tables() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nCheckout collaboration crosses Orders and Billing.\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- Primary problem: checkout crosses Orders and Billing.
+- Discovery depth: bounded-context because checkout crosses contexts.
+- Primary bounded context: Orders
+- Supporting contexts: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned language | Relationship pattern |
+| --- | --- | --- | --- | --- |
+| Orders | checkout lifecycle | Orders owner | Order and checkout | |
+| Billing | invoice settlement | Billing owner | Invoice and payment | |
+
+## Model Ownership
+
+- Translation boundaries: Billing payment status becomes an Orders-local checkout settlement state.
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("relationship pattern")
+        }),
+        "missing relationship column values should warn even when owner columns are populated, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_requires_ownership_for_each_affected_context() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nCheckout collaboration crosses Orders, Billing, and Fulfillment.\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- Primary bounded context: Orders
+- Supporting contexts: Billing, Fulfillment
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned language | Relationship pattern |
+| --- | --- | --- | --- | --- |
+| Orders | checkout lifecycle | Orders owner | Order and checkout | customer/supplier |
+| Billing | invoice settlement | Billing owner | Invoice and payment | supplier |
+| Fulfillment | shipment release |  | Shipment | customer/supplier |
+
+## Model Ownership
+
+- Translation boundaries: Billing and Fulfillment concepts become Orders-local settlement and release states.
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.message.contains("context ownership")
+        }),
+        "each affected context should require explicit ownership, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_is_silent_for_single_context_discovery() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: None
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- |
+| Orders | Owns order lifecycle. | Order | None |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders need clearer lifecycle rules.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("context_boundary_consistency") }),
+        "single-context discovery should not warn, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_rules_can_run_from_artifact_rules_for_event_driven_schemas() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("schema.yaml"),
+        r#"
+name: event-like
+version: 1
+artifacts:
+  - id: domain-discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    optional: true
+    requires: []
+  - id: specs
+    generates: specs/**/*.md
+    template: specs/spec.md
+    requires: []
+"#,
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("validation.yaml"),
+        r#"
+version: 1
+artifacts:
+  domain-discovery:
+    required: true
+    validate_as: ito.delta-specs.v1
+    rules:
+      context_boundary_consistency: warning
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: event-like\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary bounded context**: Orders
+- **Supporting contexts**: Billing
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| Orders | Order lifecycle. |  | Order |  |
+| Billing |  |  | Invoice |  |
+"#,
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("specs")
+            .join("orders")
+            .join("spec.md"),
+        r#"
+## ADDED Requirements
+
+### Requirement: Coordinate billing
+The system SHALL coordinate checkout with billing.
+
+#### Scenario: Billing event arrives
+- **GIVEN** an order is pending settlement
+- **WHEN** a billing event arrives
+- **THEN** checkout state is updated
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.path == "domain-discovery.bounded-context-map"
+        }),
+        "artifact-level domain rule should run without proposal.md, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn spec_only_artifact_rules_are_rejected_for_domain_discovery_artifacts() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("schema.yaml"),
+        r#"
+name: event-like
+version: 1
+artifacts:
+  - id: domain-discovery
+    generates: domain-discovery.md
+    template: domain-discovery.md
+    requires: []
+"#,
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("validation.yaml"),
+        r#"
+version: 1
+artifacts:
+  domain-discovery:
+    required: true
+    validate_as: ito.delta-specs.v1
+    rules:
+      scenario_grammar: warning
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: event-like\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        "# Domain Discovery\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.path == "schema.validation.artifacts.domain-discovery.rules.scenario_grammar"
+                && issue
+                    .message
+                    .contains("Unknown validation rule 'scenario_grammar'")
+        }),
+        "spec-only artifact rule should be rejected outside specs, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn non_domain_discovery_artifacts_still_accept_spec_artifact_rules() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("schema.yaml"),
+        r#"
+name: event-like
+version: 1
+artifacts:
+  - id: event-modeling
+    generates: event-modeling.md
+    template: event-modeling.md
+    requires: []
+"#,
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("event-like")
+            .join("validation.yaml"),
+        r#"
+version: 1
+artifacts:
+  event-modeling:
+    required: true
+    validate_as: ito.delta-specs.v1
+    rules:
+      scenario_grammar: warning
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: event-like\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("event-modeling.md"),
+        "# Event Modeling\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report.issues.iter().any(|issue| {
+            issue.path == "schema.validation.artifacts.event-modeling.rules.scenario_grammar"
+                && issue.message.contains("Unknown validation rule")
+        }),
+        "non-domain-discovery artifacts should keep spec artifact rules, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_documentation_consistency_rule_checks_existing_project_context_docs() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A tenant-scoped collaboration boundary. | Collaboration | canonical term |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need clearer collaboration language.\n",
+    );
+    write(
+        &project_root.join("docs").join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Workspace | A billing account container. | Collaboration | existing docs |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+                && issue.path == "docs/CONTEXT.md"
+                && issue.message.contains("Workspace")
+        }),
+        "existing context docs should be checked, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_documentation_consistency_rule_allows_same_term_in_different_contexts() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Account | A tenant billing contract. | Billing | canonical term |
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nBilling needs account language.\n",
+    );
+    write(
+        &project_root.join("docs").join("CONTEXT.md"),
+        r#"# Context
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| Account | A login identity. | Identity | existing docs |
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+                && issue.path == "docs/CONTEXT.md"
+        }),
+        "same term in a different context should not be treated as drift, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn context_boundary_consistency_rule_warns_for_direct_context_coordination_without_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    context_boundary_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nOrders coordinates with Billing during checkout settlement.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                && issue.path == "domain-discovery.bounded-context-map"
+        }),
+        "direct context coordination should require boundary framing, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn domain_rules_are_silent_without_domain_discovery_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n    context_boundary_consistency: warning\n    domain_documentation_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        "## Why\n\nUsers need a project space for collaboration.\n",
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("ubiquitous_language_consistency")
+                || issue.rule_id.as_deref() == Some("context_boundary_consistency")
+                || issue.rule_id.as_deref() == Some("domain_documentation_consistency")
+        }),
+        "domain rules should be no-op without handoff, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn ubiquitous_language_rule_ignores_rejected_alias_declaration_itself() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Users need clearer checkout collaboration language.
+
+## Domain Discovery Summary
+
+- Primary problem: checkout needs consistent collaboration language.
+- Canonical terms: Workspace -> A tenant-scoped collaboration boundary.
+- Rejected aliases / overloaded terms: project space -> Workspace
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        !report
+            .issues
+            .iter()
+            .any(|issue| { issue.rule_id.as_deref() == Some("ubiquitous_language_consistency") }),
+        "rejected alias declaration should not self-trigger, got issues: {:?}",
+        report.issues
+    );
+}
+
+#[test]
+fn placeholder_standalone_discovery_does_not_hide_embedded_handoff() {
+    let td = tempfile::tempdir().unwrap();
+    let project_root = td.path();
+    let ito = project_root.join(".ito");
+    let change_id = "001-01_demo";
+
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("schema.yaml"),
+        "name: proposal-rules\nversion: 1\nartifacts: []\n",
+    );
+    write(
+        &project_root
+            .join(".ito")
+            .join("templates")
+            .join("schemas")
+            .join("proposal-rules")
+            .join("validation.yaml"),
+        "version: 1\nproposal:\n  required: true\n  validate_as: ito.delta-specs.v1\n  rules:\n    ubiquitous_language_consistency: warning\n",
+    );
+    write(
+        &ito.join("changes").join(change_id).join(".ito.yaml"),
+        "schema: proposal-rules\n",
+    );
+    write(
+        &ito.join("changes")
+            .join(change_id)
+            .join("domain-discovery.md"),
+        r#"# Domain Discovery
+
+## Domain Discovery Summary
+
+- **Primary problem**: <!-- One sentence describing the domain problem. -->
+- **Discovery depth**: <!-- direct, lightweight, bounded-context, or rigorous domain-grill; include trigger rationale. -->
+- **Supporting contexts**: None
+- **Translation boundaries**: None
+"#,
+    );
+    write(
+        &ito.join("changes").join(change_id).join("proposal.md"),
+        r#"## Why
+
+Users need a project space for checkout collaboration.
+
+## Domain Discovery Summary
+
+- Primary problem: checkout needs consistent collaboration language.
+- Canonical terms: Workspace -> A tenant-scoped collaboration boundary.
+- Rejected aliases / overloaded terms: project space -> Workspace
+"#,
+    );
+
+    let change_repo = FsChangeRepository::new(&ito);
+    let report = validate_change(&change_repo, &ito, change_id, false).unwrap();
+
+    assert!(
+        report.issues.iter().any(|issue| {
+            issue.rule_id.as_deref() == Some("ubiquitous_language_consistency")
+                && issue.message.contains("project space")
+        }),
+        "meaningless standalone artifact should fall through to embedded handoff, got issues: {:?}",
+        report.issues
+    );
+}

--- a/ito-rs/crates/ito-templates/assets/commands/ito-plan.md
+++ b/ito-rs/crates/ito-templates/assets/commands/ito-plan.md
@@ -1,0 +1,20 @@
+---
+name: ito-plan
+description: Explore rough ideas before proposal scaffolding, including DDD discovery when useful.
+category: Ito
+tags: [ito, plan, discovery, ddd]
+---
+
+<UserRequest>
+$ARGUMENTS
+</UserRequest>
+
+<!-- ITO:START -->
+
+Load and follow the `ito-plan` skill. Pass the <UserRequest> block as input.
+
+Use the least sufficient discovery depth. Inspect repository evidence before asking questions, and route the resulting handoff to `ito-proposal-intake` or `ito-proposal` when proposal-ready.
+
+If the skill is missing, ask the user to run `ito init` or `ito update`, then stop.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -13,6 +13,68 @@ Do NOT jump straight into creating files. First, make sure you understand what t
 
 If the user's request is already precise and well-scoped, a quick confirmation is enough — don't over-interview.
 
+## Before Schema Selection: Domain Discovery Gate
+
+If the request is ambiguous, architectural, policy-heavy, sequencing-heavy, public-contract-changing, hard to reverse, or cross-context, run a DDD discovery pass before creating proposal files. Use the least sufficient discovery depth:
+
+| Depth | Trigger | Behavior |
+| --- | --- | --- |
+| Direct / skip | Routine, low-risk, one-context work with clear vocabulary | Keep the normal proposal path. |
+| Lightweight discovery | Vocabulary is fuzzy, overloaded, or domain-specific | Resolve canonical terms, rejected aliases, overloaded terms, and open language questions. |
+| Bounded-context discovery | Work crosses ownership, integrations, modules, capabilities, or domain models | Name primary/supporting bounded contexts, model ownership, relationship pattern or `provisional/unknown`, consistency expectations, and translation boundary. |
+| Rigorous domain-grill | User opts in, or work is high-impact, architectural, public-contract-changing, hard to reverse, policy-heavy, sequencing-heavy, or cross-context with unresolved ownership | Inspect code/docs first, then challenge one unresolved decision at a time with a recommended answer. |
+
+Clear cross-context work must use at least bounded-context discovery. Do not treat Ito modules, Ito capabilities, code directories, tables, or services as bounded contexts without checking who owns the domain language, rules, lifecycle, and decisions.
+
+### Discovery Bundle
+
+Capture the following when relevant to the selected depth:
+
+- Business/domain capability, distinct from Ito capability names.
+- Model ownership: who owns rules, lifecycle, language, and decisions.
+- Ubiquitous language: canonical terms, definitions, rejected aliases, overloaded terms, and unresolved vocabulary.
+- Bounded contexts: primary/supporting contexts, responsibilities, ownership, owned language, and external concepts referenced.
+- Cross-context relationship pattern: customer/supplier, conformist, anti-corruption layer, shared kernel, separate ways, another explicit relationship, or `provisional/unknown`.
+- Translation boundaries and published language between contexts.
+- Consistency requirements: strong/eventual consistency, conflict owner, stale-data impact, and downstream-unavailable behavior when relevant.
+- Technique fit: selected and skipped DDD techniques with rationale.
+- Evidence checked: code, specs, `CONTEXT.md`, `CONTEXT-MAP.md`, ADRs, or prior planning docs consulted before asking the user.
+- Proposed documentation updates: lazy `CONTEXT.md`, `CONTEXT-MAP.md`, or ADR candidates only for durable terms, context boundaries, or decisions that are hard to reverse, surprising without context, and based on a real trade-off.
+
+Use event-storming concepts when sequencing, reactions, policies, actors, aggregates, read models, or invariants clarify behavior. Optional event-storming fields are actors, commands, queries/read-model questions, domain events, policies, aggregates/entities, read models, and invariants.
+
+In rigorous domain-grill mode, challenge boundary-smell requests such as `add a status`, `reuse the existing model`, `just sync the data`, `expose this field`, `put it in shared`, `add a flag`, or `use a common helper`. Use concrete scenarios to probe ownership, lifecycle, failure behavior, consistency, and translation.
+
+### Discovery Handoff
+
+Carry discovery into proposal scaffolding as a stable handoff:
+
+```markdown
+## Domain Discovery Summary
+- Primary problem: <one sentence>
+- Discovery depth: <direct|lightweight|bounded-context|rigorous domain-grill> because <trigger>
+- Business/domain capability: <capability distinct from Ito capability>
+- Primary bounded context: <context that owns the main behavior>
+- Supporting contexts: <other contexts involved, or none>
+- Model ownership: <who owns rules/lifecycle/language/decisions>
+- Canonical terms: <term -> definition>
+- Rejected aliases / overloaded terms: <alias or term -> guidance>
+- Bounded contexts: <name -> responsibility, ownership, owned language>
+- Owned concepts changed: <rules/lifecycle/language/decisions>
+- External concepts referenced: <borrowed concepts from other contexts>
+- Cross-context relationships: <pattern or provisional/unknown, published language, translation boundary>
+- Translation boundaries: <where external concepts become local concepts>
+- Consistency requirements: <strong/eventual, conflict owner, stale-data impact, unavailable-downstream behavior>
+- Technique fit: <selected and skipped DDD techniques with rationale>
+- Event-storming snapshot: <actors, commands, queries, events, policies, aggregates, read models, invariants if used>
+- Candidate Ito capabilities: <proposal/spec capability names>
+- Open questions: <unresolved vocabulary, ownership, policy, or sequencing questions>
+- Evidence checked: <specs/files/docs/ADRs consulted>
+- Proposed documentation updates: <CONTEXT.md, CONTEXT-MAP.md, ADR candidates, or none>
+```
+
+If the request needs this discovery but there is not enough context yet, route to `ito-plan` or `ito-proposal-intake` before continuing. Do not create proposal scaffolding until blocking language, ownership, and boundary ambiguity is resolved or explicitly recorded as an open question.
+
 ## Step 0: Synchronize Coordination State
 
 `ito agent instruction proposal` refreshes coordination state before rendering this guide. If you are using this guide later, refresh again before listing modules or creating proposal state. `ito sync` is a no-op unless coordination-worktree storage is active, and it rate-limits pushes to avoid excessive remote updates.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/review.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/review.md.j2
@@ -14,9 +14,9 @@ You are reviewing an Ito change proposal package before implementation. Focus on
 
 ## Artifact Inventory
 
-| Artifact | Present | Path |
-| --- | --- | --- |
-{% for artifact in artifacts %}| `{{ artifact.id }}` | {{ "yes" if artifact.present else "no" }} | `{{ artifact.path }}` |
+| Artifact | Required | Present | Path |
+| --- | --- | --- | --- |
+{% for artifact in artifacts %}| `{{ artifact.id }}` | {{ "no" if artifact.optional | default(value=false) else "yes" }} | {{ "yes" if artifact.present else "no" }} | `{{ artifact.path }}` |
 {% endfor %}
 
 ## Structural Validation
@@ -47,6 +47,11 @@ Check and report:
 - Claimed impact aligns with listed changes.
 - Risks and trade-offs are concrete and testable.
 - Success criteria are measurable and falsifiable.
+- For ambiguous, architectural, public-contract, or cross-context work, the selected discovery depth is justified and proportional.
+- Domain language is stable: business/domain capability, canonical terms, rejected aliases, and overloaded terms are carried from discovery into proposal language.
+- Model ownership is clear: the package distinguishes business/domain capabilities, Ito capabilities, Ito modules, and bounded contexts.
+- Cross-context scope names affected contexts, ownership, relationship pattern or provisional unknown, consistency expectations, and translation boundaries.
+- Evidence checks, proposed `CONTEXT.md` / `CONTEXT-MAP.md` updates, and ADR candidates are present when discovery resolved durable domain language or consequential decisions.
 {% endif %}
 
 {% if artifacts | selectattr("id", "equalto", "specs") | selectattr("present") | list | length > 0 %}
@@ -69,6 +74,7 @@ Check and report:
 - Alternatives and trade-offs are documented.
 - Operational concerns (observability, rollback, migration) are addressed.
 - Security/performance implications are explicit and actionable.
+- Consistency assumptions from discovery are reflected in design choices, especially conflict ownership, stale-data impact, and downstream-unavailable behavior.
 {% endif %}
 
 {% if task_summary %}
@@ -81,6 +87,7 @@ Check and report:
 - Dependencies and wave sequencing are realistic.
 - Verification commands validate intended behavior.
 - Task granularity is actionable and reviewable.
+- Tasks preserve discovery outputs through implementation, validation, and any proposed domain-doc promotion instead of treating discovery as disposable planning notes.
 {% endif %}
 
 {% if traceability %}
@@ -126,6 +133,8 @@ Check and report:
 - Flag any system-wide impacts that are not captured in requirements.
 - Evaluate whether testing strategy is sufficient for risk level.
 - Confirm decomposition supports incremental, reversible delivery.
+- Check whether DDD discovery should have been invoked or deepened before implementation proceeds.
+- Confirm optional domain validators (`ubiquitous_language_consistency`, `context_boundary_consistency`, `domain_documentation_consistency`) are enabled or intentionally skipped for domain-heavy changes.
 {% if affected_specs|length > 0 %}
 - Affected main specs (`MODIFIED` deltas):
 {% for spec in affected_specs %}

--- a/ito-rs/crates/ito-templates/assets/schemas/event-driven/schema.yaml
+++ b/ito-rs/crates/ito-templates/assets/schemas/event-driven/schema.yaml
@@ -2,6 +2,21 @@ name: event-driven
 version: 1
 description: Event-driven workflow from discovery to AsyncAPI-first planning
 artifacts:
+  - id: domain-discovery
+    generates: domain-discovery.md
+    description: Optional DDD discovery handoff for ambiguous, architectural, or cross-context work
+    template: domain-discovery.md
+    optional: true
+    instruction: |
+      Create this optional discovery artifact when event-storming should be grounded in
+      explicit business/domain capability, model ownership, ubiquitous language, bounded
+      contexts, relationship patterns, consistency expectations, technique-fit decisions,
+      evidence checked, or proposed domain-documentation updates.
+
+      Keep event-driven discovery outputs aligned with this handoff, but do not force the
+      artifact for routine event-driven changes where vocabulary and boundaries are already clear.
+    requires: []
+
   - id: event-storming
     generates: event-storming.md
     description: Discovery of events, commands, actors, and boundaries

--- a/ito-rs/crates/ito-templates/assets/schemas/event-driven/templates/domain-discovery.md
+++ b/ito-rs/crates/ito-templates/assets/schemas/event-driven/templates/domain-discovery.md
@@ -1,0 +1,81 @@
+<!-- ITO:START -->
+# Domain Discovery
+
+Use this optional artifact when a change needs DDD-oriented discovery before proposal, specs, or tasks. Keep routine one-context work on the normal fast path.
+
+## Domain Discovery Summary
+
+- **Primary problem**: <!-- One sentence describing the domain problem. -->
+- **Discovery depth**: <!-- direct, lightweight, bounded-context, or rigorous domain-grill; include trigger rationale. -->
+- **Business/domain capability**: <!-- Business capability being changed, distinct from Ito capability names. -->
+- **Primary bounded context**: <!-- Context that owns the main behavior. -->
+- **Supporting contexts**: <!-- Other contexts referenced or affected, or None. -->
+- **Candidate Ito capabilities**: <!-- Proposed spec capability names informed by discovery. -->
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| <!-- canonical term --> | <!-- precise meaning --> | <!-- bounded context --> | <!-- aliases or caveats --> |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| <!-- alias --> | <!-- canonical term --> | <!-- why this avoids confusion --> |
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| <!-- context --> | <!-- business responsibility --> | <!-- owning team/context/person --> | <!-- owned terms --> | <!-- customer/supplier, conformist, ACL, shared kernel, separate ways, provisional/unknown --> |
+
+## Model Ownership
+
+- **Owned concepts changed**: <!-- Rules, lifecycle, language, or decisions owned by the primary context. -->
+- **External concepts referenced**: <!-- Concepts borrowed from supporting contexts. -->
+- **Translation boundaries**: <!-- Where external concepts become local concepts, or None. -->
+
+## Consistency Requirements
+
+- **Consistency expectation**: <!-- strong, eventual, or not applicable. -->
+- **Conflict owner**: <!-- Context/actor that resolves conflicts. -->
+- **Stale-data impact**: <!-- What breaks or degrades if downstream data is stale. -->
+- **Downstream-unavailable behavior**: <!-- Retry, queue, fail closed/open, or not applicable. -->
+
+## Technique Fit
+
+| Technique | Selected? | Rationale |
+| --- | --- | --- |
+| Ubiquitous language | <!-- yes/no --> | <!-- why enough or unnecessary --> |
+| Bounded context mapping | <!-- yes/no --> | <!-- why enough or unnecessary --> |
+| Event storming / event modeling | <!-- yes/no --> | <!-- why useful or skipped --> |
+| Domain-grill questioning | <!-- yes/no --> | <!-- why rigorous questioning is or is not needed --> |
+
+## Event Storming Snapshot
+
+<!-- Optional. Use when behavior depends on sequence, policies, reactions, or invariants. -->
+
+- **Actors**: <!-- People, systems, or roles. -->
+- **Commands**: <!-- Intentful actions. -->
+- **Queries / read-model questions**: <!-- Questions the system must answer. -->
+- **Domain events**: <!-- Past-tense business facts. -->
+- **Policies**: <!-- Reactions or automations. -->
+- **Aggregates / entities**: <!-- Consistency boundaries or long-lived domain objects. -->
+- **Read models**: <!-- Projection needs. -->
+- **Invariants**: <!-- Rules that must always hold. -->
+
+## Evidence Checked
+
+- <!-- Specs, code, CONTEXT.md, CONTEXT-MAP.md, ADRs, docs, or other evidence consulted before asking questions. -->
+
+## Proposed Documentation Updates
+
+- **CONTEXT.md**: <!-- Proposed durable language updates, or None. -->
+- **CONTEXT-MAP.md**: <!-- Proposed context-map updates, or None. -->
+- **ADR**: <!-- ADR-worthy decisions, or None. -->
+
+## Open Questions
+
+- <!-- Unresolved vocabulary, ownership, policy, sequencing, or boundary questions. -->
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/schemas/spec-driven/schema.yaml
+++ b/ito-rs/crates/ito-templates/assets/schemas/spec-driven/schema.yaml
@@ -2,6 +2,23 @@ name: spec-driven
 version: 1
 description: Default Ito workflow - proposal -> specs -> design -> tasks
 artifacts:
+  - id: domain-discovery
+    generates: domain-discovery.md
+    description: Optional DDD discovery handoff for ambiguous, architectural, or cross-context work
+    template: domain-discovery.md
+    optional: true
+    instruction: |
+      Create this optional discovery artifact only when the change needs domain discovery
+      before proposal or spec drafting.
+
+      Use it to capture the canonical discovery handoff: discovery depth, business/domain
+      capability, model ownership, ubiquitous language, bounded contexts, relationship
+      patterns, consistency expectations, technique-fit decisions, optional event-storming
+      outputs, evidence checked, and proposed domain-documentation updates.
+
+      Keep the artifact proportional. Routine one-context work can skip it.
+    requires: []
+
   - id: proposal
     generates: proposal.md
     description: Initial proposal document outlining the change

--- a/ito-rs/crates/ito-templates/assets/schemas/spec-driven/templates/domain-discovery.md
+++ b/ito-rs/crates/ito-templates/assets/schemas/spec-driven/templates/domain-discovery.md
@@ -1,0 +1,81 @@
+<!-- ITO:START -->
+# Domain Discovery
+
+Use this optional artifact when a change needs DDD-oriented discovery before proposal, specs, or tasks. Keep routine one-context work on the normal fast path.
+
+## Domain Discovery Summary
+
+- **Primary problem**: <!-- One sentence describing the domain problem. -->
+- **Discovery depth**: <!-- direct, lightweight, bounded-context, or rigorous domain-grill; include trigger rationale. -->
+- **Business/domain capability**: <!-- Business capability being changed, distinct from Ito capability names. -->
+- **Primary bounded context**: <!-- Context that owns the main behavior. -->
+- **Supporting contexts**: <!-- Other contexts referenced or affected, or None. -->
+- **Candidate Ito capabilities**: <!-- Proposed spec capability names informed by discovery. -->
+
+## Ubiquitous Language
+
+| Term | Definition | Owner / Context | Notes |
+| --- | --- | --- | --- |
+| <!-- canonical term --> | <!-- precise meaning --> | <!-- bounded context --> | <!-- aliases or caveats --> |
+
+## Rejected Aliases / Overloaded Terms
+
+| Term or Alias | Use Instead / Clarify As | Rationale |
+| --- | --- | --- |
+| <!-- alias --> | <!-- canonical term --> | <!-- why this avoids confusion --> |
+
+## Bounded Context Map
+
+| Context | Responsibilities | Owner | Owned Language / Concepts | Relationship Pattern |
+| --- | --- | --- | --- | --- |
+| <!-- context --> | <!-- business responsibility --> | <!-- owning team/context/person --> | <!-- owned terms --> | <!-- customer/supplier, conformist, ACL, shared kernel, separate ways, provisional/unknown --> |
+
+## Model Ownership
+
+- **Owned concepts changed**: <!-- Rules, lifecycle, language, or decisions owned by the primary context. -->
+- **External concepts referenced**: <!-- Concepts borrowed from supporting contexts. -->
+- **Translation boundaries**: <!-- Where external concepts become local concepts, or None. -->
+
+## Consistency Requirements
+
+- **Consistency expectation**: <!-- strong, eventual, or not applicable. -->
+- **Conflict owner**: <!-- Context/actor that resolves conflicts. -->
+- **Stale-data impact**: <!-- What breaks or degrades if downstream data is stale. -->
+- **Downstream-unavailable behavior**: <!-- Retry, queue, fail closed/open, or not applicable. -->
+
+## Technique Fit
+
+| Technique | Selected? | Rationale |
+| --- | --- | --- |
+| Ubiquitous language | <!-- yes/no --> | <!-- why enough or unnecessary --> |
+| Bounded context mapping | <!-- yes/no --> | <!-- why enough or unnecessary --> |
+| Event storming / event modeling | <!-- yes/no --> | <!-- why useful or skipped --> |
+| Domain-grill questioning | <!-- yes/no --> | <!-- why rigorous questioning is or is not needed --> |
+
+## Event Storming Snapshot
+
+<!-- Optional. Use when behavior depends on sequence, policies, reactions, or invariants. -->
+
+- **Actors**: <!-- People, systems, or roles. -->
+- **Commands**: <!-- Intentful actions. -->
+- **Queries / read-model questions**: <!-- Questions the system must answer. -->
+- **Domain events**: <!-- Past-tense business facts. -->
+- **Policies**: <!-- Reactions or automations. -->
+- **Aggregates / entities**: <!-- Consistency boundaries or long-lived domain objects. -->
+- **Read models**: <!-- Projection needs. -->
+- **Invariants**: <!-- Rules that must always hold. -->
+
+## Evidence Checked
+
+- <!-- Specs, code, CONTEXT.md, CONTEXT-MAP.md, ADRs, docs, or other evidence consulted before asking questions. -->
+
+## Proposed Documentation Updates
+
+- **CONTEXT.md**: <!-- Proposed durable language updates, or None. -->
+- **CONTEXT-MAP.md**: <!-- Proposed context-map updates, or None. -->
+- **ADR**: <!-- ADR-worthy decisions, or None. -->
+
+## Open Questions
+
+- <!-- Unresolved vocabulary, ownership, policy, sequencing, or boundary questions. -->
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-plan/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-plan/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ito-plan
+description: Explore rough ideas before proposal scaffolding, including DDD discovery for ambiguous, architectural, or cross-context work.
+---
+
+<!-- ITO:START -->
+
+# Plan Before Proposal
+
+Use this skill when the request is too rough for safe proposal scaffolding or when the user asks to plan before creating a change.
+
+## Goal
+
+Turn an idea into a proposal-ready plan without prematurely choosing vocabulary, ownership, module boundaries, or schema details.
+
+## Guardrails
+
+- Inspect existing code, specs, `CONTEXT.md`, `CONTEXT-MAP.md`, and ADRs before asking questions the repository can answer.
+- Ask one unresolved question at a time, with a recommended answer and short rationale.
+- Keep routine work lightweight; do not force DDD ceremony onto local mechanical changes.
+- Distinguish business/domain capabilities, bounded contexts, Ito modules, and Ito capabilities.
+- End with either a proposal handoff, a research task, or a clear reason no proposal is needed.
+
+## Discovery Depth Gate
+
+Choose the least sufficient discovery depth:
+
+| Depth | Use When | Output |
+| --- | --- | --- |
+| Direct / skip | The work is routine, low-risk, one-context, and vocabulary is clear | Continue to proposal or implementation with a brief summary. |
+| Lightweight discovery | Terms are fuzzy, overloaded, or domain-specific but scope is otherwise bounded | Resolve canonical terms, rejected aliases, and open vocabulary questions. |
+| Bounded-context discovery | Work crosses ownership, integrations, modules, capabilities, or domain models | Name primary/supporting contexts, ownership, relationship pattern or `provisional/unknown`, and translation boundary. |
+| Rigorous domain-grill | User opts in, or work is high-impact, architectural, public-contract-changing, hard to reverse, policy-heavy, sequencing-heavy, or cross-context with unresolved ownership | Challenge one decision at a time using repository evidence, concrete scenarios, and recommended defaults. |
+
+Clear cross-context work must use at least bounded-context discovery.
+
+## DDD Discovery Bundle
+
+Capture only the sections that add signal for the selected depth:
+
+- **Primary problem**: one sentence describing the domain problem.
+- **Discovery depth**: selected depth and trigger rationale.
+- **Business/domain capability**: the business capability being changed, distinct from Ito capability names.
+- **Model ownership**: which bounded context owns the rules, lifecycle, language, and decision authority; do not use table, file, or service location as ownership proof.
+- **Ubiquitous language**: canonical terms, definitions, rejected aliases, overloaded terms, and unresolved vocabulary.
+- **Bounded contexts**: context names, responsibilities, ownership, owned language, primary context, and supporting contexts.
+- **Cross-context relationships**: customer/supplier, conformist, anti-corruption layer, shared kernel, separate ways, another explicit pattern, or `provisional/unknown`.
+- **Translation boundaries**: where external concepts become local concepts and which published language is consumed.
+- **Consistency requirements**: strong/eventual consistency, conflict owner, stale-data impact, and downstream-unavailable behavior when relevant.
+- **Technique fit**: selected and skipped techniques with rationale.
+- **Evidence checked**: code, specs, context docs, ADRs, or prior plans consulted before asking the user.
+- **Proposed documentation updates**: candidate `CONTEXT.md`, `CONTEXT-MAP.md`, or ADR updates, created lazily only for durable terms, context boundaries, or decisions that are hard to reverse, surprising without context, and based on a real trade-off.
+
+When behavior is sequence-, policy-, or reaction-heavy, optionally add an event-storming snapshot:
+
+- **Actors**
+- **Commands**
+- **Queries / read-model questions**
+- **Domain events**
+- **Policies**
+- **Aggregates / entities**
+- **Read models**
+- **Invariants**
+
+## Technique Fit Triage
+
+- Use ubiquitous language work when terminology is overloaded, inconsistent, or domain-specific.
+- Use bounded-context mapping when the request crosses ownership, capabilities, modules, integrations, or multiple domain models.
+- Use event storming when sequencing, actors, commands, policies, reactions, invariants, or read-model questions clarify behavior.
+- Skip any technique that does not reduce ambiguity for the current request.
+
+## Domain-Grill Mode
+
+Use rigorous domain-grill only at the selected depth. Challenge fuzzy plans by:
+
+- Comparing user language against existing docs, specs, code, and the current discovery handoff.
+- Proposing precise canonical terms when language is vague.
+- Testing boundaries with concrete lifecycle, ownership, failure, and translation scenarios.
+- Cross-checking claims against code and docs before accepting them as domain truth.
+- Asking who owns rules, lifecycle, language, and decisions instead of who owns the data location.
+- Treating `add a status`, `reuse the existing model`, `just sync the data`, `expose this field`, `put it in shared`, `add a flag`, and `use a common helper` as boundary-smell prompts.
+
+## Proposal Handoff Format
+
+When the plan is ready for proposal creation, hand off this summary:
+
+```markdown
+## Domain Discovery Summary
+- Primary problem: <one sentence>
+- Discovery depth: <direct|lightweight|bounded-context|rigorous domain-grill> because <trigger>
+- Business/domain capability: <capability distinct from Ito capability>
+- Primary bounded context: <context that owns the main behavior>
+- Supporting contexts: <other contexts involved, or none>
+- Model ownership: <who owns rules/lifecycle/language/decisions>
+- Canonical terms: <term -> definition>
+- Rejected aliases / overloaded terms: <alias or term -> guidance>
+- Bounded contexts: <name -> responsibility, ownership, owned language>
+- Owned concepts changed: <rules/lifecycle/language/decisions>
+- External concepts referenced: <borrowed concepts from other contexts>
+- Cross-context relationships: <pattern or provisional/unknown, published language, translation boundary>
+- Translation boundaries: <where external concepts become local concepts>
+- Consistency requirements: <strong/eventual, conflict owner, stale-data impact, unavailable-downstream behavior>
+- Technique fit: <selected and skipped DDD techniques with rationale>
+- Event-storming snapshot: <actors, commands, queries, events, policies, aggregates, read models, invariants if used>
+- Candidate Ito capabilities: <proposal/spec capability names>
+- Open questions: <unresolved vocabulary, ownership, policy, or sequencing questions>
+- Evidence checked: <specs/files/docs/ADRs consulted>
+- Proposed documentation updates: <CONTEXT.md, CONTEXT-MAP.md, ADR candidates, or none>
+```
+
+Then route to `ito-proposal-intake` or `ito-proposal` using this handoff as shared context. Do not restart discovery unless a blocking ambiguity remains.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-proposal-intake/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-proposal-intake/SKILL.md
@@ -33,12 +33,41 @@ Clarify only the missing pieces needed to route the request safely:
 - Is the blast radius local, cross-cutting, or architectural?
 - Does existing code or an existing spec already define the intended behavior?
 
+## Domain Discovery Gate
+
+Before recommending a schema, choose the least sufficient discovery depth:
+
+| Depth | Use When | Outcome |
+| --- | --- | --- |
+| Direct / skip | Routine, low-risk, one-context work with clear vocabulary | Continue with normal intake. |
+| Lightweight discovery | Terms are fuzzy, overloaded, or domain-specific | Resolve canonical terms, rejected aliases, and open vocabulary questions. |
+| Bounded-context discovery | Work crosses ownership, integrations, modules, capabilities, or domain models | Identify primary/supporting bounded contexts, model ownership, relationship pattern or `provisional/unknown`, and translation boundary. |
+| Rigorous domain-grill | User opts in, or work is high-impact, architectural, public-contract-changing, hard to reverse, policy-heavy, sequencing-heavy, or cross-context with unresolved ownership | Use evidence-backed, one-question-at-a-time domain grilling with recommended answers. |
+
+Clear cross-context work must use at least bounded-context discovery. Keep routine work on the fast path.
+
+When discovery is needed, capture this grammar before proposal scaffolding:
+
+- **Business/domain capability**: the business capability being changed, distinct from Ito capability names.
+- **Model ownership**: who owns the rules, lifecycle, language, and decisions; do not infer ownership from data, table, service, or file location alone.
+- **Ubiquitous language**: canonical terms, definitions, rejected aliases, overloaded terms, and unresolved language questions.
+- **Bounded contexts**: primary context, supporting contexts, responsibilities, owned language, and external concepts referenced.
+- **Relationship pattern**: customer/supplier, conformist, anti-corruption layer, shared kernel, separate ways, another explicit pattern, or `provisional/unknown`.
+- **Consistency requirements**: strong/eventual consistency, conflict owner, stale-data impact, and downstream-unavailable behavior when relevant.
+- **Technique fit**: selected and skipped DDD techniques with rationale.
+- **Evidence checked**: code, specs, context docs, ADRs, or prior plans consulted before asking the user.
+
+Use optional event-storming concepts when sequencing, policy, reactions, or invariants clarify behavior: actors, commands, queries, domain events, policies, aggregates/entities, read models, and invariants.
+
+In rigorous domain-grill mode, challenge fuzzy or boundary-smell requests like `add a status`, `reuse the existing model`, `just sync the data`, `expose this field`, `put it in shared`, `add a flag`, or `use a common helper`. Probe ownership, lifecycle, failure behavior, and translation boundaries with concrete scenarios.
+
 ## Schema Recommendation Rules
 
 - Recommend `minimalist` for bounded fixes and small, rigorous platform, tooling, CI, or infrastructure changes.
 - Recommend `tdd` for regression-oriented changes where reproducing the failure with a test is the safest starting point.
 - Recommend `spec-driven` for new capabilities, broad behavior changes, architecture work, or requests that remain ambiguous after intake.
 - If the request is event- or message-centric, consider `event-driven`.
+- If the request needs more discovery before any proposal is safe, route to `ito-plan` with the selected discovery depth instead of forcing a schema decision.
 
 ## Outcomes
 
@@ -48,7 +77,9 @@ End the intake with one of these outcomes:
    - Provide a concise summary and a recommended schema.
 2. **Needs `ito-brainstorming` first**
    - Use this when the user is still exploring solution shape rather than scoping a concrete change.
-3. **No proposal needed**
+3. **Needs `ito-plan` domain discovery first**
+   - Use this when the request is proposal-shaped but needs language, ownership, boundary, consistency, or event-storming discovery before scaffolding.
+4. **No proposal needed**
    - Use this for straightforward fixes or edits that should be handled directly.
 
 ## Handoff Format
@@ -63,8 +94,36 @@ When the change is ready for proposal creation, hand off this summary to the nex
 - Scope: <what is in>
 - Non-goals: <what is out>
 - Brownfield evidence: <specs/files/patterns, if relevant>
+- Domain discovery depth: <direct|lightweight|bounded-context|rigorous domain-grill>
+- Domain discovery summary: <business capability, primary context, model ownership, canonical terms, relationship pattern, consistency requirements, technique fit, open questions>
 - Recommended schema: <minimalist|tdd|spec-driven|event-driven>
 - Rationale: <why this schema fits>
+```
+
+If domain discovery has produced a full handoff, include it immediately after the intake summary:
+
+```markdown
+## Domain Discovery Summary
+- Primary problem: <one sentence>
+- Discovery depth: <direct|lightweight|bounded-context|rigorous domain-grill> because <trigger>
+- Business/domain capability: <capability distinct from Ito capability>
+- Primary bounded context: <context that owns the main behavior>
+- Supporting contexts: <other contexts involved, or none>
+- Model ownership: <who owns rules/lifecycle/language/decisions>
+- Canonical terms: <term -> definition>
+- Rejected aliases / overloaded terms: <alias or term -> guidance>
+- Bounded contexts: <name -> responsibility, ownership, owned language>
+- Owned concepts changed: <rules/lifecycle/language/decisions>
+- External concepts referenced: <borrowed concepts from other contexts>
+- Cross-context relationships: <pattern or provisional/unknown, published language, translation boundary>
+- Translation boundaries: <where external concepts become local concepts>
+- Consistency requirements: <strong/eventual, conflict owner, stale-data impact, unavailable-downstream behavior>
+- Technique fit: <selected and skipped DDD techniques with rationale>
+- Event-storming snapshot: <actors, commands, queries, events, policies, aggregates, read models, invariants if used>
+- Candidate Ito capabilities: <proposal/spec capability names>
+- Open questions: <unresolved vocabulary, ownership, policy, or sequencing questions>
+- Evidence checked: <specs/files/docs/ADRs consulted>
+- Proposed documentation updates: <CONTEXT.md, CONTEXT-MAP.md, ADR candidates, or none>
 ```
 
 Then continue with `ito-proposal` using that summary as the shared understanding. Do not restart discovery unless a blocking ambiguity remains.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -262,6 +262,7 @@ fn review_template_renders_conditional_sections() {
         id: &'static str,
         path: &'static str,
         present: bool,
+        optional: bool,
     }
 
     #[derive(Serialize)]
@@ -324,21 +325,25 @@ fn review_template_renders_conditional_sections() {
                 id: "proposal",
                 path: "/tmp/.ito/changes/000-01_test-change/proposal.md",
                 present: true,
+                optional: false,
             },
             Artifact {
                 id: "design",
                 path: "/tmp/.ito/changes/000-01_test-change/design.md",
                 present: false,
+                optional: true,
             },
             Artifact {
                 id: "tasks",
                 path: "/tmp/.ito/changes/000-01_test-change/tasks.md",
                 present: true,
+                optional: false,
             },
             Artifact {
                 id: "specs",
                 path: "/tmp/.ito/changes/000-01_test-change/specs",
                 present: true,
+                optional: false,
             },
         ],
         validation_issues: vec![ValidationIssue {

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -481,6 +481,9 @@ fn find_marker_index(content: &str, marker: &str, from_index: usize) -> Option<u
 }
 
 #[cfg(test)]
+mod agent_surface_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -15,9 +15,6 @@ use include_dir::{Dir, include_dir};
 /// Embedded agent definitions.
 pub mod agents;
 
-#[cfg(test)]
-mod agent_surface_tests;
-
 /// Embedded instruction artifacts.
 pub mod instructions;
 
@@ -661,9 +658,6 @@ mod tests {
             get_skill_file("ito-orchestrate/SKILL.md").expect("ito-orchestrate skill");
         let orchestrate = std::str::from_utf8(orchestrate).expect("utf8");
         assert!(orchestrate.starts_with("---\nname: ito-orchestrate\n"));
-        assert!(orchestrate.contains("ito agent instruction orchestrate"));
-        assert!(!orchestrate.contains("canonical default order"));
-        assert!(!orchestrate.contains(".ito/.state/orchestrate/runs"));
 
         let setup =
             get_skill_file("ito-orchestrate-setup/SKILL.md").expect("ito-orchestrate-setup skill");
@@ -674,8 +668,6 @@ mod tests {
             .expect("ito-orchestrator-workflow skill");
         let workflow = std::str::from_utf8(workflow).expect("utf8");
         assert!(workflow.starts_with("---\nname: ito-orchestrator-workflow\n"));
-        assert!(workflow.contains("repo-specific"));
-        assert!(!workflow.contains("Security-review: prioritize"));
 
         let commands = commands_files();
         assert!(
@@ -733,19 +725,6 @@ mod tests {
                     "expected {expected} in {harness:?} agent templates"
                 );
             }
-
-            let orchestrator = match harness {
-                Harness::Codex => "ito-orchestrator/SKILL.md",
-                Harness::OpenCode | Harness::ClaudeCode | Harness::GitHubCopilot | Harness::Pi => {
-                    "ito-orchestrator.md"
-                }
-            };
-            let (_, contents) = files
-                .iter()
-                .find(|(name, _)| *name == orchestrator)
-                .expect("orchestrator template");
-            let contents = std::str::from_utf8(contents).expect("orchestrator utf8");
-            assert!(contents.contains("ito agent instruction orchestrate"));
         }
     }
 
@@ -763,6 +742,16 @@ mod tests {
         let feature = get_skill_file("ito-feature/SKILL.md").expect("feature skill should exist");
         let feature_text = std::str::from_utf8(feature).expect("skill should be utf8");
         assert!(feature_text.starts_with("---\nname: ito-feature\n"));
+
+        let plan = get_skill_file("ito-plan/SKILL.md").expect("plan skill should exist");
+        let plan_text = std::str::from_utf8(plan).expect("skill should be utf8");
+        assert!(plan_text.starts_with("---\nname: ito-plan\n"));
+
+        let commands = commands_files();
+        assert!(
+            commands.iter().any(|f| f.relative_path == "ito-plan.md"),
+            "expected ito-plan command to be embedded"
+        );
     }
 
     #[test]
@@ -1052,53 +1041,6 @@ mod tests {
         assert!(
             violations.is_empty(),
             "agents missing `ito-` prefix: {violations:?}"
-        );
-    }
-
-    #[test]
-    fn every_shipped_agent_is_in_surface_inventory() {
-        use crate::agents::agent_surface_inventory;
-        use std::collections::BTreeSet;
-
-        let inventory = agent_surface_inventory();
-        let inventory_names: BTreeSet<&str> =
-            inventory.iter().map(|surface| surface.name).collect();
-        let mut asset_names: BTreeSet<String> = BTreeSet::new();
-
-        for harness_dir in AGENTS_DIR.dirs() {
-            for entry_file in harness_dir.files() {
-                let Some(name) = entry_file.path().file_name().and_then(|s| s.to_str()) else {
-                    continue;
-                };
-                let name = name
-                    .strip_suffix(".md")
-                    .or_else(|| name.strip_suffix(".md.j2"))
-                    .unwrap_or(name);
-                asset_names.insert(name.to_string());
-            }
-
-            for nested in harness_dir.dirs() {
-                let Some(name) = nested.path().file_name().and_then(|s| s.to_str()) else {
-                    continue;
-                };
-                asset_names.insert(name.to_string());
-            }
-        }
-
-        let missing_from_inventory: Vec<&str> = asset_names
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !inventory_names.contains(name))
-            .collect();
-        let missing_from_assets: Vec<&str> = inventory_names
-            .iter()
-            .copied()
-            .filter(|name| !asset_names.contains(*name))
-            .collect();
-
-        assert!(
-            missing_from_inventory.is_empty() && missing_from_assets.is_empty(),
-            "agent surface inventory mismatch — missing from inventory: {missing_from_inventory:?}; missing from assets: {missing_from_assets:?}"
         );
     }
 

--- a/ito-rs/crates/source-guide.md
+++ b/ito-rs/crates/source-guide.md
@@ -1,0 +1,37 @@
+# Source Guide: ito-rs/crates
+
+## Responsibility
+This directory contains all Rust workspace crates. Use this file to pick the right crate before opening deeper code.
+
+## Entry Points
+
+| Crate | Responsibility | Guide |
+|---|---|---|
+| `ito-cli` | CLI parsing, command dispatch, user-facing terminal behavior. | `ito-cli/source-guide.md` |
+| `ito-core` | Application use-cases, persistence adapters, validation, installers, orchestration. | `ito-core/source-guide.md` |
+| `ito-domain` | Domain entities, repository traits, pure status/traceability logic. | `ito-domain/source-guide.md` |
+| `ito-config` | Cascading configuration and invocation context. | `ito-config/source-guide.md` |
+| `ito-common` | Shared filesystem, path, ID, matching, and URL utilities. | `ito-common/source-guide.md` |
+| `ito-templates` | Embedded templates, skills, commands, schemas, and instruction rendering helpers. | `ito-templates/source-guide.md` |
+| `ito-backend` | Multi-tenant HTTP backend adapter. | `ito-backend/source-guide.md` |
+| `ito-web` | Browser UI and terminal adapter. | `ito-web/source-guide.md` |
+| `ito-logging` | Resilient append-only telemetry. | `ito-logging/source-guide.md` |
+| `ito-test-support` | Shared test helpers and fake repositories. | `ito-test-support/source-guide.md` |
+
+## Design
+- Prefer adding domain concepts to `ito-domain`, executable behavior to `ito-core`, and surface-specific wiring to adapter crates.
+- Template content should be embedded through `ito-templates`; installers live in `ito-core`.
+- Test-only helpers belong in `ito-test-support`, not production crates.
+
+## Flow
+1. Identify whether a change affects model shape, behavior, surface, or assets.
+2. Start in the matching crate guide.
+3. Follow upstream/downstream links before editing shared traits or public APIs.
+
+## Gotchas
+- `ito-cli` tests often exercise `ito-core` behavior end-to-end using the compiled binary.
+- `ito-core` is intentionally broad; prefer subsystem modules over adding logic to catch-all files.
+
+## Tests
+- Crate-scoped: `cargo test -p <crate>`.
+- End-to-end CLI behavior: `cargo test -p ito-cli --test <integration_test>`.

--- a/source-guide.md
+++ b/source-guide.md
@@ -1,0 +1,44 @@
+# Source Guide: Ito Workspace
+
+## Responsibility
+Ito is a Rust workspace for change-driven development workflows: proposals, specs, tasks, validation, worktrees, orchestration, backend sync, template installation, and web/backend adapters. This guide is an orientation map for agents; source code remains authoritative.
+
+## Entry Points
+- `Cargo.toml`: workspace membership and shared dependency versions.
+- `Makefile`: developer verification targets such as `make check`, `make test`, and release helpers.
+- `ito-rs/crates/ito-cli/src/main.rs`: CLI binary entrypoint.
+- `ito-rs/crates/ito-web/src/main.rs`: standalone web adapter binary.
+- `ito-rs/crates/*/source-guide.md`: crate-level atlas pages.
+
+## Design
+- `ito-domain` owns data shapes and traits.
+- `ito-core` owns use-cases, persistence adapters, installers, validation, orchestration, and workflow semantics.
+- `ito-cli`, `ito-web`, and `ito-backend` are adapters over `ito-core`.
+- `ito-config`, `ito-common`, `ito-templates`, `ito-logging`, and `ito-test-support` provide shared infrastructure.
+
+## Flow
+1. CLI args are parsed in `ito-cli` and routed to app handlers.
+2. App handlers compose configuration from `ito-config` and call `ito-core` use-cases.
+3. Core use-cases read/write repositories defined by `ito-domain` traits and implemented by filesystem, backend, or remote adapters.
+4. Template and instruction assets come from `ito-templates` and are installed or rendered by `ito-core`.
+5. Optional adapters expose the same behavior over HTTP (`ito-backend`) or a browser UI (`ito-web`).
+
+## Directory Summary
+
+| Directory | Responsibility | Guide |
+|---|---|---|
+| `ito-rs/` | Rust workspace source tree. | `ito-rs/source-guide.md` |
+| `ito-rs/crates/` | Crate-by-crate architecture index. | `ito-rs/crates/source-guide.md` |
+| `.ito/` | Ito workflow specs, changes, modules, prompts, and project config. | Ito instructions |
+
+
+## Gotchas
+- Main/control checkout is read-only for Ito change work; use a dedicated worktree.
+- `.ito/`, `.opencode/`, `.github/`, and `.codex/` contain Ito-managed files and may be overwritten by `ito init` / `ito update`.
+- `source-guide.md` files are orientation only. Verify behavior in source before editing.
+- Refresh `source-guide.json` after updating source guides so future agents can detect drift.
+
+## Tests
+- Prefer `make check` for broad verification.
+- Use targeted `cargo test -p <crate>` or integration-test filters for fast feedback.
+- The repo has a max-lines guardrail; touching already-large files can trigger `make check` failures.


### PR DESCRIPTION
## Summary
- add a DDD-oriented domain discovery lane with reusable discovery artifacts for spec-driven and event-driven workflows
- introduce opt-in validation rules for ubiquitous language, context boundaries, and domain documentation consistency
- update workflow docs, manifesto/instruction rendering, and review guidance to carry discovery outputs into proposal creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a domain discovery step with selectable depth levels and a “Discovery Handoff” format.
  * Introduced optional artifacts that don’t block completion and are rendered as optional in status output.
  * New validation rules: ubiquitous-language consistency, domain-documentation consistency, and context-boundary consistency.

* **Documentation**
  * Updated workflows, diagrams, templates, and agent guidance to include discovery, review checklists, and archival rules.

* **Tests**
  * Expanded test coverage for optional-artifact behavior and the new validation rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/withakay/ito/pull/240)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->