### PR TITLE
feat(worktrees): use worktrunk for worktree setup

### DIFF
--- a/ito-rs/crates/ito-core/src/audit/worktree.rs
+++ b/ito-rs/crates/ito-core/src/audit/worktree.rs
@@ -1,7 +1,7 @@
 //! Worktree discovery for audit event aggregation and streaming.
 //!
-//! Uses `git worktree list --porcelain` to enumerate all worktrees and
-//! resolves their routed audit stores.
+//! Uses worktree listing commands to enumerate all worktrees and resolves
+//! their routed audit stores.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -97,6 +97,10 @@ fn parse_worktree_list(output: &str) -> Vec<WorktreeInfo> {
 /// Used by Ralph to resolve the effective working directory for a change
 /// when worktree-based workflows are active.
 pub fn find_worktree_for_branch(branch: &str) -> Option<PathBuf> {
+    if let Some(path) = find_worktree_for_branch_with_worktrunk(branch) {
+        return Some(path);
+    }
+
     let output = std::process::Command::new("git")
         .args(["worktree", "list", "--porcelain"])
         .output()
@@ -108,6 +112,59 @@ pub fn find_worktree_for_branch(branch: &str) -> Option<PathBuf> {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     find_worktree_for_branch_in_output(&stdout, branch)
+}
+
+fn find_worktree_for_branch_with_worktrunk(branch: &str) -> Option<PathBuf> {
+    let output = std::process::Command::new("wt")
+        .args(["list", "--format=json"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    find_worktree_for_branch_in_worktrunk_json(&stdout, branch)
+}
+
+fn find_worktree_for_branch_in_worktrunk_json(output: &str, branch: &str) -> Option<PathBuf> {
+    let value: serde_json::Value = serde_json::from_str(output).ok()?;
+    let entries = value
+        .as_array()
+        .or_else(|| value.get("worktrees").and_then(serde_json::Value::as_array))?;
+
+    entries.iter().find_map(|entry| {
+        let is_bare = entry
+            .get("bare")
+            .or_else(|| entry.get("is_bare"))
+            .or_else(|| entry.get("isBare"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if is_bare {
+            return None;
+        }
+
+        let entry_branch = entry
+            .get("branch")
+            .or_else(|| entry.get("name"))
+            .and_then(serde_json::Value::as_str)
+            .and_then(normalize_branch_name)?;
+        if entry_branch != branch {
+            return None;
+        }
+
+        let path = entry
+            .get("path")
+            .or_else(|| entry.get("worktree"))
+            .or_else(|| entry.get("root"))
+            .and_then(serde_json::Value::as_str)?;
+        Some(PathBuf::from(path))
+    })
+}
+
+fn normalize_branch_name(branch: &str) -> Option<&str> {
+    branch.strip_prefix("refs/heads/").or(Some(branch))
 }
 
 /// Parse porcelain worktree output and find the path for a given branch name.
@@ -297,6 +354,34 @@ branch refs/heads/feature-b
         // Non-matching returns None
         let result = find_worktree_for_branch_in_output(output, "feature-c");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn ralph_worktree_prefers_worktrunk_json_match() {
+        let output = r#"[
+  {"path": "/home/user/ito-worktrees/002-16_ralph-worktree-awareness", "branch": "refs/heads/002-16_ralph-worktree-awareness"},
+  {"path": "/home/user/ito-worktrees/other", "branch": "other"}
+]"#;
+
+        let result =
+            find_worktree_for_branch_in_worktrunk_json(output, "002-16_ralph-worktree-awareness");
+        assert_eq!(
+            result,
+            Some(PathBuf::from(
+                "/home/user/ito-worktrees/002-16_ralph-worktree-awareness"
+            ))
+        );
+    }
+
+    #[test]
+    fn ralph_worktree_worktrunk_json_ignores_bare_entries() {
+        let output = r#"{"worktrees":[
+  {"path": "/home/user/project.git", "branch": "refs/heads/main", "bare": true},
+  {"path": "/home/user/ito-worktrees/main", "branch": "main", "bare": false}
+]}"#;
+
+        let result = find_worktree_for_branch_in_worktrunk_json(output, "main");
+        assert_eq!(result, Some(PathBuf::from("/home/user/ito-worktrees/main")));
     }
 
     #[test]

--- a/ito-rs/crates/ito-core/src/worktree_ensure.rs
+++ b/ito-rs/crates/ito-core/src/worktree_ensure.rs
@@ -127,11 +127,12 @@ pub(crate) fn ensure_worktree_with_runner(
         })?;
     }
 
