### PR TITLE
feat(wiki): seed Ito project wiki

### DIFF
--- a/.ito/wiki/_meta/config.yaml
+++ b/.ito/wiki/_meta/config.yaml
@@ -1,0 +1,31 @@
+version: 1
+root: .ito/wiki
+purpose: ito-scoped-llm-maintained-knowledge
+default_sources:
+  - docs/ito/specs
+  - docs/ito/changes
+  - .ito/research
+  - .ito/project.md
+  - .ito/AGENTS.md
+external_sources: link-only
+page_types:
+  - topic
+  - spec-summary
+  - research-synthesis
+  - query-result
+  - workflow-note
+  - decision-note
+authority_levels:
+  - canonical-summary
+  - advisory-synthesis
+  - decision-record
+  - query-artifact
+freshness_states:
+  - fresh
+  - stale
+  - unknown
+write_policy:
+  default: llm-maintained
+  upgrade: preserve-existing-content
+  force_refresh: may-rewrite-managed-template-content
+  marker_managed_sections: explicit-only

--- a/.ito/wiki/_meta/schema.md
+++ b/.ito/wiki/_meta/schema.md
@@ -1,0 +1,41 @@
+# Ito Wiki Schema
+
+The Ito wiki is a durable synthesis layer for future proposal, research,
+review, and archive work in this repository. It summarizes Ito artifacts and
+links back to source truth; it does not replace accepted specs, change
+proposals, task files, or project guidance.
+
+## Source Boundary
+
+Default sources are Ito-owned artifacts:
+
+- `docs/ito/specs/`
+- `docs/ito/changes/`
+- `.ito/research/`
+- `.ito/project.md`
+- `.ito/AGENTS.md`
+
+External files can be linked when they clarify an Ito decision, but the wiki
+should not mirror source code or broad project documentation by default.
+
+## Page Metadata
+
+Durable topic pages should include:
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: YYYY-MM-DD
+source_refs:
+  - docs/ito/specs/example/spec.md
+known_gaps: []
+```
+
+## Maintenance Rules
+
+- Prefer topic pages over one page per archived change.
+- Cite raw Ito sources for claims that future agents may rely on.
+- Warn and fall back to raw artifacts when coverage is missing, stale, or contradictory.
+- Update `index.md`, `log.md`, and `_meta/status.md` after meaningful maintenance.
+- Preserve existing wiki content during normal upgrades unless a marker-managed section explicitly says otherwise.

--- a/.ito/wiki/_meta/status.md
+++ b/.ito/wiki/_meta/status.md
@@ -1,0 +1,28 @@
+# Ito Wiki Status
+
+```yaml
+page_type: workflow-note
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/
+  - docs/ito/changes/archive/
+  - .ito/research/
+known_gaps:
+  - Module summaries are not seeded because coordinated module links are runtime state.
+  - Spec coverage is grouped by theme rather than exhaustively summarized one spec per page.
+```
+
+## Coverage
+
+- Workflow and change lifecycle: seeded in `topics/workflow.md`
+- Runtime, storage, and backend model: seeded in `topics/runtime-and-storage.md`
+- Agent distribution and instruction surfaces: seeded in `topics/distribution-and-agents.md`
+- Validation and quality gates: seeded in `topics/validation-quality-gates.md`
+- Rust port research: seeded in `research/rust-port.md`
+
+## Next Maintenance Step
+
+Expand topic pages when a proposal touches one of the linked specs or archives.
+If a page is stale, update the page and append a short entry to `log.md`.

--- a/.ito/wiki/index.md
+++ b/.ito/wiki/index.md
@@ -1,0 +1,24 @@
+# Ito Wiki Index
+
+This wiki is an Ito-scoped knowledge layer for LLM-assisted planning,
+research, review, and archive work. It summarizes durable knowledge from Ito
+artifacts without replacing those artifacts as source truth.
+
+## Start Here
+
+- [[overview]] - high-level project and wiki usage synthesis
+- [[topics/workflow]] - change lifecycle, proposal, task, archive, and traceability flow
+- [[topics/runtime-and-storage]] - filesystem, SQLite, backend, coordination, and worktree model
+- [[topics/distribution-and-agents]] - agent instructions, skills, templates, and harness surfaces
+- [[topics/validation-quality-gates]] - validation, pre-push hooks, coverage, and repo guardrails
+- [[research/rust-port]] - durable synthesis from the Rust port research notes
+- [[log]] - notable wiki maintenance events
+- [[_meta/schema]] - page model, authority levels, and source rules
+- [[_meta/status]] - current freshness and known gaps
+
+## Source Boundary
+
+Default sources are Ito-owned artifacts: `docs/ito/specs/`,
+`docs/ito/changes/`, `.ito/research/`, `.ito/project.md`, and
+`.ito/AGENTS.md`. Link external project files only when they clarify Ito
+decisions.

--- a/.ito/wiki/log.md
+++ b/.ito/wiki/log.md
@@ -1,0 +1,9 @@
+# Ito Wiki Log
+
+## 2026-05-27 Initial Seed
+
+- Created repo-local wiki scaffold and first topic pages.
+- Seeded workflow, runtime/storage, distribution/agents, quality gates, and
+  Rust port research synthesis.
+- Source window: current `docs/ito/specs/`, active/archived change summaries,
+  and existing `.ito/research/` notes.

--- a/.ito/wiki/overview.md
+++ b/.ito/wiki/overview.md
@@ -1,0 +1,38 @@
+# Ito Wiki Overview
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/
+  - docs/ito/changes/archive/
+  - .ito/research/SUMMARY.md
+known_gaps:
+  - This is a first-pass synthesis, not exhaustive spec coverage.
+```
+
+Ito is a change-driven workflow tool with a Rust workspace implementation,
+template-managed agent surfaces, and Ito-managed proposal/spec/task artifacts.
+The repository keeps accepted capability specs in `docs/ito/specs/`, active and
+archived changes in `docs/ito/changes/`, and research notes under
+`.ito/research/`.
+
+## Current Shape
+
+- The CLI and core crates manage changes, modules, specs, tasks, validation,
+  archive flows, repository runtime selection, backend sync, and worktree-aware
+  workflows.
+- Template assets install AGENTS guidance, commands, skills, agent prompts,
+  schema templates, and workflow instructions for multiple harnesses.
+- Coordination state is shared through Ito-managed runtime links in worktree
+  mode, while canonical docs remain committed under `docs/ito/`.
+
+## How Future Agents Should Use This Wiki
+
+- Start with the topic page closest to the requested work.
+- Treat source refs as the authority trail, then inspect raw specs or changes
+  before editing behavior.
+- If wiki coverage is stale, say so and update the page after the source work
+  is complete.

--- a/.ito/wiki/research/rust-port.md
+++ b/.ito/wiki/research/rust-port.md
@@ -1,0 +1,39 @@
+# Rust Port Research
+
+```yaml
+page_type: research-synthesis
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - .ito/research/SUMMARY.md
+  - .ito/research/parity-matrix.md
+  - .ito/research/investigations/rust-crate-architecture.md
+  - .ito/research/investigations/rust-cli-ux.md
+  - .ito/research/investigations/config-crate-extraction.md
+  - .ito/research/investigations/packaging-distribution.md
+known_gaps:
+  - Does not replace the detailed parity matrix.
+```
+
+The Rust implementation emphasizes a CLI-first workflow, embedded templates,
+strong validation, and parity with the previous Ito behavior while reducing
+runtime dependencies. Research notes cover CLI UX, crate architecture,
+configuration extraction, packaging, parity testing, and task-interface
+comparisons.
+
+## Durable Findings
+
+- Keep CLI flows explicit and scriptable; interactive behavior should have
+  non-interactive equivalents.
+- Keep domain parsing and validation out of presentation surfaces when a crate
+  boundary can express the behavior.
+- Prefer embedded template assets with tests proving distribution and rendering
+  behavior.
+- Preserve artifact compatibility during migration by testing real fixtures and
+  command output, not only unit-level parser behavior.
+
+## Follow-Up
+
+When a change touches CLI UX, crate boundaries, packaging, or parity behavior,
+review the underlying research file before relying on this summary.

