### PR TITLE
feat(schemas): embed openspec schema metadata

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,37 @@
+# Third-Party Notices
+
+## OpenSpec custom schemas
+
+Ito vendors selected schema assets from the OpenSpec custom schemas repository:
+
+- Project: `intent-driven-dev/openspec-schemas`
+- Source: https://github.com/intent-driven-dev/openspec-schemas
+- Pinned commit: `7cff0a6210714631baceee1e8effc58c18d5f107`
+- Vendored schemas: `minimalist`, `event-driven`
+- License: MIT
+
+The upstream MIT license follows.
+
+```text
+MIT License
+
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -75,6 +75,23 @@ Merge semantics:
 
 ## Common Settings
 
+### Workflow Schemas
+
+Ito ships embedded workflow schemas that can be used without installation:
+
+- `spec-driven`: full proposal, specs, design, and tasks workflow.
+- `minimalist`: OpenSpec-derived lightweight specs and tasks workflow.
+- `event-driven`: OpenSpec-derived event-storming, event-modeling, specs, design, AsyncAPI, and tasks workflow.
+- `tdd`: test-first workflow.
+
+Project schemas under `.ito/templates/schemas/<name>/schema.yaml` take precedence over user-level schemas, and user-level schemas take precedence over embedded schemas. Export embedded schemas with:
+
+```bash
+ito templates schemas export --to .ito/templates/schemas
+```
+
+The embedded OpenSpec-derived schemas include Ito-authored `validation.yaml` files. They perform presence checks and task tracking validation, and emit an informational manual semantic-validation note because Ito does not yet implement full OpenSpec semantic validation for those workflows.
+
 ### Worktrees
 
 Worktree behavior is controlled by the `worktrees` object.

--- a/ito-rs/crates/ito-cli/tests/templates_schemas_export.rs
+++ b/ito-rs/crates/ito-cli/tests/templates_schemas_export.rs
@@ -41,6 +41,12 @@ fn templates_schemas_export_writes_embedded_files() {
             "{schema} should export validation.yaml when bundled"
         );
     }
+    for schema in ["minimalist", "event-driven"] {
+        assert!(
+            target.join(schema).join("UPSTREAM.md").exists(),
+            "{schema} should export upstream attribution metadata"
+        );
+    }
 }
 
 /// Ensures exporting embedded template schemas does not overwrite existing files unless `--force` is used, and that using `--force` restores embedded defaults.

--- a/ito-rs/crates/ito-core/src/templates/types.rs
+++ b/ito-rs/crates/ito-core/src/templates/types.rs
@@ -464,6 +464,9 @@ pub struct ValidationYaml {
     /// Validation schema version.
     pub version: u32,
     #[serde(default)]
+    /// Optional informational note emitted when semantic validation remains manual.
+    pub manual_semantic_validation_note: Option<String>,
+    #[serde(default)]
     /// Default rules applied when per-artifact config is omitted.
     pub defaults: ValidationDefaultsYaml,
     #[serde(default)]
@@ -582,6 +585,7 @@ mod tests {
     fn validation_yaml_parses_minimal_config() {
         let src = r#"
 version: 1
+manual_semantic_validation_note: Semantic validation is manual.
 artifacts:
   specs:
     required: true
@@ -594,6 +598,10 @@ tracking:
 
         let parsed: super::ValidationYaml = serde_yaml::from_str(src).expect("parse validation");
         assert_eq!(parsed.version, 1);
+        assert_eq!(
+            parsed.manual_semantic_validation_note.as_deref(),
+            Some("Semantic validation is manual.")
+        );
         assert_eq!(parsed.artifacts.len(), 1);
         assert!(parsed.artifacts.get("specs").expect("specs").required);
         assert_eq!(

--- a/ito-rs/crates/ito-core/src/validate/mod.rs
+++ b/ito-rs/crates/ito-core/src/validate/mod.rs
@@ -383,6 +383,10 @@ fn validate_change_against_schema_validation(
 ) -> CoreResult<()> {
     let change_dir = paths::change_dir(ito_path, change_id);
 
+    if let Some(note) = validation.manual_semantic_validation_note.as_deref() {
+        rep.push(info("schema.validation.manual", note));
+    }
+
     let missing_level = validation
         .defaults
         .missing_required_artifact_level

--- a/ito-rs/crates/ito-core/tests/validate.rs
+++ b/ito-rs/crates/ito-core/tests/validate.rs
@@ -410,7 +410,7 @@ artifacts:
             .join("schemas")
             .join("nodeltas")
             .join("validation.yaml"),
-        "version: 1\n",
+        "version: 1\nmanual_semantic_validation_note: Schema semantics require manual validation.\n",
     );
 
     write(
@@ -425,6 +425,15 @@ artifacts:
             .iter()
             .any(|i| i.message.contains("at least one delta")),
         "schema validation without delta validator should not require deltas, got issues: {:?}",
+        r.issues
+    );
+    assert!(
+        r.issues.iter().any(|i| {
+            i.path == "schema.validation.manual"
+                && i.message
+                    .contains("Schema semantics require manual validation.")
+        }),
+        "schema validation should emit manual semantic validation note, got issues: {:?}",
         r.issues
     );
 }

--- a/ito-rs/crates/ito-templates/assets/schemas/event-driven/UPSTREAM.md
+++ b/ito-rs/crates/ito-templates/assets/schemas/event-driven/UPSTREAM.md
@@ -1,0 +1,9 @@
+<!-- ITO:START -->
+# Upstream
+
+- Source: https://github.com/intent-driven-dev/openspec-schemas
+- Pinned commit: `7cff0a6210714631baceee1e8effc58c18d5f107`
+- Upstream path: `openspec/schemas/event-driven`
+- License: MIT
+- Vendored for Ito as embedded schema asset `event-driven`.
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/schemas/event-driven/validation.yaml
+++ b/ito-rs/crates/ito-templates/assets/schemas/event-driven/validation.yaml
@@ -1,10 +1,20 @@
 version: 1
+manual_semantic_validation_note: "OpenSpec event-driven schema semantics are not fully validated by Ito; manually review event storming, event modeling, and AsyncAPI content."
 defaults:
   missing_required_artifact_level: error
 artifacts:
+  event-storming:
+    required: true
+  event-modeling:
+    required: true
   specs:
     required: true
-    validate_as: ito.delta-specs.v1
+  design:
+    required: true
+  asyncapi:
+    required: true
+  tasks:
+    required: true
 tracking:
   source: apply_tracks
   required: true

--- a/ito-rs/crates/ito-templates/assets/schemas/minimalist/UPSTREAM.md
+++ b/ito-rs/crates/ito-templates/assets/schemas/minimalist/UPSTREAM.md
@@ -1,0 +1,9 @@
+<!-- ITO:START -->
+# Upstream
+
+- Source: https://github.com/intent-driven-dev/openspec-schemas
+- Pinned commit: `7cff0a6210714631baceee1e8effc58c18d5f107`
+- Upstream path: `openspec/schemas/minimalist`
+- License: MIT
+- Vendored for Ito as embedded schema asset `minimalist`.
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/schemas/minimalist/validation.yaml
+++ b/ito-rs/crates/ito-templates/assets/schemas/minimalist/validation.yaml
@@ -1,10 +1,12 @@
 version: 1
+manual_semantic_validation_note: "OpenSpec minimalist schema semantics are not fully validated by Ito; review specs and tasks manually for workflow intent."
 defaults:
   missing_required_artifact_level: error
 artifacts:
   specs:
     required: true
-    validate_as: ito.delta-specs.v1
+  tasks:
+    required: true
 tracking:
   source: apply_tracks
   required: true

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -561,6 +561,26 @@ mod tests {
                 .any(|f| f.relative_path == "spec-driven/schema.yaml")
         );
         assert!(files.iter().any(|f| f.relative_path == "tdd/schema.yaml"));
+        assert!(
+            files
+                .iter()
+                .any(|f| f.relative_path == "minimalist/schema.yaml")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.relative_path == "event-driven/schema.yaml")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.relative_path == "minimalist/UPSTREAM.md")
+        );
+        assert!(
+            files
+                .iter()
+                .any(|f| f.relative_path == "event-driven/UPSTREAM.md")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds OpenSpec upstream metadata and third-party notices for embedded schemas.
- Documents embedded OpenSpec schema provenance and validation behavior.
- Adds manual semantic validation notes to schema validation output.

## Verification
- `ito tasks status 019-05_embed-openspec-schemas` shows 6/6 complete.
- `ito validate 019-05_embed-openspec-schemas --strict` passed.
- Focused schema listing/export and validation tests passed.
- `cargo fmt --all` passed during implementation.

Upstream source: https://github.com/intent-driven-dev/openspec-schemas at commit `7cff0a6210714631baceee1e8effc58c18d5f107`.