-    // Create the git worktree.
+    // Create the Worktrunk-managed worktree.
     let default_branch = &config.worktrees.default_branch;
     create_change_worktree(
         runner,
         &env.project_root,
+        &env.ito_root,
         change_id,
         default_branch,
         &worktree_path,
@@ -262,76 +263,41 @@ fn validate_change_id(change_id: &str) -> CoreResult<()> {
     Ok(())
 }
 
-/// Check whether a git branch already exists in the repository.
-///
-/// Runs `git rev-parse --verify <branch>` and returns `true` when the exit
-/// code is 0 (branch exists), `false` when it is non-zero (branch absent).
-/// Any process-execution error is propagated as a [`CoreError`].
-fn branch_exists(
-    runner: &dyn ProcessRunner,
-    project_root: &Path,
-    branch: &str,
-) -> CoreResult<bool> {
-    let request = ProcessRequest::new("git")
-        .args(["rev-parse", "--verify", branch])
-        .current_dir(project_root);
-
-    let output = runner.run(&request).map_err(|err| {
-        CoreError::process(format!(
-            "Cannot check whether branch '{branch}' exists.\n\
-             Git command failed to run: {err}\n\
-             Fix: ensure git is installed and '{project_root}' is a git repository.",
-            project_root = project_root.display(),
-        ))
-    })?;
-
-    Ok(output.success)
-}
-
-/// Create a git worktree for a change.
-///
-/// Pre-checks whether the branch already exists using `git rev-parse --verify`
-/// to avoid relying on English-only git error message text.  When the branch
-/// exists, `git worktree add <path> <branch>` is used; when it does not,
-/// `git worktree add <path> -b <branch> <base_branch>` creates it.
+/// Create a Worktrunk-managed worktree for a change.
 fn create_change_worktree(
     runner: &dyn ProcessRunner,
     project_root: &Path,
+    ito_root: &Path,
     change_id: &str,
     base_branch: &str,
     target_path: &Path,
 ) -> CoreResult<()> {
-    let target_str = target_path.to_string_lossy();
+    let config_path = write_worktrunk_path_config(ito_root, target_path)?;
+    let config_arg = config_path.to_string_lossy().to_string();
+    let project_root_arg = project_root.to_string_lossy().to_string();
 
-    // Pre-check branch existence to choose the right `git worktree add` form.
-    let branch_already_exists = branch_exists(runner, project_root, change_id)?;
-
-    let request = if branch_already_exists {
-        // Branch exists — attach the new worktree to it without -b.
-        ProcessRequest::new("git")
-            .args(["worktree", "add", target_str.as_ref(), change_id])
-            .current_dir(project_root)
-    } else {
-        // Branch absent — create it from base_branch.
-        ProcessRequest::new("git")
-            .args([
-                "worktree",
-                "add",
-                target_str.as_ref(),
-                "-b",
-                change_id,
-                base_branch,
-            ])
-            .current_dir(project_root)
-    };
+    let request = ProcessRequest::new("wt")
+        .args([
+            "--config",
+            &config_arg,
+            "-C",
+            &project_root_arg,
+            "--yes",
+            "switch",
+            "--create",
+            change_id,
+            "--base",
+            base_branch,
+        ])
+        .current_dir(project_root);
 
     let output = runner.run(&request).map_err(|err| {
         CoreError::process(format!(
             "Cannot create worktree for change '{change_id}' at '{target}'.\n\
-             Git command failed to run: {err}\n\
-             Fix: ensure git is installed and '{project_root}' is a git repository.",
+             Worktrunk command failed to run: {err}\n\
+             Command context: wt switch --create {change_id} --base {base_branch}\n\
+             Fix: install Worktrunk and ensure `wt` is available on PATH, or create the worktree manually at the target path.",
             target = target_path.display(),
-            project_root = project_root.display(),
         ))
     })?;
 
@@ -349,12 +315,56 @@ fn create_change_worktree(
 
     Err(CoreError::process(format!(
         "Cannot create worktree for change '{change_id}' at '{target}'.\n\
-         Git reported: {detail}\n\
-         Fix: ensure the base branch '{base_branch}' exists and the target path \
-         does not already exist. If the branch is already checked out in another \
-         worktree, run `git worktree list` to inspect.",
+         Worktrunk reported: {detail}\n\
+         Command context: wt switch --create {change_id} --base {base_branch}\n\
+         Fix: ensure Worktrunk can access base branch '{base_branch}', the target path is free, and the local Worktrunk path config points at the Ito worktree root.",
         target = target_path.display(),
     )))
+}
+
+fn write_worktrunk_path_config(ito_root: &Path, target_path: &Path) -> CoreResult<PathBuf> {
+    let parent = target_path.parent().ok_or_else(|| {
+        CoreError::validation(format!(
+            "Cannot derive Worktrunk path config for '{}'.\n\
+             Fix: configure worktrees so the target path has a parent directory.",
+            target_path.display(),
+        ))
+    })?;
+
+    let config_dir = ito_root.join("worktrunk");
+    std::fs::create_dir_all(&config_dir).map_err(|err| {
+        CoreError::io(
+            format!(
+                "Cannot create Worktrunk config directory '{}'.\n\
+                 Fix: ensure the Ito directory is writable.",
+                config_dir.display(),
+            ),
+            err,
+        )
+    })?;
+
+    let config_path = config_dir.join("worktree-path.toml");
+    let template = parent.join("{{ branch | sanitize }}");
+    let contents = format!(
+        "worktree-path = \"{}\"\n",
+        template
+            .to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+    );
+
+    std::fs::write(&config_path, contents).map_err(|err| {
+        CoreError::io(
+            format!(
+                "Cannot write Worktrunk path config '{}'.\n\
+                 Fix: ensure the Ito directory is writable.",
+                config_path.display(),
+            ),
+            err,
+        )
+    })?;
+
+    Ok(config_path)
 }
 
 #[cfg(test)]

--- a/ito-rs/crates/ito-core/src/worktree_ensure_tests.rs
+++ b/ito-rs/crates/ito-core/src/worktree_ensure_tests.rs
@@ -191,43 +191,27 @@ fn ensure_creates_worktree_when_absent() {
     let fake_gitdir = worktrees_root.join("my-change.git");
     let paths = make_enabled_paths(worktrees_root.clone(), main_root);
 
-    // Runner that handles two calls:
-    //   1. `git rev-parse --verify my-change` — returns failure (branch absent).
-    //   2. `git worktree add <path> -b my-change main` — creates the directory.
     struct CreatingRunner {
         target_path: PathBuf,
         fake_gitdir: PathBuf,
-        call_count: std::cell::Cell<usize>,
+        calls: RefCell<Vec<(String, Vec<String>)>>,
     }
 
     impl ProcessRunner for CreatingRunner {
-        fn run(&self, _request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
-            let count = self.call_count.get();
-            self.call_count.set(count + 1);
-            match count {
-                // First call: rev-parse — branch does not exist.
-                0 => Ok(ProcessOutput {
-                    exit_code: 1,
-                    success: false,
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    timed_out: false,
-                }),
-                // Second call: worktree add — create the directory + .git file.
-                _ => {
-                    std::fs::create_dir_all(&self.target_path).unwrap();
-                    std::fs::create_dir_all(&self.fake_gitdir).unwrap();
-                    std::fs::write(self.target_path.join(".git"), "gitdir: ../my-change.git")
-                        .unwrap();
-                    Ok(ProcessOutput {
-                        exit_code: 0,
-                        success: true,
-                        stdout: String::new(),
-                        stderr: String::new(),
-                        timed_out: false,
-                    })
-                }
-            }
+        fn run(&self, request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
+            self.calls
+                .borrow_mut()
+                .push((request.program.clone(), request.args.clone()));
+            std::fs::create_dir_all(&self.target_path).unwrap();
+            std::fs::create_dir_all(&self.fake_gitdir).unwrap();
+            std::fs::write(self.target_path.join(".git"), "gitdir: ../my-change.git").unwrap();
+            Ok(ProcessOutput {
+                exit_code: 0,
+                success: true,
+                stdout: self.target_path.display().to_string(),
+                stderr: String::new(),
+                timed_out: false,
+            })
         }
 
         fn run_with_timeout(
@@ -242,7 +226,7 @@ fn ensure_creates_worktree_when_absent() {
     let runner = CreatingRunner {
         target_path: expected.clone(),
         fake_gitdir: fake_gitdir.clone(),
-        call_count: std::cell::Cell::new(0),
+        calls: RefCell::new(Vec::new()),
     };
 
     let result =
@@ -258,6 +242,18 @@ fn ensure_creates_worktree_when_absent() {
         !expected.join(INIT_MARKER).exists(),
         "marker must not appear in working tree"
     );
+    let calls = runner.calls.borrow();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].0, "wt");
+    assert!(calls[0].1.contains(&"switch".to_string()));
+    assert!(calls[0].1.contains(&"--create".to_string()));
+    assert!(calls[0].1.contains(&"my-change".to_string()));
+    assert!(calls[0].1.contains(&"--base".to_string()));
+    assert!(calls[0].1.contains(&"main".to_string()));
+    let config_path = project_root.join(".ito/worktrunk/worktree-path.toml");
+    let config = std::fs::read_to_string(config_path).unwrap();
+    assert!(config.contains("ito-worktrees"));
+    assert!(config.contains("{{ branch | sanitize }}"));
 }
 
 #[test]
@@ -280,41 +276,23 @@ fn ensure_with_include_files_copies_them() {
     let fake_gitdir = worktrees_root.join("my-change.git");
     let paths = make_enabled_paths(worktrees_root, main_root.clone());
 
-    // Runner that handles two calls:
-    //   1. `git rev-parse --verify my-change` — branch absent (exit 1).
-    //   2. `git worktree add ...` — creates the directory + .git file.
     struct CreatingRunner {
         target_path: PathBuf,
         fake_gitdir: PathBuf,
-        call_count: std::cell::Cell<usize>,
     }
 
     impl ProcessRunner for CreatingRunner {
         fn run(&self, _request: &ProcessRequest) -> Result<ProcessOutput, ProcessExecutionError> {
-            let count = self.call_count.get();
-            self.call_count.set(count + 1);
-            match count {
-                0 => Ok(ProcessOutput {
-                    exit_code: 1,
-                    success: false,
-                    stdout: String::new(),
-                    stderr: String::new(),
-                    timed_out: false,
-                }),
-                _ => {
-                    std::fs::create_dir_all(&self.target_path).unwrap();
-                    std::fs::create_dir_all(&self.fake_gitdir).unwrap();
-                    std::fs::write(self.target_path.join(".git"), "gitdir: ../my-change.git")
-                        .unwrap();
-                    Ok(ProcessOutput {
-                        exit_code: 0,
-                        success: true,
-                        stdout: String::new(),
-                        stderr: String::new(),
-                        timed_out: false,
-                    })
-                }
-            }
+            std::fs::create_dir_all(&self.target_path).unwrap();
+            std::fs::create_dir_all(&self.fake_gitdir).unwrap();
+            std::fs::write(self.target_path.join(".git"), "gitdir: ../my-change.git").unwrap();
+            Ok(ProcessOutput {
+                exit_code: 0,
+                success: true,
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+            })
         }
 
         fn run_with_timeout(
@@ -329,7 +307,6 @@ fn ensure_with_include_files_copies_them() {
     let runner = CreatingRunner {
         target_path: change_wt_path,
         fake_gitdir,
-        call_count: std::cell::Cell::new(0),
     };
 
     let result =
@@ -344,7 +321,7 @@ fn ensure_with_include_files_copies_them() {
 }
 
 #[test]
-fn ensure_git_failure_returns_error() {
+fn ensure_worktrunk_failure_returns_error() {
     let tmp = tempfile::tempdir().unwrap();
     let project_root = tmp.path();
     let worktrees_root = project_root.join("ito-worktrees");
@@ -354,17 +331,13 @@ fn ensure_git_failure_returns_error() {
     let config = make_embedded_config();
     let env = make_env(project_root);
     let paths = make_enabled_paths(worktrees_root, main_root);
-    // Two outputs are needed:
-    //   1. `git rev-parse --verify my-change` — branch absent (exit 1).
-    //   2. `git worktree add ... -b my-change main` — git error (exit 1).
-    let runner = StubRunner::with_outputs(vec![
-        fail_output(""),
-        fail_output("fatal: not a git repository"),
-    ]);
+    let runner = StubRunner::with_outputs(vec![fail_output("path occupied")]);
 
     let result =
         ensure_worktree_with_runner(&runner, "my-change", &config, &env, &paths, project_root);
     assert!(result.is_err());
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("my-change"));
+    assert!(err_msg.contains("Worktrunk reported"));
+    assert!(err_msg.contains("path occupied"));
 }

--- a/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
@@ -32,10 +32,16 @@ Rules:
 
 - Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
 - The main worktree is the only worktree that may check out `{{ default_branch }}`; `{{ default_branch }}` must only ever be checked out in the main worktree.
-- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no change ID exists yet, create a temporary proposal worktree, create the change there, then switch to the final change worktree before editing generated artifacts.
+- Before any write operation, create or switch to a dedicated change worktree with Worktrunk (`wt`) for that change. If no change ID exists yet, create a temporary proposal worktree, create the change there, then switch to the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse one worktree for two changes.
 - If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+
+Worktrunk path configuration for Ito-managed worktrees:
+
+```toml
+worktree-path = "<ito-worktrees-root>/{% raw %}{{ branch | sanitize }}{% endraw %}"
+```
 
 {% if strategy == "checkout_subdir" %}
 In-repo worktrees live under:
@@ -48,7 +54,7 @@ Create one with:
 
 ```bash
 mkdir -p ".{{ layout_dir_name }}"
-git worktree add ".{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 {% elif strategy == "checkout_siblings" %}
 Sibling-directory worktrees live under:
@@ -61,7 +67,7 @@ Create one with:
 
 ```bash
 mkdir -p "../<project-name>-{{ layout_dir_name }}"
-git worktree add "../<project-name>-{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 {% elif strategy == "bare_control_siblings" %}
 Bare/control layout:
@@ -79,7 +85,7 @@ Create one with:
 
 ```bash
 mkdir -p "../{{ layout_dir_name }}"
-git worktree add "../{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 
 Always branch new change worktrees from `{{ default_branch }}`. Do not create them from the bare/control repo placeholder `HEAD`.

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/apply.md.j2
@@ -94,11 +94,11 @@ if [ ! -d "$CHANGE_DIR" ]; then
 {% if worktree.strategy == "bare_control_siblings" %}
   PROJECT_ROOT="$(ito path project-root)"
   mkdir -p "$(ito path worktrees-root)"
-  git -C "$PROJECT_ROOT" worktree add "$CHANGE_DIR" -b "$CHANGE_NAME" "{{ worktree.default_branch }}"
+  (cd "$PROJECT_ROOT" && WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "$CHANGE_NAME" --base "{{ worktree.default_branch }}")
 {% else %}
   WORKTREE_ROOT="$(ito path worktree-root)"
   mkdir -p "$(ito path worktrees-root)"
-  git -C "$WORKTREE_ROOT" worktree add "$CHANGE_DIR" -b "$CHANGE_NAME" "{{ worktree.default_branch }}"
+  (cd "$WORKTREE_ROOT" && WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "$CHANGE_NAME" --base "{{ worktree.default_branch }}")
 {% endif %}
 fi
 

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -193,7 +193,7 @@ Before running any command that writes proposal artifacts, create and use a **ne
 ```bash
 {% if worktree is defined and worktree.enabled %}
 # If the final change ID is not known yet, create a temporary proposal worktree first.
-git worktree add "../{{ worktree.layout_dir_name | default(value="ito-worktrees") }}/proposal-<short-name>" -b "proposal-<short-name>" {{ worktree.default_branch | default(value="main") }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "proposal-<short-name>" --base {{ worktree.default_branch | default(value="main") }}
 cd "../{{ worktree.layout_dir_name | default(value="ito-worktrees") }}/proposal-<short-name>"
 
 {% endif %}

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/worktrees.md.j2
@@ -84,7 +84,7 @@ LAYOUT_DIR_NAME='{{ worktree.layout_dir_name | replace("'", "'\"'\"'") }}'
 WORKTREES_IGNORE="${LAYOUT_DIR_NAME%/}/"
 grep -qxF "$WORKTREES_IGNORE" "$GITIGNORE_PATH" 2>/dev/null || printf '%s\n' "$WORKTREES_IGNORE" >> "$GITIGNORE_PATH"
 
-git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}" "{{ worktree.default_branch }}"
+WORKTRUNK_WORKTREE_PATH="$WORKTREES_ROOT/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "${BRANCH_NAME}" --base "{{ worktree.default_branch }}"
 ```
 {% elif worktree.strategy == "checkout_siblings" %}
 #### Strategy: `checkout_siblings`
@@ -103,7 +103,7 @@ WORKTREE_ROOT="$(ito path worktree-root)"
 WORKTREES_ROOT="$(ito path worktrees-root)"
 mkdir -p "$WORKTREES_ROOT"
 
-git -C "$WORKTREE_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}" "{{ worktree.default_branch }}"
+WORKTRUNK_WORKTREE_PATH="$WORKTREES_ROOT/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "${BRANCH_NAME}" --base "{{ worktree.default_branch }}"
 ```
 {% elif worktree.strategy == "bare_control_siblings" %}
 #### Strategy: `bare_control_siblings`
@@ -116,7 +116,7 @@ Bare repo root: `{{ worktree.project_root }}`
 Worktree root: `{{ worktree.worktree_root }}`
 {% endif %}
 
-Run git worktree commands against the bare/control root, but create each change worktree from `{{ worktree.default_branch }}` rather than the bare placeholder `HEAD`.
+Run Worktrunk from the bare/control root, and create each change worktree from `{{ worktree.default_branch }}` rather than the bare placeholder `HEAD`.
 
 ```bash
 BRANCH_NAME="<full-change-id>"
@@ -124,7 +124,8 @@ PROJECT_ROOT="$(ito path project-root)"
 WORKTREES_ROOT="$(ito path worktrees-root)"
 mkdir -p "$WORKTREES_ROOT"
 
-git -C "$PROJECT_ROOT" worktree add "$WORKTREES_ROOT/${BRANCH_NAME}" -b "${BRANCH_NAME}" "{{ worktree.default_branch }}"
+cd "$PROJECT_ROOT"
+WORKTRUNK_WORKTREE_PATH="$WORKTREES_ROOT/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create "${BRANCH_NAME}" --base "{{ worktree.default_branch }}"
 ```
 {% endif %}
 

--- a/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-using-git-worktrees/SKILL.md
@@ -19,10 +19,16 @@ Use isolated worktrees for change work so the main/control checkout stays clean.
 
 - Treat the main/control checkout (the shared default-branch checkout, or the control checkout in a bare/control layout) as read-only. Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work.
 - The main worktree is the only worktree that may check out `{{ default_branch }}`; `{{ default_branch }}` must only ever be checked out in the main worktree.
-- Before any write operation, create a dedicated change worktree or move into the existing worktree for that change. If no change ID exists yet, create a temporary proposal worktree, create the change there, then switch to the final change worktree before editing generated artifacts.
+- Before any write operation, create or switch to a dedicated change worktree with Worktrunk (`wt`) for that change. If no change ID exists yet, create a temporary proposal worktree, create the change there, then switch to the final change worktree before editing generated artifacts.
 - Use the full change ID as the branch and primary worktree directory name, including module/sub-module prefixes such as `012-06_example-change`.
 - Do not reuse one worktree for two changes.
 - If one change needs multiple worktrees, prefix each extra worktree and branch with the full change ID, then add a suffix such as `012-06_example-change-review`.
+
+Worktrunk path configuration for Ito-managed worktrees:
+
+```toml
+worktree-path = "<ito-worktrees-root>/{% raw %}{{ branch | sanitize }}{% endraw %}"
+```
 
 ## Layout
 
@@ -37,7 +43,7 @@ Create one with:
 
 ```bash
 mkdir -p ".{{ layout_dir_name }}"
-git worktree add ".{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 {% elif strategy == "checkout_siblings" %}
 Worktrees live under a sibling directory:
@@ -50,7 +56,7 @@ Create one with:
 
 ```bash
 mkdir -p "../<project-name>-{{ layout_dir_name }}"
-git worktree add "../<project-name>-{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 {% elif strategy == "bare_control_siblings" %}
 Worktrees live under the bare/control layout:
@@ -65,7 +71,7 @@ Create one with:
 
 ```bash
 mkdir -p "../{{ layout_dir_name }}"
-git worktree add "../{{ layout_dir_name }}/<full-change-id>" -b <full-change-id> {{ default_branch }}
+WORKTRUNK_WORKTREE_PATH="$(ito path worktrees-root)/{% raw %}{{ branch | sanitize }}{% endraw %}" wt switch --create <full-change-id> --base {{ default_branch }}
 ```
 
 Always branch from `{{ default_branch }}`. Never use the bare/control repo placeholder `HEAD` as the checkout source.

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -430,7 +430,7 @@ fn worktrees_template_bare_control_siblings_branches_from_default_branch() {
     );
     assert!(out.contains("Do not reuse one worktree for two changes"));
     assert!(out.contains(
-        "git -C \"$PROJECT_ROOT\" worktree add \"$WORKTREES_ROOT/${BRANCH_NAME}\" -b \"${BRANCH_NAME}\" \"develop\""
+        "WORKTRUNK_WORKTREE_PATH=\"$WORKTREES_ROOT/{{ branch | sanitize }}\" wt switch --create \"${BRANCH_NAME}\" --base \"develop\""
     ));
 }
 
@@ -593,7 +593,7 @@ fn apply_template_bare_control_siblings_branches_from_default_branch() {
         "Additional worktrees for this same change must start with `000-01_test-change`"
     ));
     assert!(out.contains(
-        "git -C \"$PROJECT_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
+        "WORKTRUNK_WORKTREE_PATH=\"$(ito path worktrees-root)/{{ branch | sanitize }}\" wt switch --create \"$CHANGE_NAME\" --base \"develop\""
     ));
     assert!(out.contains("does **not** sync coordination state by default"));
     assert!(out.contains("ito agent instruction apply --change <id> --sync"));
@@ -720,7 +720,7 @@ fn apply_template_checkout_subdir_branches_from_default_branch() {
     assert_change_worktree_guardrails(&out);
     assert!(out.contains("Default branch: `develop`"));
     assert!(out.contains(
-        "git -C \"$WORKTREE_ROOT\" worktree add \"$CHANGE_DIR\" -b \"$CHANGE_NAME\" \"develop\""
+        "WORKTRUNK_WORKTREE_PATH=\"$(ito path worktrees-root)/{{ branch | sanitize }}\" wt switch --create \"$CHANGE_NAME\" --base \"develop\""
     ));
 }
 

--- a/ito-rs/crates/ito-templates/src/project_templates.rs
+++ b/ito-rs/crates/ito-templates/src/project_templates.rs
@@ -102,7 +102,7 @@ mod tests {
     const READ_ONLY_MAIN_RULE: &str = "Treat the main/control checkout";
     const MAIN_BRANCH_EXCLUSIVE_RULE: &str =
         "The main worktree is the only worktree that may check out";
-    const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create a dedicated change worktree or move into the existing worktree for that change";
+    const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create or switch to a dedicated change worktree with Worktrunk";
     const NO_MAIN_WRITE_RULE: &str = "Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work";
 
     fn assert_main_worktree_guardrails(text: &str) {
@@ -110,6 +110,12 @@ mod tests {
         assert!(text.contains(MAIN_BRANCH_EXCLUSIVE_RULE));
         assert!(text.contains(BEFORE_WRITE_WORKTREE_RULE));
         assert!(text.contains(NO_MAIN_WRITE_RULE));
+    }
+
+    fn assert_worktrunk_command(text: &str, default_branch: &str) {
+        assert!(text.contains(&format!(
+            "WORKTRUNK_WORKTREE_PATH=\"$(ito path worktrees-root)/{{{{ branch | sanitize }}}}\" wt switch --create <full-change-id> --base {default_branch}"
+        )));
     }
 
     #[test]
@@ -205,9 +211,7 @@ mod tests {
             )
         );
         assert!(text.contains("Do not reuse one worktree for two changes"));
-        assert!(text.contains(
-            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-        ));
+        assert_worktrunk_command(&text, "main");
         assert!(
             text.contains(".ito-worktrees/<full-change-id>/"),
             "should contain repo-relative worktree path"
@@ -244,9 +248,7 @@ mod tests {
             )
         );
         assert!(text.contains("Do not reuse one worktree for two changes"));
-        assert!(text.contains(
-            "git worktree add \"../<project-name>-worktrees/<full-change-id>\" -b <full-change-id> develop"
-        ));
+        assert_worktrunk_command(&text, "develop");
         assert!(
             text.contains("../<project-name>-worktrees/<full-change-id>/"),
             "should contain repo-relative sibling worktree path"
@@ -285,9 +287,7 @@ mod tests {
         assert!(text.contains("Do not reuse one worktree for two changes"));
         assert!(text.contains(".bare/"));
         assert!(text.contains("ito-worktrees/"));
-        assert!(text.contains(
-            "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-        ));
+        assert_worktrunk_command(&text, "main");
         assert!(text.contains("Do not create them from the bare/control repo placeholder `HEAD`"));
         let layout_line = text
             .lines()

--- a/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
+++ b/ito-rs/crates/ito-templates/tests/worktree_template_rendering.rs
@@ -9,7 +9,8 @@ use ito_templates::project_templates::{WorktreeTemplateContext, render_project_t
 const READ_ONLY_MAIN_RULE: &str = "Treat the main/control checkout";
 const MAIN_BRANCH_EXCLUSIVE_RULE: &str =
     "The main worktree is the only worktree that may check out";
-const BEFORE_WRITE_WORKTREE_RULE: &str = "Before any write operation, create a dedicated change worktree or move into the existing worktree for that change";
+const BEFORE_WRITE_WORKTREE_RULE: &str =
+    "Before any write operation, create or switch to a dedicated change worktree with Worktrunk";
 const NO_MAIN_WRITE_RULE: &str = "Do not write there: no proposal artifacts, code edits, documentation edits, generated asset updates, commits, or implementation work";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +113,18 @@ fn assert_no_discovery_heuristics(text: &str, label: &str) {
             "{label}: should not contain discovery heuristic '{heuristic}'"
         );
     }
+}
+
+fn assert_no_unrendered_jinja(text: &str) {
+    let text = text.replace("{{ branch | sanitize }}", "");
+    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert!(!text.contains("{%"), "should not contain raw jinja blocks");
+}
+
+fn assert_worktrunk_command(text: &str, default_branch: &str) {
+    assert!(text.contains(&format!(
+        "WORKTRUNK_WORKTREE_PATH=\"$(ito path worktrees-root)/{{{{ branch | sanitize }}}}\" wt switch --create <full-change-id> --base {default_branch}"
+    )));
 }
 
 // ---------------------------------------------------------------------------
@@ -217,7 +230,7 @@ fn disabled_ctx() -> WorktreeTemplateContext {
 /// Verifies that AGENTS.md renders appropriate worktree instructions and paths for the `checkout_subdir` strategy.
 ///
 /// Ensures the rendered text includes the "Worktree Workflow" section, the configured strategy label,
-/// a repository-relative `.ito-worktrees/<full-change-id>/` worktree path and the corresponding `git worktree add` example,
+/// a repository-relative `.ito-worktrees/<full-change-id>/` worktree path and the corresponding Worktrunk command,
 /// and that it does not contain raw template syntax, discovery heuristics, or an embedded absolute project root.
 ///
 /// # Examples
@@ -235,17 +248,13 @@ fn agents_md_checkout_subdir() {
 
     assert!(text.contains("## Worktree Workflow"));
     assert!(text.contains("**Strategy:** `checkout_subdir`"));
-    assert!(
-        text.contains(
-            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-        )
-    );
+    assert_worktrunk_command(&text, "main");
     assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
     assert!(text.contains("Do not reuse one worktree for two changes"));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "agents_md_checkout_subdir");
     assert!(
         text.contains(".ito-worktrees/<full-change-id>/"),
@@ -265,10 +274,8 @@ fn agents_md_checkout_siblings() {
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
     assert!(text.contains("Do not reuse one worktree for two changes"));
-    assert!(text.contains(
-        "git worktree add \"../<project-name>-wt/<full-change-id>\" -b <full-change-id> develop"
-    ));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_worktrunk_command(&text, "develop");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "agents_md_checkout_siblings");
     assert!(
         text.contains("../<project-name>-wt/<full-change-id>/"),
@@ -304,11 +311,9 @@ fn agents_md_bare_control_siblings() {
     assert!(text.contains("Do not reuse one worktree for two changes"));
     assert!(text.contains(".bare/"));
     assert!(text.contains("ito-worktrees/"));
-    assert!(text.contains(
-        "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-    ));
+    assert_worktrunk_command(&text, "main");
     assert!(text.contains("Do not create them from the bare/control repo placeholder `HEAD`"));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "agents_md_bare_control_siblings");
     let layout_line = text
         .lines()
@@ -327,7 +332,7 @@ fn agents_md_disabled() {
 
     assert!(text.contains("Worktrees are not configured for this project."));
     assert!(text.contains("Do NOT create git worktrees by default."));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "agents_md_disabled");
 }
 
@@ -341,17 +346,13 @@ fn skill_checkout_subdir() {
     let text = render_text(skill_md_bytes(), &ctx);
 
     assert!(text.contains("**Configured strategy:** `checkout_subdir`"));
-    assert!(
-        text.contains(
-            "git worktree add \".ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-        )
-    );
+    assert_worktrunk_command(&text, "main");
     assert_main_worktree_guardrails(&text);
     assert!(
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
     assert!(text.contains("Do not reuse one worktree for two changes"));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "skill_checkout_subdir");
     assert_no_absolute_project_root(&text, &ctx.project_root, "skill_checkout_subdir");
 }
@@ -367,10 +368,8 @@ fn skill_checkout_siblings() {
         text.contains("Use the full change ID as the branch and primary worktree directory name")
     );
     assert!(text.contains("Do not reuse one worktree for two changes"));
-    assert!(text.contains(
-        "git worktree add \"../<project-name>-wt/<full-change-id>\" -b <full-change-id> develop"
-    ));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_worktrunk_command(&text, "develop");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "skill_checkout_siblings");
     assert_no_absolute_project_root(&text, &ctx.project_root, "skill_checkout_siblings");
 }
@@ -387,7 +386,7 @@ fn skill_checkout_siblings() {
 /// let text = render_text(skill_md_bytes(), &ctx);
 /// assert!(text.contains("**Configured strategy:** `bare_control_siblings`"));
 /// assert!(text.contains("ito-worktrees/"));
-/// assert!(!text.contains("{{"));
+/// assert_no_unrendered_jinja(&text);
 /// assert_no_discovery_heuristics(&text, "skill_bare_control_siblings");
 /// assert_no_absolute_project_root(&text, &ctx.project_root, "skill_bare_control_siblings");
 /// ```
@@ -403,13 +402,11 @@ fn skill_bare_control_siblings() {
     );
     assert!(text.contains("Do not reuse one worktree for two changes"));
     assert!(text.contains("ito-worktrees/"));
-    assert!(text.contains(
-        "git worktree add \"../ito-worktrees/<full-change-id>\" -b <full-change-id> main"
-    ));
+    assert_worktrunk_command(&text, "main");
     assert!(
         text.contains("Never use the bare/control repo placeholder `HEAD` as the checkout source")
     );
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "skill_bare_control_siblings");
     assert_no_absolute_project_root(&text, &ctx.project_root, "skill_bare_control_siblings");
 }
@@ -420,6 +417,6 @@ fn skill_disabled() {
 
     assert!(text.contains("Worktrees are not configured for this project."));
     assert!(text.contains("Work in the current checkout."));
-    assert!(!text.contains("{{"), "should not contain raw jinja");
+    assert_no_unrendered_jinja(&text);
     assert_no_discovery_heuristics(&text, "skill_disabled");
 }


### PR DESCRIPTION
## Summary
- Replaces raw `git worktree add` setup with Worktrunk-backed worktree creation.
- Updates worktree guidance templates for Worktrunk flow.
- Adds Worktrunk JSON lookup for Ralph worktree discovery with Git porcelain fallback.

## Verification
- `ito tasks status 012-08_replace-raw-git-worktrees-with-worktrunk` shows 7/7 complete.
- `ito validate 012-08_replace-raw-git-worktrees-with-worktrunk --strict` passed.
- Focused worktree, Ralph worktree, template rendering, and init activation tests passed.
- `make check` reaches Rust gates but this repo currently has pre-existing markdownlint baseline failures in archived docs.