--- a/.ito/wiki/topics/distribution-and-agents.md
+++ b/.ito/wiki/topics/distribution-and-agents.md
@@ -1,0 +1,36 @@
+# Distribution And Agents
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/agent-instructions/spec.md
+  - docs/ito/specs/agent-surface-taxonomy/spec.md
+  - docs/ito/specs/instruction-source-of-truth/spec.md
+  - docs/ito/specs/template-assets/spec.md
+  - docs/ito/specs/distribution/spec.md
+  - docs/ito/specs/ito-skill-routing/spec.md
+known_gaps: []
+```
+
+Ito ships managed instructions, prompts, commands, skills, and agent templates
+for multiple harnesses. Template assets are the source for generated harness
+surfaces; generated files should stay thin and refreshable through Ito update
+flows.
+
+## Current Pattern
+
+- Shared skill and command assets live under `ito-templates` and are embedded
+  into the Rust binary.
+- Harness-specific output paths differ, but behavior should stay driven by
+  shared templates and skill instructions where possible.
+- Agent instructions should route to Ito CLI instruction artifacts rather than
+  duplicating long policy text in every harness surface.
+
+## Wiki-Specific Note
+
+The wiki skills add a maintenance workflow and a search workflow. They should be
+distributed like other shared Ito skills and should remain Ito-scoped rather
+than becoming a general repository documentation system.

--- a/.ito/wiki/topics/runtime-and-storage.md
+++ b/.ito/wiki/topics/runtime-and-storage.md
@@ -1,0 +1,38 @@
+# Runtime And Storage
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/repository-runtime-selection/spec.md
+  - docs/ito/specs/change-repository/spec.md
+  - docs/ito/specs/task-repository/spec.md
+  - docs/ito/specs/spec-repository/spec.md
+  - docs/ito/specs/backend-client-runtime/spec.md
+  - docs/ito/specs/coordination-worktree/spec.md
+  - docs/ito/specs/worktree-lifecycle/spec.md
+known_gaps:
+  - Does not yet summarize every backend API spec.
+```
+
+Ito has moved toward repository-backed runtime abstractions so command handlers
+can read and mutate artifacts without hard-coding filesystem layout. Filesystem,
+SQLite, and remote-backed modes should expose consistent repositories and
+mutation services.
+
+## Key Concepts
+
+- Repository runtime selection decides whether operations use local markdown,
+  SQLite-backed storage, or remote backend services.
+- Coordination worktree storage shares change, module, spec, workflow, and
+  audit state across change worktrees through `.ito/*` runtime links.
+- Worktree lifecycle is Worktrunk-backed for creation/switching while retaining
+  Ito's configured `ito-worktrees/<change-id>` path convention.
+
+## Review Notes
+
+When changing runtime behavior, check both read and mutation paths. Tests should
+cover filesystem mode and at least one non-filesystem mode when behavior is
+shared through repository contracts.

--- a/.ito/wiki/topics/validation-quality-gates.md
+++ b/.ito/wiki/topics/validation-quality-gates.md
@@ -1,0 +1,33 @@
+# Validation And Quality Gates
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/cli-validate/spec.md
+  - docs/ito/specs/validate-repo-cli-surface/spec.md
+  - docs/ito/specs/repo-precommit-quality-gates/spec.md
+  - docs/ito/specs/rust-documentation-standards/spec.md
+  - docs/ito/specs/rust-foundations/spec.md
+known_gaps: []
+```
+
+Validation spans Ito artifact validation, repository guardrails, Rust checks,
+markdown checks, docs checks, coverage, and architecture boundaries.
+
+## Practical Gate Sequence
+
+- `ito validate <change-id> --strict` for change package integrity.
+- Focused Rust tests for touched behavior before repo-wide checks.
+- `make test` for the workspace test suite.
+- `make check` for pre-push hooks: markdownlint, fmt, clippy, rustdoc,
+  coverage, affected tests, max-lines, architecture guardrails, and cargo-deny.
+
+## Current Expectations
+
+Coverage has an 80 percent hard floor. Source file size guardrails enforce a
+1200-line hard limit for Rust source files and warn over the soft limit.
+Architecture guardrails protect crate boundaries and prevent accidental
+dependency regressions.

--- a/.ito/wiki/topics/workflow.md
+++ b/.ito/wiki/topics/workflow.md
@@ -1,0 +1,35 @@
+# Workflow
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: fresh
+last_reviewed: 2026-05-27
+source_refs:
+  - docs/ito/specs/cli-change/spec.md
+  - docs/ito/specs/cli-tasks/spec.md
+  - docs/ito/specs/cli-archive/spec.md
+  - docs/ito/specs/requirement-traceability/spec.md
+  - docs/ito/specs/archive-completion-validation/spec.md
+known_gaps: []
+```
+
+Ito work is organized around proposed changes with tasks, spec deltas, and
+validation. Proposals describe intent and impact, tasks provide ordered
+implementation checkpoints, and specs capture accepted behavior through
+requirements and scenarios.
+
+## Lifecycle
+
+- Create or update a change under `docs/ito/changes/active/`.
+- Track work through `tasks.md`; complete tasks only after their verification
+  commands or review criteria are satisfied.
+- Promote accepted behavior into `docs/ito/specs/` during archive.
+- Keep archive follow-through tied to specs, modules, research, demos, and
+  workflow documentation rather than treating archive as file movement only.
+
+## Traceability
+
+Requirement IDs and task references are used to connect implementation work to
+spec intent. When a change adds or modifies behavior, prefer explicit
+requirement IDs and scenario coverage that future validation can inspect.

--- a/ito-rs/crates/ito-core/src/installers/json_tests.rs
+++ b/ito-rs/crates/ito-core/src/installers/json_tests.rs
@@ -70,6 +70,10 @@ fn classify_project_file_ownership_handles_user_owned_paths() {
         FileOwnership::UserOwned
     );
     assert_eq!(
+        classify_project_file_ownership(".ito/wiki/index.md", ito_dir),
+        FileOwnership::UserOwned
+    );
+    assert_eq!(
         classify_project_file_ownership(".ito/commands/review-edge.md", ito_dir),
         FileOwnership::ItoManaged
     );

--- a/ito-rs/crates/ito-core/src/installers/mod.rs
+++ b/ito-rs/crates/ito-core/src/installers/mod.rs
@@ -465,6 +465,11 @@ fn classify_project_file_ownership(rel: &str, ito_dir: &str) -> FileOwnership {
         return FileOwnership::UserOwned;
     }
 
+    let wiki_prefix = format!("{ito_dir}/wiki/");
+    if rel.starts_with(&wiki_prefix) {
+        return FileOwnership::UserOwned;
+    }
+
     FileOwnership::ItoManaged
 }
 

--- a/ito-rs/crates/ito-core/tests/distribution.rs
+++ b/ito-rs/crates/ito-core/tests/distribution.rs
@@ -221,6 +221,25 @@ fn github_manifests_includes_skills_and_commands() {
 }
 
 #[test]
+fn wiki_skills_are_distributed_to_all_harnesses() {
+    let project_root = Path::new("/tmp/test");
+
+    for (harness, manifests) in [
+        ("opencode", opencode_manifests(project_root)),
+        ("claude", claude_manifests(project_root)),
+        ("codex", codex_manifests(project_root)),
+        ("github", github_manifests(project_root)),
+    ] {
+        for source in ["ito-wiki/SKILL.md", "ito-wiki-search/SKILL.md"] {
+            assert!(
+                manifests.iter().any(|manifest| manifest.source == source),
+                "expected {source} in {harness} manifests"
+            );
+        }
+    }
+}
+
+#[test]
 fn install_manifests_writes_files_to_disk() {
     let td = tempfile::tempdir().unwrap();
     let config_dir = td.path().join(".opencode");

--- a/ito-rs/crates/ito-core/tests/wiki_install.rs
+++ b/ito-rs/crates/ito-core/tests/wiki_install.rs
@@ -1,0 +1,80 @@
+use std::collections::BTreeSet;
+
+use ito_config::ConfigContext;
+use ito_core::installers::{InitOptions, InstallMode, install_default_templates};
+
+fn install(project: &std::path::Path, mode: InstallMode, opts: InitOptions) {
+    let ctx = ConfigContext {
+        project_dir: Some(project.to_path_buf()),
+        ..Default::default()
+    };
+    install_default_templates(project, &ctx, mode, &opts, None).expect("install should succeed");
+}
+
+#[test]
+fn update_preserves_existing_wiki_content_and_installs_missing_scaffold() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let project = dir.path();
+
+    install(
+        project,
+        InstallMode::Init,
+        InitOptions::new(BTreeSet::new(), false, false),
+    );
+
+    let overview = project.join(".ito/wiki/overview.md");
+    let config = project.join(".ito/wiki/_meta/config.yaml");
+    let status = project.join(".ito/wiki/_meta/status.md");
+    let overview_contents = "# Project-owned overview\n\nKeep this synthesis.\n";
+    let config_contents = "version: 99\nwrite_policy:\n  default: project-owned\n";
+
+    std::fs::write(&overview, overview_contents).expect("overview write should succeed");
+    std::fs::write(&config, config_contents).expect("config write should succeed");
+    std::fs::remove_file(&status).expect("status removal should succeed");
+
+    install(
+        project,
+        InstallMode::Update,
+        InitOptions::new(BTreeSet::new(), false, true),
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&overview).expect("overview read should succeed"),
+        overview_contents
+    );
+    assert_eq!(
+        std::fs::read_to_string(&config).expect("config read should succeed"),
+        config_contents
+    );
+    assert!(
+        status.exists(),
+        "missing wiki scaffold file should be installed"
+    );
+}
+
+#[test]
+fn init_upgrade_preserves_existing_wiki_content() {
+    let dir = tempfile::tempdir().expect("tempdir should succeed");
+    let project = dir.path();
+
+    install(
+        project,
+        InstallMode::Init,
+        InitOptions::new(BTreeSet::new(), false, false),
+    );
+
+    let index = project.join(".ito/wiki/index.md");
+    let index_contents = "# Project-owned wiki index\n";
+    std::fs::write(&index, index_contents).expect("index write should succeed");
+
+    install(
+        project,
+        InstallMode::Init,
+        InitOptions::new_upgrade(BTreeSet::new()),
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&index).expect("index read should succeed"),
+        index_contents
+    );
+}

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/AGENTS.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/AGENTS.md
@@ -12,6 +12,7 @@ Instructions for AI coding assistants using Ito for change-driven development.
 ## TL;DR Quick Checklist
 
 |search: `ito list --specs`, `ito list`, `ito list-archive`, `ito list --modules`; filter: `--pending|--partial|--completed`
+|wiki: consult `.ito/wiki/index.md` when present; warn and fall back to raw Ito artifacts if stale, missing, or contradictory
 |choose module by semantic fit; create new if none fit; avoid dumping unrelated work into arbitrary module
 |scope: new capability vs modify existing; large features → create module to group changes
 |change-id: unique, `NNN-CC_name` format for modular (e.g., `001-01_init-repo`)
@@ -37,7 +38,8 @@ Skip proposal for: bug fixes restoring intended behavior | typos/formatting/comm
 
 **Workflow:**
 1. Pick lane: `ito-feature`, `ito-fix`, `ito-proposal`, or `ito-brainstorming`
-1. Review `.ito/project.md`, `ito list`, `ito list --specs`
+1. Review `.ito/wiki/index.md` when present, then `.ito/project.md`, `ito list`, and `ito list --specs`
+1. If wiki coverage is stale, missing relevant coverage, or contradicts raw Ito artifacts, warn briefly, trust the raw artifacts, and update durable synthesis back into `.ito/wiki/` after proposal work
 1. Choose schema: `spec-driven` (new/broad/high-risk) | `minimalist` (bounded fixes/small changes) | `tdd` (regression-first) | `event-driven` (event/message-centric)
 1. Choose unique verb-led `change-id`; scaffold under `.ito/changes/<id>/`
 1. Draft spec deltas: `## ADDED|MODIFIED|REMOVED Requirements` with ≥1 `#### Scenario:` each
@@ -71,6 +73,8 @@ After deployment, create separate PR to:
 - Run `ito audit reconcile --change <change-id>` to ensure audit consistency before archiving
 - Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
 - Update `specs/` if capabilities changed
+- Refresh relevant `.ito/wiki/` topic pages when `.ito/wiki/index.md` exists, linking archived changes to affected specs, modules, research, architecture notes, and documentation
+- Prefer topic-page synthesis over one wiki page per archived change unless the archived change is historically important or too large for an existing topic page
 - Use `ito archive <change-id> --skip-specs --yes` for tooling-only changes (always pass the change ID explicitly)
 - Run `ito validate --strict` to confirm the archived change passes checks
 
@@ -79,6 +83,7 @@ After deployment, create separate PR to:
 **Context Checklist:**
 
 - [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] If `.ito/wiki/index.md` exists, review relevant wiki topic pages for synthesized context and freshness metadata
 - [ ] Check pending changes in `changes/` for conflicts
 - [ ] Read `.ito/project.md` for conventions
 - [ ] Run `ito list` to see active changes | `ito list --specs` to see existing capabilities

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/config.yaml
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/config.yaml
@@ -1,0 +1,40 @@
+version: 1
+root: .ito/wiki
+purpose: ito-scoped-llm-maintained-knowledge
+default_sources:
+  - .ito/specs
+  - .ito/changes
+  - .ito/research
+  - .ito/modules
+  - .ito/project.md
+  - .ito/user-prompts
+  - .ito/AGENTS.md
+external_sources: link-only
+page_types:
+  - topic
+  - spec-summary
+  - research-synthesis
+  - query-result
+  - workflow-note
+  - decision-note
+authority_levels:
+  - canonical-summary
+  - advisory-synthesis
+  - decision-record
+  - query-artifact
+freshness_states:
+  - fresh
+  - stale
+  - unknown
+reserved_paths:
+  - index.md
+  - overview.md
+  - log.md
+  - _meta/config.yaml
+  - _meta/schema.md
+  - _meta/status.md
+write_policy:
+  default: llm-maintained
+  upgrade: preserve-existing-content
+  force_refresh: may-rewrite-managed-template-content
+  marker_managed_sections: explicit-only

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/schema.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/schema.md
@@ -1,0 +1,60 @@
+<!-- ITO:START -->
+
+# Ito Wiki Schema
+
+The Ito wiki is a durable, LLM-maintained synthesis layer over Ito artifacts. It is not the source of truth for requirements, accepted behavior, or workflow policy unless a page explicitly says so and links to the governing artifact.
+
+## Source Boundary
+
+Default ingestion sources are Ito-owned artifacts:
+
+- `.ito/specs/`
+- `.ito/changes/`
+- `.ito/research/`
+- `.ito/modules/`
+- `.ito/project.md`
+- `.ito/user-prompts/`
+- `.ito/AGENTS.md`
+
+External project files may be linked as supporting references when they explain an Ito decision. Do not mirror source code, generated docs, or general project documentation into this wiki by default.
+
+## Page Types
+
+- `topic` - synthesis across multiple Ito artifacts around one concept
+- `spec-summary` - summary of accepted specs that defers to `.ito/specs/`
+- `research-synthesis` - durable synthesis from research artifacts
+- `query-result` - cited answer worth retaining beyond one chat
+- `workflow-note` - workflow guidance derived from Ito instructions or project guidance
+- `decision-note` - durable decision record with source links and tradeoffs
+
+## Authority Levels
+
+- `canonical-summary` - summarizes canonical sources but defers to those sources on conflict
+- `advisory-synthesis` - useful interpretation or planning aid, not source truth
+- `decision-record` - records a durable decision and should identify where it is enforced
+- `query-artifact` - preserved answer with citations and bounded freshness
+
+## Expected Metadata
+
+Every durable page should include, near the top:
+
+```yaml
+page_type: topic
+authority: advisory-synthesis
+freshness: unknown
+last_reviewed: YYYY-MM-DD
+source_refs:
+  - .ito/specs/example/spec.md
+known_gaps:
+  - Not reviewed yet
+```
+
+## Maintenance Rules
+
+- Prefer topic pages over one page per archived change.
+- Cite raw Ito sources for claims that future agents may rely on.
+- Warn and fall back to raw artifacts when wiki coverage is absent, stale, or contradictory.
+- Update `index.md`, `log.md`, and `_meta/status.md` after meaningful maintenance.
+- Preserve existing wiki content during normal upgrades unless a marker-managed section explicitly says otherwise.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/status.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/_meta/status.md
@@ -1,0 +1,30 @@
+<!-- ITO:START -->
+
+# Ito Wiki Status
+
+## Freshness
+
+- Overall status: unknown
+- Last reviewed: not reviewed
+- Source window: initial scaffold only
+
+## Coverage
+
+- Specs: not seeded
+- Changes: not seeded
+- Research: not seeded
+- Modules: not seeded
+- Workflow guidance: not seeded
+
+## Known Gaps
+
+- Project-specific topic pages are missing.
+- Accepted spec summaries are missing.
+- Archived-change synthesis is missing.
+- Research synthesis is missing.
+
+## Next Maintenance Step
+
+Seed topic pages from current Ito specs, modules, research, high-signal archived changes, and workflow guidance.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/index.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/index.md
@@ -1,0 +1,25 @@
+<!-- ITO:START -->
+
+# Ito Wiki Index
+
+This wiki is an Ito-scoped knowledge layer for LLM-assisted planning, research, review, and archive work. It summarizes durable knowledge from Ito artifacts without replacing those artifacts as source truth.
+
+## Start Here
+
+- [[overview]] - high-level project and Ito workflow synthesis
+- [[log]] - notable wiki maintenance events
+- [[_meta/schema]] - page model, authority levels, and source rules
+- [[_meta/status]] - freshness and known gaps
+
+## Reserved Areas
+
+- `topics/` - topic-oriented synthesis across specs, changes, modules, research, and guidance
+- `specs/` - optional summaries of accepted specs that defer to `.ito/specs/`
+- `research/` - durable syntheses from `.ito/research/` and change research artifacts
+- `queries/` - cited query outputs worth keeping beyond a single chat
+
+## Source Boundary
+
+Default sources are Ito-owned artifacts: `.ito/specs/`, `.ito/changes/`, `.ito/research/`, `.ito/modules/`, `.ito/project.md`, `.ito/user-prompts/`, and `.ito/AGENTS.md`. Link external project files only when they clarify Ito decisions; do not mirror the whole repository here.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/log.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/log.md
@@ -1,0 +1,16 @@
+<!-- ITO:START -->
+
+# Ito Wiki Log
+
+Record meaningful wiki maintenance events here. Keep entries concise and link to affected pages and source artifacts.
+
+## Entries
+
+### Initial Scaffold
+
+- Action: created reserved wiki entry points and metadata pages
+- Scope: `index.md`, `overview.md`, `_meta/config.yaml`, `_meta/schema.md`, `_meta/status.md`
+- Source window: template scaffold only
+- Notes: replace this entry after the first project-specific seed pass if it becomes noisy
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/overview.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/.ito/wiki/overview.md
@@ -1,0 +1,27 @@
+<!-- ITO:START -->
+
+# Ito Wiki Overview
+
+This page is the first project-level synthesis for the Ito wiki. Keep it short, linked, and focused on information future agents need before creating proposals, running research, or archiving completed changes.
+
+## Project Summary
+
+- Purpose: not reviewed yet
+- Primary workflows: proposal, research, implementation, review, archive
+- Important modules: not reviewed yet
+- Current source window: initial scaffold only
+
+## How To Use This Wiki
+
+- Consult the wiki first for durable context and navigation.
+- Treat page metadata and source links as part of the answer.
+- Fall back to raw Ito artifacts when coverage is missing, stale, or contradictory.
+- Update topic pages when a workflow produces durable synthesis.
+
+## Known Gaps
+
+- Initial project topics have not been seeded.
+- Spec summaries have not been generated.
+- Research syntheses have not been reviewed.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
+++ b/ito-rs/crates/ito-templates/assets/default/project/AGENTS.md
@@ -10,6 +10,8 @@ Files under `.ito/`, `.opencode/`, `.github/`, and `.codex/` are Ito-managed and
 
 Keep this block so `ito init --upgrade` can refresh managed content safely. To refresh only this managed section, run `ito init --upgrade`.
 
+When present, use `.ito/wiki/index.md` for Ito-scoped synthesis, freshness warnings, and archive follow-through.
+
 ## Path Helpers
 
 Use `ito path ...` for runtime absolute paths; do not hardcode machine-specific paths into committed files:

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/archive.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/archive.md.j2
@@ -16,6 +16,10 @@ ito audit reconcile --change {{ change }}
 ito archive {{ change }} --yes
 ```
 
+After archive/spec sync succeeds, refresh relevant `.ito/wiki/` topic pages when `.ito/wiki/index.md` exists. Prefer updating existing topic pages with links to the archived change, affected specs, modules, research, architecture notes, and documentation. Create a separate archived-change wiki page only for historically important changes or when a topic page would become too large.
+
+If the wiki is absent, stale, or contradictory, note the risk and continue from the archived change and raw Ito artifacts; wiki refresh is recommended follow-through, not an archive blocker.
+
 If the reconcile reports drift, fix it first:
 
 ```bash
@@ -59,6 +63,7 @@ Mode `{{ archive.main_integration_mode }}` is unrecognized. Set a valid mode wit
 - All tasks in `tasks.md` are complete
 - The PR has been merged (or the change has been integrated into `main`)
 - You want to record the change as done and update the canonical specs
+- You want to refresh durable wiki synthesis after successful archive/spec sync
 
 ### Commands
 
@@ -84,6 +89,12 @@ ito agent instruction archive --change <change-id>
 ```
 
 Default archive main integration mode: `{{ archive.main_integration_mode }}`
+
+### Wiki follow-through
+
+After archive/spec sync succeeds, refresh relevant `.ito/wiki/` topic pages when `.ito/wiki/index.md` exists. Link to the archived change, affected specs, modules, research, architecture notes, and documentation. Prefer topic-page synthesis over one wiki page per archived change; create archived-change pages only for historically important changes or oversized topics.
+
+If the wiki is absent, stale, or contradictory, note the risk and continue from the archive and raw Ito artifacts. Wiki refresh should not block archiving.
 
 {% if available_changes | length > 0 %}
 ### Available changes

--- a/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
+++ b/ito-rs/crates/ito-templates/assets/instructions/agent/new-proposal.md.j2
@@ -83,6 +83,14 @@ If the request needs this discovery but there is not enough context yet, route t
 ito sync
 ```
 
+## Step 0.5: Consult the Ito Wiki When Present
+
+If `.ito/wiki/index.md` exists, read it early to discover relevant topic pages, specs, modules, research syntheses, archived-change summaries, and workflow notes before choosing the schema or module.
+
+- Treat wiki pages as synthesized navigation and context, not automatic source truth. Follow each page's authority and freshness metadata.
+- If wiki coverage is missing, stale, or contradicts raw Ito artifacts, briefly warn the user or note the risk, then fall back to `.ito/specs/`, `.ito/changes/`, `.ito/research/`, `.ito/modules/`, and project guidance.
+- If proposal work creates durable synthesis that would help future planning, update the most relevant `.ito/wiki/` topic page, `index.md`, `log.md`, or `_meta/status.md` after the proposal artifacts are created.
+
 ## Step 1: Choose a Schema
 
 Before creating the change, pick the workflow schema.

--- a/ito-rs/crates/ito-templates/assets/skills/ito-archive/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-archive/SKILL.md
@@ -36,4 +36,6 @@ Run the CLI-generated archive instructions for a specific change.
 
 3. Follow the printed instructions exactly.
 
+4. After archive/spec sync succeeds, refresh relevant `.ito/wiki/` topic pages when `.ito/wiki/index.md` exists. Prefer topic-page synthesis that links to the archived change, specs, modules, research, architecture notes, and documentation instead of creating one wiki page per archived change. If wiki coverage is absent, stale, or contradictory, note the risk and continue from raw Ito artifacts; wiki refresh is recommended follow-through, not an archive blocker.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-proposal/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-proposal/SKILL.md
@@ -27,6 +27,14 @@ Do NOT jump straight into creating files. Confirm the change shape first:
 
 Only proceed to Step 1 once you and the user agree on what the change is and why it matters.
 
+**Step 0.5: Consult the Ito wiki when present**
+
+If `.ito/wiki/index.md` exists, read it early to find relevant topic pages, specs, modules, research syntheses, archived-change summaries, and workflow notes.
+
+- Treat wiki pages as synthesized navigation and context; raw specs, active changes, research artifacts, modules, and project guidance remain authoritative when they conflict.
+- Warn or call out the risk when wiki coverage is missing, stale, or contradictory, then continue from raw Ito sources rather than blocking proposal work.
+- When the proposal process creates durable synthesis, update the relevant `.ito/wiki/` topic page, `index.md`, `log.md`, or `_meta/status.md` so future planning can reuse it.
+
 **Step 1: Choose a schema**
 
 ```bash

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/SKILL.md
@@ -30,7 +30,15 @@ Use this skill for technology evaluation, feature research, proposal review, and
 
 ## Output Location
 
-Save research under the Ito directory. For absolute paths:
+Save research outputs under the Ito directory.
+
+Research source artifacts and wiki synthesis have different jobs:
+
+- `$ITO_ROOT/research/{{topic}}/` and `$ITO_ROOT/changes/{{change_id}}/reviews/` store the original investigation or review output.
+- `$ITO_ROOT/wiki/` stores durable synthesis, topic links, query artifacts, and freshness notes that help future proposal, research, and archive sessions.
+- Do not replace the source research file with a wiki page; cite the source artifact from the wiki page instead.
+
+If you need absolute paths at runtime:
 
 ```bash
 ITO_ROOT="$(ito path ito-root)"
@@ -41,8 +49,54 @@ Then save to:
 - `$ITO_ROOT/research/{{topic}}/` for feature/technology research
 - `$ITO_ROOT/changes/{{change_id}}/reviews/` for change reviews
 
+If `$ITO_ROOT/wiki/index.md` exists, read it before starting to find prior topic pages and known gaps. If coverage is stale, missing, or contradictory, call that out and continue from source research or raw Ito artifacts.
+
+After completing research, update the wiki only when the finding is durable enough to help future sessions:
+
+- Add lasting recommendations, decisions, and cross-cutting findings to relevant topic pages.
+- Add one-off investigations or prompt-specific answers under `$ITO_ROOT/wiki/queries/` when they are useful but not topic-page material.
+- Update `index.md`, `log.md`, and `_meta/status.md` when wiki coverage changes meaningfully.
+
+## Example Usage
+
+### Technology Research
+
+```
+User: Research options for implementing real-time notifications
+
+Agent: I'll use the ito-research skill to evaluate options.
+
+1. First, I'll use @research-stack.md to compare:
+   - WebSockets vs SSE vs Polling
+   - Library options (socket.io, ws, etc.)
+
+2. Then @research-architecture.md for:
+   - Pub/sub patterns
+   - Scaling considerations
+
+3. Finally @research-synthesize.md to recommend an approach.
+```
+
+### Change Review
+
+```
+User: Review the auth refactor change for security issues
+
+Agent: I'll use @review-security.md to audit the change:
+- Map attack surface
+- Check for auth bypasses
+- Verify input validation
+- Review cryptographic usage
+```
+
 ## Integration with Ito Workflow
 
-Research outputs can feed proposals and designs: run the relevant templates, save the results, reference them in `proposal.md` / `design.md`, and use them to shape `tasks.md`.
+Research outputs can feed into change proposals:
+
+1. Complete research using templates above
+2. Save findings to `$ITO_ROOT/research/{{topic}}/`
+3. Reference research in `proposal.md` or `design.md`
+4. Update relevant `.ito/wiki/` topic pages or query artifacts when findings have durable reuse value
+5. Use research to inform `tasks.md` prioritization
 
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/research-architecture.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/research-architecture.md
@@ -46,4 +46,8 @@ Describe the recommended approach with diagram (ASCII or description).
 
 List external systems and how to integrate.
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this research produced durable architecture decisions, patterns, or integration lessons, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this source research file as the cited investigation record.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/research-features.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/research-features.md
@@ -46,4 +46,8 @@ Lower priority features:
 |---------|-----------|--------|----------|
 | ... | High/Med/Low | High/Med/Low | P0/P1/P2 |
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this research produced durable feature taxonomy, prioritization, or reusable market context, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this source research file as the cited investigation record.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/research-pitfalls.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/research-pitfalls.md
@@ -46,4 +46,8 @@ Signs that something is going wrong:
 - Signal 1
 - Signal 2
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this research produced durable pitfalls, gotchas, or risk patterns, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this source research file as the cited investigation record.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/research-stack.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/research-stack.md
@@ -17,4 +17,8 @@ Evaluate technology choices and stack options for: **{{topic}}**
 
 Write markdown with: requirements, an options table (`Option | Pros | Cons | Maturity | Community`), recommendation, alternatives, and references.
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this research produced durable stack decisions or reusable trade-offs, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this source research file as the cited investigation record.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/research-synthesize.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/research-synthesize.md
@@ -58,4 +58,8 @@ Top pitfalls and mitigations:
 
 Questions needing more research or stakeholder input.
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists, file durable synthesis back into the wiki after saving this research summary. Prefer updating relevant topic pages for reusable decisions and cross-links; use `.ito/wiki/queries/` for one-off query artifacts. Cite this research summary from the wiki rather than moving the source record.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/review-edge.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/review-edge.md
@@ -61,4 +61,8 @@ Think like a chaos monkey. What happens when:
 - [ ] Minor edge case improvements needed
 - [ ] Significant gaps in error handling
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this review found reusable edge-case or error-handling lessons, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this review file as the cited source of the finding.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/review-scale.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/review-scale.md
@@ -65,4 +65,8 @@ Brief summary of the proposed architecture from a scaling perspective.
 - [ ] Needs optimization before launch
 - [ ] Requires architectural changes
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this review found reusable scale, performance, or capacity lessons, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this review file as the cited source of the finding.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-research/review-security.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-research/review-security.md
@@ -52,4 +52,8 @@ Proactive improvements beyond specific findings.
 - [ ] Requires changes before implementation
 - [ ] Needs significant redesign
 
+## Wiki Follow-Up
+
+If `.ito/wiki/index.md` exists and this review found reusable security lessons, update the relevant topic page or create a query artifact under `.ito/wiki/queries/`. Keep this review file as the cited source of the finding.
+
 <!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-wiki-search/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-wiki-search/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: ito-wiki-search
+description: Search and answer from the Ito `.ito/wiki/` layer first, with cited fallbacks to raw Ito artifacts when wiki coverage is missing, stale, or contradictory.
+---
+
+<!-- ITO:START -->
+
+# Ito Wiki Search
+
+Search the `.ito/wiki/` knowledge layer before re-synthesizing raw Ito artifacts. Use cited answers and make freshness explicit.
+
+## When To Use
+
+Use this skill when the user asks about:
+
+- Existing Ito decisions, specs, modules, proposals, research, or archive history
+- Project workflow context stored under `.ito/`
+- Prior planning or research synthesis that may already be captured in the wiki
+- Finding topic pages, source references, or known gaps in Ito knowledge
+
+Do not use this as a general repository search skill. The wiki is Ito-scoped.
+
+## Search Workflow
+
+1. Locate the Ito root with `ito path ito-root` when needed.
+2. Open `.ito/wiki/index.md` first if it exists.
+3. Check `.ito/wiki/_meta/status.md` for freshness and known gaps.
+4. Search likely topic, spec, research, and query pages under `.ito/wiki/`.
+5. Read cited `source_refs` before making claims that depend on current truth.
+6. If wiki coverage is missing, stale, or contradictory, warn briefly and fall back to raw Ito artifacts such as `.ito/specs/`, `.ito/changes/`, `.ito/research/`, `.ito/modules/`, `.ito/project.md`, `.ito/user-prompts/`, and `.ito/AGENTS.md`.
+7. Answer with citations to wiki pages and, when needed, raw source artifacts.
+
+## Answer Rules
+
+- Prefer concise answers backed by file paths.
+- State whether the answer came from fresh wiki coverage, stale wiki coverage, or raw-source fallback.
+- Distinguish canonical summaries from advisory synthesis using page authority metadata.
+- Defer to accepted specs and project guidance when a wiki page conflicts with source artifacts.
+- Do not create durable wiki content for routine chat answers.
+
+## Durable Artifact Rule
+
+Only update the wiki when the search produces durable value, such as:
+
+- A missing topic that future agents are likely to need
+- A stale page whose source refs were revalidated
+- A contradiction resolved against canonical Ito sources
+- A cited query answer worth preserving under `.ito/wiki/queries/`
+
+When updating, use the `ito-wiki` maintenance workflow and update `log.md` and `_meta/status.md` as needed.
+
+## Fallback Message Pattern
+
+Use a short warning when falling back:
+
+> Wiki coverage is missing/stale for this topic, so I am checking raw Ito artifacts and will update the wiki if the result is durable.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/assets/skills/ito-wiki/SKILL.md
+++ b/ito-rs/crates/ito-templates/assets/skills/ito-wiki/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ito-wiki
+description: Maintain and lint the Ito `.ito/wiki/` knowledge layer. Use when setting up, refreshing, repairing, ingesting durable synthesis into, or checking freshness of an Ito wiki.
+---
+
+<!-- ITO:START -->
+
+# Ito Wiki Maintenance
+
+Maintain the repo-local `.ito/wiki/` knowledge layer. The wiki is an LLM-maintained synthesis layer over Ito artifacts; it does not replace specs, proposals, research, modules, or project guidance as source truth.
+
+## When To Use
+
+Use this skill when you need to:
+
+- Set up or inspect `.ito/wiki/`
+- Refresh stale topic pages after proposal, research, review, or archive work
+- Ingest durable synthesis from Ito artifacts into wiki pages
+- Repair broken wiki links, missing metadata, or stale status notes
+- Lint wiki health before relying on it for planning or research
+
+Do not use this skill to mirror arbitrary repository documentation or source code. External files may be linked as supporting references, but default ingestion sources must stay Ito-owned.
+
+## Source Boundary
+
+Default sources are:
+
+- `.ito/specs/`
+- `.ito/changes/`
+- `.ito/research/`
+- `.ito/modules/`
+- `.ito/project.md`
+- `.ito/user-prompts/`
+- `.ito/AGENTS.md`
+
+Link non-Ito files only when they clarify a decision, workflow, or source reference already anchored in Ito artifacts.
+
+## Maintenance Workflow
+
+1. Find the wiki root with `ito path ito-root`, then inspect `.ito/wiki/index.md` and `.ito/wiki/_meta/status.md` if they exist.
+2. If the wiki is missing, create only the scaffold files described by `.ito/wiki/_meta/schema.md` or the project template. Do not invent a large wiki in one pass.
+3. Read the relevant raw Ito artifacts for the task before editing any wiki page.
+4. Update the most relevant topic page first. Prefer topic synthesis over one page per change.
+5. Add or update page metadata: `page_type`, `authority`, `freshness`, `last_reviewed`, `source_refs`, and `known_gaps`.
+6. Cite source paths for claims future agents may rely on.
+7. Update `index.md` for new important pages, `log.md` for meaningful maintenance events, and `_meta/status.md` for freshness or coverage changes.
+
+## Warn-And-Update Behavior
+
+Stale, missing, or contradictory wiki coverage must not block work.
+
+- Warn briefly that wiki coverage is stale, missing, or conflicting.
+- Fall back to raw Ito sources.
+- Continue the requested workflow.
+- Update the wiki afterward when the result has durable value.
+
+## Lint Checklist
+
+Check these before treating the wiki as useful context:
+
+- Reserved files exist: `index.md`, `overview.md`, `log.md`, `_meta/config.yaml`, `_meta/schema.md`, `_meta/status.md`
+- Durable pages have page type, authority, freshness, source refs, and known gaps
+- Source refs point primarily to Ito artifacts
+- Topic pages synthesize instead of copying whole source files
+- `index.md` links to important topic pages
+- `log.md` records meaningful maintenance events
+- `_meta/status.md` identifies stale areas and next maintenance steps
+- Wiki pages defer to canonical specs or guidance when conflicts appear
+
+## Repair Rules
+
+- Do the smallest repair that restores trustworthy navigation or freshness.
+- Preserve project-authored wiki content during upgrades and refreshes.
+- Do not delete pages unless they are clearly duplicate, empty, or harmful; prefer marking known gaps.
+- If a page conflicts with source truth, update the page and cite the source that resolved the conflict.
+
+<!-- ITO:END -->

--- a/ito-rs/crates/ito-templates/src/instructions_tests.rs
+++ b/ito-rs/crates/ito-templates/src/instructions_tests.rs
@@ -885,6 +885,10 @@ fn new_proposal_template_moves_to_worktree_after_create() {
     assert!(out.contains("CHANGE_DIR=$(ito worktree ensure --change \"<change-id>\")"));
     assert!(out.contains("cd \"$CHANGE_DIR\""));
     assert!(out.contains("Run all subsequent file operations from `$CHANGE_DIR`"));
+    assert!(out.contains("## Step 0.5: Consult the Ito Wiki When Present"));
+    assert!(out.contains(".ito/wiki/index.md"));
+    assert!(out.contains("briefly warn"));
+    assert!(out.contains("fall back to `.ito/specs/`"));
 }
 
 #[test]
@@ -1051,6 +1055,9 @@ fn archive_template_renders_targeted_instruction_with_change() {
     assert!(out.contains("ito audit reconcile --change 009-02_event-sourced-audit-log"));
     assert!(out.contains("Configured mode: `pull_request_auto_merge`"));
     assert!(out.contains("request auto-merge"));
+    assert!(out.contains("refresh relevant `.ito/wiki/` topic pages"));
+    assert!(out.contains("Prefer updating existing topic pages"));
+    assert!(out.contains("not an archive blocker"));
 }
 
 #[test]

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -794,6 +794,22 @@ mod tests {
     }
 
     #[test]
+    fn wiki_skills_are_embedded() {
+        let wiki = get_skill_file("ito-wiki/SKILL.md").expect("ito-wiki skill should exist");
+        let wiki = std::str::from_utf8(wiki).expect("skill should be utf8");
+        assert!(wiki.starts_with("---\nname: ito-wiki\n"));
+        assert!(wiki.contains("## Maintenance Workflow"));
+        assert!(wiki.contains("## Lint Checklist"));
+
+        let search =
+            get_skill_file("ito-wiki-search/SKILL.md").expect("ito-wiki-search skill should exist");
+        let search = std::str::from_utf8(search).expect("skill should be utf8");
+        assert!(search.starts_with("---\nname: ito-wiki-search\n"));
+        assert!(search.contains("## Search Workflow"));
+        assert!(search.contains("## Answer Rules"));
+    }
+
+    #[test]
     fn default_project_agents_mentions_fix_and_feature_entrypoints() {
         let agents = default_project_files()
             .into_iter()

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -27,6 +27,9 @@ pub mod manifest;
 /// Jinja2 rendering for project templates (AGENTS.md, skills).
 pub mod project_templates;
 
+#[cfg(test)]
+mod wiki_tests;
+
 static DEFAULT_PROJECT_DIR: Dir<'static> =
     include_dir!("$CARGO_MANIFEST_DIR/assets/default/project");
 static DEFAULT_HOME_DIR: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/assets/default/home");
@@ -781,30 +784,6 @@ mod tests {
             commands.iter().any(|f| f.relative_path == "ito-plan.md"),
             "expected ito-plan command to be embedded"
         );
-
-        let proposal = get_skill_file("ito-proposal/SKILL.md").expect("proposal skill should exist");
-        let proposal_text = std::str::from_utf8(proposal).expect("skill should be utf8");
-        assert!(proposal_text.contains("**Step 0.5: Consult the Ito wiki when present**"));
-        assert!(proposal_text.contains(".ito/wiki/index.md"));
-    }
-
-    #[test]
-    fn research_and_archive_skills_include_wiki_follow_up() {
-        let research = get_skill_file("ito-research/SKILL.md").expect("research skill should exist");
-        let research = std::str::from_utf8(research).expect("skill should be utf8");
-        assert!(research.contains("Research source artifacts and wiki synthesis have different jobs"));
-        assert!(research.contains("$ITO_ROOT/wiki/queries/"));
-
-        let synthesize = get_skill_file("ito-research/research-synthesize.md")
-            .expect("research synthesize template should exist");
-        let synthesize = std::str::from_utf8(synthesize).expect("template should be utf8");
-        assert!(synthesize.contains("## Wiki Follow-Up"));
-        assert!(synthesize.contains("Cite this research summary from the wiki"));
-
-        let archive = get_skill_file("ito-archive/SKILL.md").expect("archive skill should exist");
-        let archive = std::str::from_utf8(archive).expect("skill should be utf8");
-        assert!(archive.contains("refresh relevant `.ito/wiki/` topic pages"));
-        assert!(archive.contains("not an archive blocker"));
     }
 
     #[test]
@@ -815,22 +794,6 @@ mod tests {
         assert!(text.contains("ito agent instruction memory-capture"));
         assert!(text.contains("ito agent instruction memory-search"));
         assert!(text.contains("ito agent instruction memory-query"));
-    }
-
-    #[test]
-    fn wiki_skills_are_embedded() {
-        let wiki = get_skill_file("ito-wiki/SKILL.md").expect("ito-wiki skill should exist");
-        let wiki = std::str::from_utf8(wiki).expect("skill should be utf8");
-        assert!(wiki.starts_with("---\nname: ito-wiki\n"));
-        assert!(wiki.contains("## Maintenance Workflow"));
-        assert!(wiki.contains("## Lint Checklist"));
-
-        let search =
-            get_skill_file("ito-wiki-search/SKILL.md").expect("ito-wiki-search skill should exist");
-        let search = std::str::from_utf8(search).expect("skill should be utf8");
-        assert!(search.starts_with("---\nname: ito-wiki-search\n"));
-        assert!(search.contains("## Search Workflow"));
-        assert!(search.contains("## Answer Rules"));
     }
 
     #[test]
@@ -846,8 +809,6 @@ mod tests {
         assert!(text.contains("`ito-brainstorming`"));
         assert!(text.contains("ito patch change <id> proposal"));
         assert!(text.contains("ito write change <id> design"));
-        assert!(text.contains(".ito/wiki/index.md"));
-        assert!(text.contains("Refresh relevant `.ito/wiki/` topic pages"));
     }
 
     #[test]

--- a/ito-rs/crates/ito-templates/src/lib.rs
+++ b/ito-rs/crates/ito-templates/src/lib.rs
@@ -781,6 +781,30 @@ mod tests {
             commands.iter().any(|f| f.relative_path == "ito-plan.md"),
             "expected ito-plan command to be embedded"
         );
+
+        let proposal = get_skill_file("ito-proposal/SKILL.md").expect("proposal skill should exist");
+        let proposal_text = std::str::from_utf8(proposal).expect("skill should be utf8");
+        assert!(proposal_text.contains("**Step 0.5: Consult the Ito wiki when present**"));
+        assert!(proposal_text.contains(".ito/wiki/index.md"));
+    }
+
+    #[test]
+    fn research_and_archive_skills_include_wiki_follow_up() {
+        let research = get_skill_file("ito-research/SKILL.md").expect("research skill should exist");
+        let research = std::str::from_utf8(research).expect("skill should be utf8");
+        assert!(research.contains("Research source artifacts and wiki synthesis have different jobs"));
+        assert!(research.contains("$ITO_ROOT/wiki/queries/"));
+
+        let synthesize = get_skill_file("ito-research/research-synthesize.md")
+            .expect("research synthesize template should exist");
+        let synthesize = std::str::from_utf8(synthesize).expect("template should be utf8");
+        assert!(synthesize.contains("## Wiki Follow-Up"));
+        assert!(synthesize.contains("Cite this research summary from the wiki"));
+
+        let archive = get_skill_file("ito-archive/SKILL.md").expect("archive skill should exist");
+        let archive = std::str::from_utf8(archive).expect("skill should be utf8");
+        assert!(archive.contains("refresh relevant `.ito/wiki/` topic pages"));
+        assert!(archive.contains("not an archive blocker"));
     }
 
     #[test]
@@ -810,7 +834,7 @@ mod tests {
     }
 
     #[test]
-    fn default_project_agents_mentions_fix_and_feature_entrypoints() {
+    fn default_project_agents_mentions_fix_feature_and_wiki_guidance() {
         let agents = default_project_files()
             .into_iter()
             .find(|f| f.relative_path == ".ito/AGENTS.md")
@@ -822,6 +846,8 @@ mod tests {
         assert!(text.contains("`ito-brainstorming`"));
         assert!(text.contains("ito patch change <id> proposal"));
         assert!(text.contains("ito write change <id> design"));
+        assert!(text.contains(".ito/wiki/index.md"));
+        assert!(text.contains("Refresh relevant `.ito/wiki/` topic pages"));
     }
 
     #[test]

--- a/ito-rs/crates/ito-templates/src/project_templates.rs
+++ b/ito-rs/crates/ito-templates/src/project_templates.rs
@@ -203,6 +203,7 @@ mod tests {
         let text = String::from_utf8(rendered).unwrap();
 
         assert!(text.contains("## Worktree Workflow"));
+        assert!(text.contains(".ito/wiki/index.md"));
         assert!(text.contains("**Strategy:** `checkout_subdir`"));
         assert_main_worktree_guardrails(&text);
         assert!(

--- a/ito-rs/crates/ito-templates/src/wiki_tests.rs
+++ b/ito-rs/crates/ito-templates/src/wiki_tests.rs
@@ -1,0 +1,56 @@
+use super::{default_project_files, get_skill_file};
+
+#[test]
+fn proposal_skill_mentions_wiki_consultation() {
+    let proposal = get_skill_file("ito-proposal/SKILL.md").expect("proposal skill should exist");
+    let proposal = std::str::from_utf8(proposal).expect("skill should be utf8");
+    assert!(proposal.contains("**Step 0.5: Consult the Ito wiki when present**"));
+    assert!(proposal.contains(".ito/wiki/index.md"));
+}
+
+#[test]
+fn research_and_archive_skills_include_wiki_follow_up() {
+    let research = get_skill_file("ito-research/SKILL.md").expect("research skill should exist");
+    let research = std::str::from_utf8(research).expect("skill should be utf8");
+    assert!(research.contains("Research source artifacts and wiki synthesis have different jobs"));
+    assert!(research.contains("$ITO_ROOT/wiki/queries/"));
+
+    let synthesize = get_skill_file("ito-research/research-synthesize.md")
+        .expect("research synthesize template should exist");
+    let synthesize = std::str::from_utf8(synthesize).expect("template should be utf8");
+    assert!(synthesize.contains("## Wiki Follow-Up"));
+    assert!(synthesize.contains("Cite this research summary from the wiki"));
+
+    let archive = get_skill_file("ito-archive/SKILL.md").expect("archive skill should exist");
+    let archive = std::str::from_utf8(archive).expect("skill should be utf8");
+    assert!(archive.contains("refresh relevant `.ito/wiki/` topic pages"));
+    assert!(archive.contains("not an archive blocker"));
+}
+
+#[test]
+fn wiki_skills_are_embedded() {
+    let wiki = get_skill_file("ito-wiki/SKILL.md").expect("ito-wiki skill should exist");
+    let wiki = std::str::from_utf8(wiki).expect("skill should be utf8");
+    assert!(wiki.starts_with("---\nname: ito-wiki\n"));
+    assert!(wiki.contains("## Maintenance Workflow"));
+    assert!(wiki.contains("## Lint Checklist"));
+
+    let search =
+        get_skill_file("ito-wiki-search/SKILL.md").expect("ito-wiki-search skill should exist");
+    let search = std::str::from_utf8(search).expect("skill should be utf8");
+    assert!(search.starts_with("---\nname: ito-wiki-search\n"));
+    assert!(search.contains("## Search Workflow"));
+    assert!(search.contains("## Answer Rules"));
+}
+
+#[test]
+fn default_project_agents_mentions_wiki_guidance() {
+    let agents = default_project_files()
+        .into_iter()
+        .find(|f| f.relative_path == ".ito/AGENTS.md")
+        .expect("expected .ito/AGENTS.md in templates");
+    let text = std::str::from_utf8(agents.contents).expect("template should be UTF-8");
+
+    assert!(text.contains(".ito/wiki/index.md"));
+    assert!(text.contains("Refresh relevant `.ito/wiki/` topic pages"));
+}

--- a/ito-rs/crates/ito-templates/tests/wiki_scaffold.rs
+++ b/ito-rs/crates/ito-templates/tests/wiki_scaffold.rs
@@ -1,0 +1,25 @@
+use std::collections::HashSet;
+
+use ito_templates::default_project_files;
+
+#[test]
+fn default_project_embeds_ito_wiki_scaffold() {
+    let files: HashSet<_> = default_project_files()
+        .into_iter()
+        .map(|file| file.relative_path)
+        .collect();
+
+    for expected in [
+        ".ito/wiki/index.md",
+        ".ito/wiki/log.md",
+        ".ito/wiki/overview.md",
+        ".ito/wiki/_meta/config.yaml",
+        ".ito/wiki/_meta/schema.md",
+        ".ito/wiki/_meta/status.md",
+    ] {
+        assert!(
+            files.contains(expected),
+            "missing wiki scaffold file: {expected}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add the default Ito wiki scaffold and repo-local seed wiki pages
- add wiki maintenance/search skills and wire wiki guidance into proposal, research, archive, and agent surfaces
- add preservation, distribution, scaffold, and template coverage for wiki assets

## Verification
- `ito validate 027-01_add-ito-wiki --strict`
- `cargo fmt --all --check`
- `cargo test -p ito-templates --test wiki_scaffold -- --nocapture`
- `cargo test -p ito-core --test wiki_install -- --nocapture`
- `cargo test -p ito-core --test distribution -- --nocapture`
- `cargo test -p ito-templates --lib -- --nocapture`
- `cargo test -p ito-templates --lib wiki -- --nocapture`
- `cargo test -p ito-cli --test source_file_size -- --nocapture`
- `make test`
- `make check`